### PR TITLE
Split release workflow: PyPI (py-v*) and crates.io (v*)

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -1,0 +1,32 @@
+name: Release (crates.io)
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  crates-io:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: crates-io
+      url: https://crates.io/crates/turbovec
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install openblas for cargo publish verification
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev pkg-config
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+      - name: Publish turbovec
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish -p turbovec

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,9 +1,9 @@
-name: Release
+name: Release (PyPI)
 
 on:
   push:
     tags:
-      - "v*"
+      - "py-v*"
   workflow_dispatch:
 
 permissions:
@@ -86,7 +86,7 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [linux, macos, sdist]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/py-v')
     environment:
       name: pypi
       url: https://pypi.org/project/turbovec
@@ -101,24 +101,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
-
-  crates-io:
-    name: Publish to crates.io
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    environment:
-      name: crates-io
-      url: https://crates.io/crates/turbovec
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install openblas for cargo publish verification
-        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev pkg-config
-      - name: Authenticate with crates.io
-        id: auth
-        uses: rust-lang/crates-io-auth-action@v1
-      - name: Publish turbovec
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: cargo publish -p turbovec

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 .cache/
+.venv/
 *.pyc
 *.bak
 *.so

--- a/turbovec-python/Cargo.toml
+++ b/turbovec-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbovec-python"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.70"
 

--- a/turbovec-python/pyproject.toml
+++ b/turbovec-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "turbovec"
-version = "0.1.3"
+version = "0.2.0"
 description = "Fast vector quantization with 2-4 bit compression and SIMD search"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Decouples Python and Rust releases. Previously a single \`v*\` tag push triggered both PyPI and crates.io publishes in lockstep — makes it impossible to release one without the other.

With this change, pushing a tag now fires only the matching workflow:

| Tag | Workflow | Publishes |
|---|---|---|
| \`v0.2.0\` | \`release-crates.yml\` | crates.io (\`cargo publish -p turbovec\`) |
| \`py-v0.2.0\` | \`release-pypi.yml\` | PyPI (wheels + sdist) |

Same pattern used by Polars and other multi-language crates — \`py-\` prefix for Python, bare \`v*\` for the default Rust/crates.io convention.

## Also bumps turbovec-python to 0.2.0

- \`turbovec-python/pyproject.toml\` → 0.2.0
- \`turbovec-python/Cargo.toml\` → 0.2.0
- \`turbovec/Cargo.toml\` stays at **0.1.3** — Rust API didn't change, no reason to republish

Minor bump (0.2.0 not 0.1.4) because the LangChain + LlamaIndex integrations in #8 added a new public feature surface and restructured the Python package layout.

## Gitignore

\`.venv/\` added so virtual environments don't get committed (I nearly did while testing).

## Release flow once this merges

\`\`\`bash
git tag py-v0.2.0
git push origin py-v0.2.0
# release-pypi.yml fires, wheels built on Linux x86_64/aarch64 + macOS aarch64,
# sdist built, all uploaded to pypi.org/project/turbovec via trusted publisher
\`\`\`

## Test plan
- [x] YAML syntax — both files parse cleanly
- [x] Tag prefix isolation — \`v*\` glob doesn't match \`py-v*\` and vice versa
- [ ] First real firing on \`py-v0.2.0\` after merge (confirms wheels upload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)