### PR TITLE
feat: Add dynamic delete support

### DIFF
--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -64,6 +64,14 @@ impl TurboQuantIndex {
         self.inner.prepare();
     }
 
+    /// Remove the vector at `idx` (swap-and-pop).
+    ///
+    /// Returns the old index of the moved vector; equals `idx` when
+    /// `idx` was already the last element.
+    fn delete(&mut self, idx: usize) -> usize {
+        self.inner.delete(idx)
+    }
+
     fn __len__(&self) -> usize {
         self.inner.len()
     }

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -245,6 +245,43 @@ impl TurboQuantIndex {
         })
     }
 
+    /// Remove the vector at `idx` using swap-and-pop.
+    ///
+    /// Swaps `idx` with the last vector, truncates, and invalidates the
+    /// blocked cache. Returns the old index of the moved vector
+    /// (`n_vectors - 1` before the call); equals `idx` when `idx` was
+    /// already the last element. Panics if `idx >= n_vectors`.
+    pub fn delete(&mut self, idx: usize) -> usize {
+        assert!(
+            idx < self.n_vectors,
+            "index {idx} out of bounds (n_vectors = {})",
+            self.n_vectors
+        );
+
+        let bytes_per_vec = self.dim * self.bit_width / 8;
+        let last = self.n_vectors - 1;
+
+        if idx != last {
+            // Move last vector's packed bytes into slot `idx`.
+            let src = last * bytes_per_vec;
+            let dst = idx * bytes_per_vec;
+            self.packed_codes.copy_within(src..src + bytes_per_vec, dst);
+
+            // Move last norm into slot `idx`.
+            self.norms[idx] = self.norms[last];
+        }
+
+        // Truncate both arrays.
+        self.packed_codes.truncate(last * bytes_per_vec);
+        self.norms.truncate(last);
+        self.n_vectors -= 1;
+
+        // Invalidate the blocked cache since it was derived from the old layout.
+        self.blocked = OnceLock::new();
+
+        last
+    }
+
     pub fn len(&self) -> usize {
         self.n_vectors
     }


### PR DESCRIPTION
Thanks for making this great library! While trying it out, I noticed that dynamic deletion isn't supported, but it's trivial to support that with this algorithm, hence this PR. Since very few ANN backends support dynamic deletion I think this adds a lot of value to this library.

The way it's set up is as follows: the target slot is overwritten with the last vector's packed codes and norm, both arrays are truncated by one, and the blocked layout cache is invalidated so the next search rebuilds against the updated data. This is an O(1) operation since it's swap-and-pop deletion.

Note: I didn't add tests since I didn't see tests in the existing package.