### PR TITLE
Concurrent search via `OnceLock` lazy caches, with x86 heap fill overflow fix

### DIFF
--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -23,7 +23,7 @@ impl TurboQuantIndex {
     }
 
     fn search<'py>(
-        &mut self,
+        &self,
         py: Python<'py>,
         queries: PyReadonlyArray2<f32>,
         k: usize,
@@ -55,6 +55,13 @@ impl TurboQuantIndex {
             pyo3::exceptions::PyIOError::new_err(format!("{}", e))
         })?;
         Ok(Self { inner })
+    }
+
+    /// Warm up the search caches (rotation matrix, Lloyd-Max centroids,
+    /// SIMD-blocked code layout) so the first `search` call does not pay
+    /// the one-time initialisation cost.
+    fn prepare(&self) {
+        self.inner.prepare();
     }
 
     fn __len__(&self) -> usize {

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -3,15 +3,36 @@
 //! Compresses high-dimensional vectors to 2-4 bits per coordinate with
 //! near-optimal distortion. Data-oblivious — no training required.
 //!
-//! ```rust
+//! ```no_run
 //! use turbovec::TurboQuantIndex;
 //!
+//! // 1536-dim vectors compressed to 4 bits per coordinate.
 //! let mut index = TurboQuantIndex::new(1536, 4);
+//!
+//! // `vectors` is a flat [f32] of length n * dim, `queries` likewise.
+//! let vectors: Vec<f32> = vec![0.0; 1536 * 10];
+//! let queries: Vec<f32> = vec![0.0; 1536 * 2];
+//!
 //! index.add(&vectors);
 //! let results = index.search(&queries, 10);
 //! index.write("index.tv").unwrap();
 //! let loaded = TurboQuantIndex::load("index.tv").unwrap();
 //! ```
+//!
+//! # Concurrent search
+//!
+//! `search` takes `&self` and is safe to call from multiple threads
+//! concurrently. Internally the rotation matrix, the Lloyd-Max centroids
+//! and the SIMD-blocked code layout are initialised lazily via
+//! [`std::sync::OnceLock`], so the first caller pays the one-time
+//! initialisation cost and every subsequent caller reads the caches
+//! without locking. [`TurboQuantIndex::prepare`] can be called once
+//! after `add`/`load` to pay that cost up front.
+//!
+//! Mutation still flows through `&mut self`: `add` extends the packed
+//! codes and invalidates the blocked layout cache by replacing its
+//! `OnceLock`. This keeps the invariant that once a cache is populated
+//! from `&self`, it matches the current `packed_codes`.
 
 pub mod codebook;
 pub mod encode;
@@ -21,10 +42,21 @@ pub mod rotation;
 pub mod search;
 
 use std::path::Path;
+use std::sync::OnceLock;
 
 const ROTATION_SEED: u64 = 42;
 const BLOCK: usize = 32;
 const FLUSH_EVERY: usize = 256;
+
+/// SIMD-blocked cache derived from `packed_codes`.
+///
+/// Materialised lazily by [`TurboQuantIndex::search`] on first call
+/// and re-materialised when [`TurboQuantIndex::add`] resets the
+/// enclosing `OnceLock`.
+struct BlockedCache {
+    data: Vec<u8>,
+    n_blocks: usize,
+}
 
 pub struct TurboQuantIndex {
     dim: usize,
@@ -32,11 +64,20 @@ pub struct TurboQuantIndex {
     n_vectors: usize,
     packed_codes: Vec<u8>,
     norms: Vec<f32>,
-    // Cached for search (lazily computed)
-    blocked: Option<Vec<u8>>,
-    n_blocks: usize,
-    centroids: Option<Vec<f32>>,
-    rotation: Option<Vec<f32>>,
+
+    // Thread-safe lazy caches. These are initialised from `&self` via
+    // `OnceLock::get_or_init`, which allows `search` to take `&self`
+    // and run concurrently from multiple threads without external
+    // locking. `add` resets `blocked` by replacing its `OnceLock` (it
+    // already has `&mut self` for the underlying extend on
+    // `packed_codes` and `norms`).
+    //
+    // `rotation` and `centroids` are deterministic functions of `(dim,
+    // ROTATION_SEED)` and `(bit_width, dim)` respectively, so they
+    // never need to be invalidated.
+    rotation: OnceLock<Vec<f32>>,
+    centroids: OnceLock<Vec<f32>>,
+    blocked: OnceLock<BlockedCache>,
 }
 
 pub struct SearchResults {
@@ -58,10 +99,7 @@ impl SearchResults {
 
 impl TurboQuantIndex {
     pub fn new(dim: usize, bit_width: usize) -> Self {
-        assert!(
-            bit_width >= 2 && bit_width <= 4,
-            "bit_width must be 2, 3, or 4"
-        );
+        assert!((2..=4).contains(&bit_width), "bit_width must be 2, 3, or 4");
         assert!(dim % 8 == 0, "dim must be a multiple of 8");
 
         Self {
@@ -70,10 +108,9 @@ impl TurboQuantIndex {
             n_vectors: 0,
             packed_codes: Vec::new(),
             norms: Vec::new(),
-            blocked: None,
-            n_blocks: 0,
-            centroids: None,
-            rotation: None,
+            rotation: OnceLock::new(),
+            centroids: OnceLock::new(),
+            blocked: OnceLock::new(),
         }
     }
 
@@ -85,11 +122,14 @@ impl TurboQuantIndex {
             "vectors length must be a multiple of dim"
         );
 
-        let rotation = self.ensure_rotation();
+        let rotation = self
+            .rotation
+            .get_or_init(|| rotation::make_rotation_matrix(self.dim))
+            .clone();
         let (boundaries, _) = codebook::codebook(self.bit_width, self.dim);
-        let (packed, norms) = encode::encode(vectors, n, self.dim, &rotation, &boundaries, self.bit_width);
+        let (packed, norms) =
+            encode::encode(vectors, n, self.dim, &rotation, &boundaries, self.bit_width);
 
-        let bytes_per_row = self.dim * self.bit_width / 8;
         if self.n_vectors == 0 {
             self.packed_codes = packed;
             self.norms = norms;
@@ -98,31 +138,55 @@ impl TurboQuantIndex {
             self.norms.extend_from_slice(&norms);
         }
         self.n_vectors += n;
-        self.blocked = None; // invalidate cache
+
+        // Invalidate the blocked cache — it was derived from the old
+        // `packed_codes` and no longer matches the extended vector set.
+        // Rotation and centroids remain valid (they only depend on
+        // `(dim, ROTATION_SEED)` and `(bit_width, dim)`).
+        self.blocked = OnceLock::new();
     }
 
-    pub fn search(&mut self, queries: &[f32], k: usize) -> SearchResults {
+    /// Run a top-`k` search against the index.
+    ///
+    /// Takes `&self` and is safe to call concurrently from multiple
+    /// threads. The first caller on a fresh index pays the one-time
+    /// cache initialisation cost (rotation matrix, Lloyd-Max centroids
+    /// and the SIMD-blocked code layout). Subsequent callers read the
+    /// caches without locking.
+    ///
+    /// Call [`TurboQuantIndex::prepare`] once after `add`/`load` to
+    /// pay that cost up front if you want deterministic first-query
+    /// latency.
+    pub fn search(&self, queries: &[f32], k: usize) -> SearchResults {
         let nq = queries.len() / self.dim;
         assert_eq!(queries.len(), nq * self.dim);
 
-        self.ensure_cached();
+        let rotation = self
+            .rotation
+            .get_or_init(|| rotation::make_rotation_matrix(self.dim));
+        let centroids = self.centroids.get_or_init(|| {
+            let (_, c) = codebook::codebook(self.bit_width, self.dim);
+            c
+        });
+        let blocked = self.blocked.get_or_init(|| {
+            let (data, n_blocks) =
+                pack::repack(&self.packed_codes, self.n_vectors, self.bit_width, self.dim);
+            BlockedCache { data, n_blocks }
+        });
 
-        let rotation = self.rotation.as_ref().unwrap();
-        let blocked = self.blocked.as_ref().unwrap();
-        let centroids = self.centroids.as_ref().unwrap();
         let k = k.min(self.n_vectors);
 
         let (scores, indices) = search::search(
             queries,
             nq,
             rotation,
-            blocked,
+            &blocked.data,
             centroids,
             &self.norms,
             self.bit_width,
             self.dim,
             self.n_vectors,
-            self.n_blocks,
+            blocked.n_blocks,
             k,
         );
 
@@ -134,8 +198,38 @@ impl TurboQuantIndex {
         }
     }
 
+    /// Eagerly populate the search caches (rotation matrix, centroids
+    /// and SIMD-blocked code layout).
+    ///
+    /// Calling `prepare` is optional — `search` will materialise the
+    /// caches on its first call if needed. Use it to move the one-time
+    /// cost out of the first query path, for example right after
+    /// [`TurboQuantIndex::load`] or after a batch of [`add`] calls.
+    ///
+    /// Safe to call multiple times and from multiple threads.
+    pub fn prepare(&self) {
+        self.rotation
+            .get_or_init(|| rotation::make_rotation_matrix(self.dim));
+        self.centroids.get_or_init(|| {
+            let (_, c) = codebook::codebook(self.bit_width, self.dim);
+            c
+        });
+        self.blocked.get_or_init(|| {
+            let (data, n_blocks) =
+                pack::repack(&self.packed_codes, self.n_vectors, self.bit_width, self.dim);
+            BlockedCache { data, n_blocks }
+        });
+    }
+
     pub fn write(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
-        io::write(path, self.bit_width, self.dim, self.n_vectors, &self.packed_codes, &self.norms)
+        io::write(
+            path,
+            self.bit_width,
+            self.dim,
+            self.n_vectors,
+            &self.packed_codes,
+            &self.norms,
+        )
     }
 
     pub fn load(path: impl AsRef<Path>) -> std::io::Result<Self> {
@@ -146,10 +240,9 @@ impl TurboQuantIndex {
             n_vectors,
             packed_codes,
             norms,
-            blocked: None,
-            n_blocks: 0,
-            centroids: None,
-            rotation: None,
+            rotation: OnceLock::new(),
+            centroids: OnceLock::new(),
+            blocked: OnceLock::new(),
         })
     }
 
@@ -167,28 +260,5 @@ impl TurboQuantIndex {
 
     pub fn bit_width(&self) -> usize {
         self.bit_width
-    }
-
-    fn ensure_rotation(&mut self) -> Vec<f32> {
-        if self.rotation.is_none() {
-            self.rotation = Some(rotation::make_rotation_matrix(self.dim));
-        }
-        self.rotation.clone().unwrap()
-    }
-
-    fn ensure_cached(&mut self) {
-        if self.rotation.is_none() {
-            self.rotation = Some(rotation::make_rotation_matrix(self.dim));
-        }
-        if self.centroids.is_none() {
-            let (_, c) = codebook::codebook(self.bit_width, self.dim);
-            self.centroids = Some(c);
-        }
-        if self.blocked.is_none() {
-            let (blocked, n_blocks) =
-                pack::repack(&self.packed_codes, self.n_vectors, self.bit_width, self.dim);
-            self.blocked = Some(blocked);
-            self.n_blocks = n_blocks;
-        }
     }
 }

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -412,12 +412,30 @@ unsafe fn search_multi_query_avx2(
             let hmi = &mut heap_min_idxs[qi];
 
             if *sz < k {
-                // Filling phase — just insert everything
+                // Filling phase — fill lane-by-lane and switch to a
+                // scalar heap update if the heap fills up mid-block.
+                //
+                // The per-lane `*sz < k` check below is load-bearing:
+                // when `k < BLOCK (= 32)` the heap reaches capacity
+                // part-way through the first block and the remaining
+                // lanes need the update path, otherwise `hs[*sz]`
+                // overflows at `*sz = k`. The matching ARM NEON path
+                // in this file already works this way.
                 for lane in 0..(end - base_vec) {
-                    hs[*sz] = block_out[lane];
-                    hi[*sz] = (base_vec + lane) as u32;
-                    *sz += 1;
-                    if *sz == k {
+                    let score = block_out[lane];
+                    if *sz < k {
+                        hs[*sz] = score;
+                        hi[*sz] = (base_vec + lane) as u32;
+                        *sz += 1;
+                        if *sz == k {
+                            *hmin = hs[0]; *hmi = 0;
+                            for h in 1..k {
+                                if hs[h] < *hmin { *hmin = hs[h]; *hmi = h; }
+                            }
+                        }
+                    } else if score > *hmin {
+                        hs[*hmi] = score;
+                        hi[*hmi] = (base_vec + lane) as u32;
                         *hmin = hs[0]; *hmi = 0;
                         for h in 1..k {
                             if hs[h] < *hmin { *hmin = hs[h]; *hmi = h; }

--- a/turbovec/tests/concurrent_search.rs
+++ b/turbovec/tests/concurrent_search.rs
@@ -1,0 +1,193 @@
+//! Integration tests for concurrent search on a shared `TurboQuantIndex`.
+//!
+//! These tests exercise the `OnceLock`-based lazy cache initialisation
+//! introduced to let `search` take `&self`. They verify that:
+//!
+//! 1. A shared `Arc<TurboQuantIndex>` can serve searches from many
+//!    threads concurrently without external locking.
+//! 2. Every concurrent thread that searches the same query against a
+//!    shared index gets the same top-`k` back.
+//! 3. `prepare()` is safe to call from multiple threads.
+//! 4. A roundtrip through `write`/`load` produces the same top-`k` as
+//!    the original in-memory index for the same queries.
+
+use std::sync::Arc;
+use std::thread;
+
+use turbovec::TurboQuantIndex;
+
+/// Deterministic pseudo-random vector generator so the tests are
+/// reproducible without pulling an extra dev-dependency.
+fn make_vectors(n: usize, dim: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed.wrapping_mul(0x9E3779B97F4A7C15);
+    let mut out = Vec::with_capacity(n * dim);
+    for _ in 0..(n * dim) {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let u = ((state >> 32) as u32) as f32 / u32::MAX as f32;
+        // Centre on zero and scale modestly so rotation has room to move things.
+        out.push(u * 2.0 - 1.0);
+    }
+    out
+}
+
+/// Build a small index ready for concurrent search.
+fn build_index() -> TurboQuantIndex {
+    let dim = 256;
+    let bit_width = 4;
+    let n = 1_024;
+
+    let vectors = make_vectors(n, dim, 1);
+    let mut index = TurboQuantIndex::new(dim, bit_width);
+    index.add(&vectors);
+    assert_eq!(index.len(), n);
+    index
+}
+
+#[test]
+fn search_is_deterministic_across_threads() {
+    let index = Arc::new(build_index());
+
+    // Warm up explicitly so no thread races on the lazy init path.
+    index.prepare();
+
+    let queries = make_vectors(4, index.dim(), 42);
+    let k = 10;
+
+    // Reference result from the main thread.
+    let reference = index.search(&queries, k);
+    let ref_indices: Vec<Vec<i64>> = (0..reference.nq)
+        .map(|qi| reference.indices_for_query(qi).to_vec())
+        .collect();
+    let nq = reference.nq;
+
+    // Every spawned thread should see the same indices for the same
+    // queries — OnceLock caches must be visible to all readers.
+    let mut handles = Vec::new();
+    for _ in 0..16 {
+        let index = Arc::clone(&index);
+        let queries = queries.clone();
+        let ref_indices = ref_indices.clone();
+        handles.push(thread::spawn(move || {
+            for _ in 0..32 {
+                let result = index.search(&queries, k);
+                assert_eq!(result.nq, nq);
+                assert_eq!(result.k, k);
+                for (qi, expected) in ref_indices.iter().enumerate() {
+                    assert_eq!(
+                        result.indices_for_query(qi),
+                        expected.as_slice(),
+                        "top-k mismatch between threads for query {qi}"
+                    );
+                }
+            }
+        }));
+    }
+    for h in handles {
+        h.join().expect("search thread panicked");
+    }
+}
+
+#[test]
+fn lazy_init_is_safe_when_prepare_is_skipped() {
+    // Deliberately do NOT call `prepare()` — the first concurrent
+    // batch races through `get_or_init`, and OnceLock must let exactly
+    // one thread initialise each cache while the others block briefly
+    // then read the shared value.
+    let index = Arc::new(build_index());
+    let queries = make_vectors(2, index.dim(), 7);
+    let k = 5;
+
+    let mut handles = Vec::new();
+    for _ in 0..32 {
+        let index = Arc::clone(&index);
+        let queries = queries.clone();
+        handles.push(thread::spawn(move || {
+            let r = index.search(&queries, k);
+            // The only thing we can assert without a reference value
+            // is that every call returns `nq * k` indices and no panic.
+            assert_eq!(r.indices.len(), r.nq * r.k);
+            assert_eq!(r.scores.len(), r.nq * r.k);
+        }));
+    }
+    for h in handles {
+        h.join().expect("search thread panicked");
+    }
+}
+
+#[test]
+fn prepare_is_idempotent_from_multiple_threads() {
+    let index = Arc::new(build_index());
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let index = Arc::clone(&index);
+        handles.push(thread::spawn(move || {
+            index.prepare();
+            index.prepare();
+        }));
+    }
+    for h in handles {
+        h.join().expect("prepare thread panicked");
+    }
+
+    // The index must still be usable afterwards.
+    let queries = make_vectors(1, index.dim(), 99);
+    let r = index.search(&queries, 3);
+    assert_eq!(r.k, 3);
+}
+
+#[test]
+fn add_after_search_invalidates_blocked_cache() {
+    // The `add` method must reset the `blocked` OnceLock so the next
+    // search sees the extended vector set. If we forgot to invalidate,
+    // the search would still score against the pre-`add` packed codes.
+    let mut index = build_index();
+    let queries = make_vectors(1, index.dim(), 3);
+    let _before = index.search(&queries, 5);
+
+    // Add 512 more vectors — roughly doubling the index.
+    let more = make_vectors(512, index.dim(), 11);
+    index.add(&more);
+    assert_eq!(index.len(), 1_024 + 512);
+
+    // The top-5 after `add` must come from an index of `len() = 1536`.
+    // The only invariant we can check cheaply is that every returned
+    // position is in-range for the new size.
+    let after = index.search(&queries, 5);
+    for &idx in after.indices_for_query(0) {
+        assert!(idx >= 0, "negative index");
+        assert!((idx as usize) < index.len(), "stale index out of range");
+    }
+}
+
+#[test]
+fn write_load_preserves_concurrent_search_results() {
+    let index = build_index();
+    let queries = make_vectors(3, index.dim(), 123);
+    let k = 8;
+
+    let before = index.search(&queries, k);
+
+    let tmp = std::env::temp_dir().join(format!("turbovec_concurrent_{}.tv", std::process::id()));
+    index.write(&tmp).expect("write");
+    let reloaded = TurboQuantIndex::load(&tmp).expect("load");
+    let _ = std::fs::remove_file(&tmp);
+
+    assert_eq!(reloaded.len(), index.len());
+    assert_eq!(reloaded.dim(), index.dim());
+    assert_eq!(reloaded.bit_width(), index.bit_width());
+
+    // The reloaded index must produce the same top-k for the same
+    // queries because rotation and centroids are deterministic
+    // functions of `(dim, seed)` and `(bit_width, dim)`.
+    let after = reloaded.search(&queries, k);
+    for qi in 0..before.nq {
+        assert_eq!(
+            before.indices_for_query(qi),
+            after.indices_for_query(qi),
+            "roundtrip changed top-k for query {qi}"
+        );
+    }
+}


### PR DESCRIPTION
````md
This PR has two commits that address related findings: a latent
bug in the x86 top-k fill path, and a refactor that lets `search`
take `&self` so a single `TurboQuantIndex` can serve concurrent
queries from multiple threads.

## 1. `fix(search): x86 heap fill overflow when k < BLOCK`

The x86_64 AVX2 search path had a per-block top-k fill loop that
checked `*sz < k` once **before** the lane loop but not inside it.
Once the heap reached capacity mid-block the next iteration wrote
`hs[*sz]` at `*sz = k` and panicked with an out-of-bounds index
access.

This is hit whenever `k < BLOCK (= 32)`: the first block scores
up to 32 lanes but the heap only holds `k` entries. With `k = 10`
the 11th fill write overflows. The benchmarks in `benchmarks/suite/`
all use `k = 64` (> `BLOCK`) so the bug never surfaces there, yet
`k` between 5 and 20 is exactly the shape of queries a RAG
application issues — a user typically asks for the top 5 to 10
relevant documents.

The ARM NEON path at the same level of the file already handles
this correctly (see the inline heap in `score_*_block_neon`
callers): it checks `if heap_sizes[qi_off] < k` per lane inside
the loop and falls back to the scalar heap-update branch when
the fill phase ends mid-block. This commit ports that per-lane
check to the x86 path.

Minimal reproducer (panics on `main`, passes with this fix):

```rust
use turbovec::TurboQuantIndex;

let mut index = TurboQuantIndex::new(256, 4);
let vectors: Vec<f32> = (0..1024 * 256).map(|i| i as f32).collect();
index.add(&vectors);
let query: Vec<f32> = vec![0.0; 256];
let _ = index.search(&query, 10);
````

Diff: +23 / -5 lines in turbovec/src/search.rs.

## 2. refactor: OnceLock-based lazy caches, search(&self) for concurrent use

Before this change `TurboQuantIndex::search` took `&mut self`
because the rotation matrix, the Lloyd-Max centroids and the
SIMD-blocked code layout were stored as `Option<Vec<_>>` fields
and populated on first call via `ensure_cached`. This forced
callers to serialise every search on the same index behind a
mutex, which is fine for a single-threaded benchmark but
unworkable for a multi-user application that expects concurrent
top-k queries on a shared index.

The fix replaces the three caches with `std::sync::OnceLock`
(stable since Rust 1.70) so initialisation is lazy AND thread-safe
from `&self`:

* rotation:  `OnceLock<Vec<f32>>`
* centroids: `OnceLock<Vec<f32>>`
* blocked:   `OnceLock<BlockedCache>` (data + n_blocks bundled)

`search` now takes `&self` and multiple threads can call it on a
shared `Arc<TurboQuantIndex>` without external locking. The first
concurrent caller pays the one-time init via `OnceLock::get_or_init`
while the others block briefly, then every subsequent read is
lock-free.

`add` still takes `&mut self` because it extends `packed_codes`
and `norms`. It invalidates the blocked cache by replacing its
`OnceLock` — the invariant is that once a cache is populated from
`&self` it matches the current `packed_codes`. `rotation` and
`centroids` are deterministic functions of `(dim, ROTATION_SEED)`
and `(bit_width, dim)` respectively, so they never need to be
reset.

A new `prepare()` method forces eager cache initialisation. It is
safe to call from multiple threads and is useful right after
`load()` or after a batch of `add()` calls to pay the one-time
cost out of the first query path. Calling it is optional — the
`OnceLock`-backed lazy path is correct either way.

The Python binding gets the same treatment: `search` on the
pyclass is now `&self` and a `prepare()` method is exposed.
Existing Python callers see no behavioural change.

### Tests (`turbovec/tests/concurrent_search.rs`)

* `search_is_deterministic_across_threads` — 16 threads × 32
  searches against a shared `Arc<TurboQuantIndex>` all return the
  same top-k as the main thread. Catches visibility and
  initialisation races in the `OnceLock` caches.
* `lazy_init_is_safe_when_prepare_is_skipped` — 32 threads hit
  `get_or_init` simultaneously on a fresh index, exercising the
  one-winner-many-readers race.
* `prepare_is_idempotent_from_multiple_threads` — eager init from
  8 concurrent callers, then a follow-up search to confirm the
  index is still usable.
* `add_after_search_invalidates_blocked_cache` — after a search
  that populates the cache, an `add` must reset `blocked` so
  subsequent searches see the new vectors.
* `write_load_preserves_concurrent_search_results` — roundtrip
  through the `.tv` file format returns the same top-k for the
  same queries.

Runs in ~2.8 s on a 24-core x86_64 host with the standard
`cargo test -p turbovec` invocation (after adding
`-lopenblas` to `RUSTFLAGS` locally — same requirement as
existing upstream benchmarks).

Diff: +324 / -54 lines across `turbovec/src/lib.rs`,
`turbovec-python/src/lib.rs`, and the new integration test.

## Relation between the two commits

The concurrent-search tests use `k = 3, 5, 8 and 10` —
realistic values for a top-k vector search. These values trigger
the x86 fill overflow described in commit 1, which is why the
two commits are presented together. The fix can be cherry-picked
independently if desired.

## MSRV

`std::sync::OnceLock` is stable since Rust 1.70 (June 2023). The
crate has no explicit `rust-version` today; happy to add
`rust-version = "1.70"` to `turbovec/Cargo.toml` as a follow-up
if you want the MSRV recorded.

## Found during

Integrating turbovec into a multi-user RAG backend where a single
`TurboQuantIndex` shard is shared across concurrent HTTP handlers.
The `&mut self` on `search` made a shared-index design impossible;
the x86 fill overflow then blocked the tests we wrote to validate
the refactor. Fixing both felt cleaner than working around either.

Thanks for the library — the data-oblivious rotation + Lloyd-Max
design is a great fit for incremental indexes and we're excited
to ship it in production.

```
```
