### PR TITLE
Expand test coverage: rotation, codebook, encode, distortion, index

### DIFF
--- a/turbovec-python/tests/test_index.py
+++ b/turbovec-python/tests/test_index.py
@@ -1,0 +1,132 @@
+"""Tests for TurboQuantIndex — the pyo3 binding surface.
+
+These exercise the public Python API exposed by the Rust extension
+(add, search, save/load, prepare, len, dim, bit_width), independent of
+the LangChain / LlamaIndex wrappers.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from turbovec import TurboQuantIndex
+
+
+def unit_vectors(n: int, dim: int, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    v = rng.standard_normal((n, dim)).astype(np.float32)
+    v /= np.linalg.norm(v, axis=1, keepdims=True) + 1e-9
+    return v
+
+
+def test_new_reports_dim_and_bit_width():
+    idx = TurboQuantIndex(dim=128, bit_width=4)
+    assert idx.dim == 128
+    assert idx.bit_width == 4
+    assert len(idx) == 0
+
+
+@pytest.mark.parametrize("bit_width", [2, 4])
+def test_bit_width_options(bit_width):
+    idx = TurboQuantIndex(dim=128, bit_width=bit_width)
+    assert idx.bit_width == bit_width
+    idx.add(unit_vectors(20, 128))
+    assert len(idx) == 20
+
+
+def test_add_updates_length():
+    idx = TurboQuantIndex(dim=128, bit_width=4)
+    idx.add(unit_vectors(50, 128))
+    assert len(idx) == 50
+
+
+def test_add_is_incremental():
+    idx = TurboQuantIndex(dim=128, bit_width=4)
+    idx.add(unit_vectors(20, 128, seed=1))
+    idx.add(unit_vectors(30, 128, seed=2))
+    assert len(idx) == 50
+
+
+def test_search_shape():
+    idx = TurboQuantIndex(dim=128, bit_width=4)
+    idx.add(unit_vectors(100, 128))
+    scores, indices = idx.search(unit_vectors(5, 128, seed=99), k=10)
+    assert scores.shape == (5, 10)
+    assert indices.shape == (5, 10)
+
+
+def test_search_single_query():
+    idx = TurboQuantIndex(dim=128, bit_width=4)
+    idx.add(unit_vectors(100, 128))
+    scores, indices = idx.search(unit_vectors(1, 128, seed=99), k=5)
+    assert scores.shape == (1, 5)
+    assert indices.shape == (1, 5)
+
+
+def test_self_query_recall_at_1():
+    vectors = unit_vectors(100, 256, seed=42)
+    idx = TurboQuantIndex(dim=256, bit_width=4)
+    idx.add(vectors)
+
+    hits = 0
+    for i in range(20):
+        _, indices = idx.search(vectors[i:i + 1], k=1)
+        if indices[0, 0] == i:
+            hits += 1
+    assert hits == 20, f"recall@1 failed: {hits}/20"
+
+
+def test_save_load_roundtrip(tmp_path):
+    vectors = unit_vectors(80, 128, seed=7)
+    idx = TurboQuantIndex(dim=128, bit_width=4)
+    idx.add(vectors)
+    idx.prepare()
+
+    path = str(tmp_path / "idx.tv")
+    idx.write(path)
+    loaded = TurboQuantIndex.load(path)
+
+    assert len(loaded) == 80
+    assert loaded.dim == 128
+    assert loaded.bit_width == 4
+
+    q = unit_vectors(3, 128, seed=8)
+    s_orig, i_orig = idx.search(q, k=10)
+    s_load, i_load = loaded.search(q, k=10)
+    np.testing.assert_array_equal(i_orig, i_load)
+    np.testing.assert_allclose(s_orig, s_load, rtol=1e-5)
+
+
+def test_prepare_is_idempotent():
+    idx = TurboQuantIndex(dim=64, bit_width=4)
+    idx.add(unit_vectors(20, 64))
+    idx.prepare()
+    idx.prepare()
+    assert len(idx) == 20
+
+
+def test_batch_query_matches_individual():
+    idx = TurboQuantIndex(dim=256, bit_width=4)
+    vectors = unit_vectors(50, 256, seed=0)
+    idx.add(vectors)
+
+    queries = unit_vectors(5, 256, seed=99)
+    _, batch_indices = idx.search(queries, k=3)
+
+    for i in range(5):
+        _, single_indices = idx.search(queries[i:i + 1], k=3)
+        np.testing.assert_array_equal(
+            batch_indices[i:i + 1], single_indices
+        )
+
+
+def test_noncontiguous_input_is_handled():
+    # A strided slice of a larger array should still work.
+    big = unit_vectors(100, 128)
+    strided = big[::2]
+    assert not strided.flags["C_CONTIGUOUS"]
+    idx = TurboQuantIndex(dim=128, bit_width=4)
+    # PyO3 layer asserts contiguity; caller is expected to convert.
+    # This test documents that behaviour: a contiguous copy works.
+    idx.add(np.ascontiguousarray(strided))
+    assert len(idx) == 50

--- a/turbovec/tests/codebook.rs
+++ b/turbovec/tests/codebook.rs
@@ -1,0 +1,134 @@
+//! Correctness tests for Lloyd-Max codebook generation.
+//!
+//! After orthogonal rotation, each coordinate of a unit vector on the
+//! sphere S^{d-1} follows Beta((d-1)/2, (d-1)/2) on [-1, 1]. The
+//! Lloyd-Max iteration produces the MMSE scalar quantizer for that
+//! distribution. These tests verify structural invariants at
+//! representative (bits, dim) pairs that the encoding pipeline relies
+//! on.
+
+use turbovec::codebook::codebook;
+
+#[test]
+fn centroids_strictly_ascending() {
+    for &bits in &[2usize, 3, 4] {
+        for &dim in &[256usize, 768, 1536] {
+            let (_, centroids) = codebook(bits, dim);
+            for i in 0..centroids.len() - 1 {
+                assert!(
+                    centroids[i] < centroids[i + 1],
+                    "centroids not ascending at bits={}, dim={}: c[{}]={} >= c[{}]={}",
+                    bits,
+                    dim,
+                    i,
+                    centroids[i],
+                    i + 1,
+                    centroids[i + 1]
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn boundaries_strictly_between_centroids() {
+    for &bits in &[2usize, 3, 4] {
+        for &dim in &[256usize, 1536] {
+            let (boundaries, centroids) = codebook(bits, dim);
+            assert_eq!(boundaries.len(), centroids.len() - 1);
+            for i in 0..boundaries.len() {
+                assert!(
+                    boundaries[i] > centroids[i],
+                    "boundary[{}] = {} not > centroid[{}] = {} (bits={}, dim={})",
+                    i,
+                    boundaries[i],
+                    i,
+                    centroids[i],
+                    bits,
+                    dim
+                );
+                assert!(
+                    boundaries[i] < centroids[i + 1],
+                    "boundary[{}] = {} not < centroid[{}] = {} (bits={}, dim={})",
+                    i,
+                    boundaries[i],
+                    i + 1,
+                    centroids[i + 1],
+                    bits,
+                    dim
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn level_counts_correct() {
+    for &bits in &[2usize, 3, 4] {
+        let (boundaries, centroids) = codebook(bits, 1536);
+        assert_eq!(
+            centroids.len(),
+            1 << bits,
+            "expected 2^{} = {} centroids, got {}",
+            bits,
+            1 << bits,
+            centroids.len()
+        );
+        assert_eq!(
+            boundaries.len(),
+            (1 << bits) - 1,
+            "expected 2^{} - 1 = {} boundaries, got {}",
+            bits,
+            (1 << bits) - 1,
+            boundaries.len()
+        );
+    }
+}
+
+#[test]
+fn symmetric_about_zero() {
+    for &bits in &[2usize, 3, 4] {
+        for &dim in &[768usize, 1536] {
+            let (_, centroids) = codebook(bits, dim);
+            let n = centroids.len();
+            for i in 0..n / 2 {
+                let lo = centroids[i];
+                let hi = centroids[n - 1 - i];
+                assert!(
+                    (lo + hi).abs() < 1e-4,
+                    "asymmetric: c[{}]={} c[{}]={} (bits={}, dim={})",
+                    i,
+                    lo,
+                    n - 1 - i,
+                    hi,
+                    bits,
+                    dim
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn deterministic_for_same_params() {
+    let (b1, c1) = codebook(4, 1536);
+    let (b2, c2) = codebook(4, 1536);
+    assert_eq!(b1, b2);
+    assert_eq!(c1, c2);
+}
+
+#[test]
+fn centroids_within_unit_interval() {
+    for &bits in &[2usize, 3, 4] {
+        let (_, centroids) = codebook(bits, 1536);
+        for (i, &c) in centroids.iter().enumerate() {
+            assert!(
+                c > -1.0 && c < 1.0,
+                "centroid[{}] = {} outside (-1, 1) (bits={})",
+                i,
+                c,
+                bits
+            );
+        }
+    }
+}

--- a/turbovec/tests/concurrent_search.rs
+++ b/turbovec/tests/concurrent_search.rs
@@ -11,6 +11,12 @@
 //! 4. A roundtrip through `write`/`load` produces the same top-`k` as
 //!    the original in-memory index for the same queries.
 
+// Pull the BLAS backend into the final test binary — ndarray's `.dot()`
+// (used by `encode` during `TurboQuantIndex::add`) references cblas_sgemm,
+// which only gets linked if something forces blas_src to be included in
+// the final executable.
+extern crate blas_src;
+
 use std::sync::Arc;
 use std::thread;
 

--- a/turbovec/tests/distortion.rs
+++ b/turbovec/tests/distortion.rs
@@ -1,0 +1,127 @@
+//! Statistical validation of quantizer distortion.
+//!
+//! Verifies that turbovec's Lloyd-Max codebook achieves the
+//! quantization MSE predicted by the TurboQuant paper's Theorem 1.
+//! Because Beta((d-1)/2, (d-1)/2) converges to N(0, 1/d) in high
+//! dimensions, the Beta-on-sphere codebook's MSE should approach
+//! `Theorem1(b) / d`, and its ratio to the Shannon lower bound
+//! `2^{-2b} / d` should stay within the paper's ~2.7x claim.
+//!
+//! These tests catch a class of bug that no structural test can:
+//! if Lloyd-Max ever failed to converge (wrong distribution,
+//! truncated iteration, broken integration), the codebook would
+//! still be well-formed but distortion would drift from the
+//! theoretical optimum.
+
+use statrs::distribution::{Beta, Continuous};
+use turbovec::codebook::codebook;
+
+/// Lloyd-Max MSE for an N(0, 1) source at b bits per dimension,
+/// from the TurboQuant paper's Theorem 1 (equivalently, Max 1960).
+/// Values match pyturboquant's `PAPER_MSE_VALUES` for cross-library
+/// consistency.
+const PAPER_MSE: &[(usize, f64)] = &[
+    (2, 0.1175),
+    (3, 0.03454),
+    (4, 0.009497),
+];
+
+#[test]
+fn codebook_mse_matches_paper_at_high_dim() {
+    // At d=1536 the Beta((d-1)/2, (d-1)/2) distribution is very close
+    // to N(0, 1/d), so the empirical Lloyd-Max MSE should equal
+    // Theorem1(b) / d to within ~5%.
+    let dim = 1536;
+
+    for &(bits, paper_val) in PAPER_MSE {
+        let (boundaries, centroids) = codebook(bits, dim);
+        let mse = compute_codebook_mse(&boundaries, &centroids, dim);
+        let expected = paper_val / dim as f64;
+        let rel_err = (mse - expected).abs() / expected;
+        assert!(
+            rel_err < 0.05,
+            "bits={}, dim={}: codebook MSE={:.3e} vs Theorem1/d={:.3e} (rel_err={:.3})",
+            bits,
+            dim,
+            mse,
+            expected,
+            rel_err,
+        );
+    }
+}
+
+#[test]
+fn codebook_mse_within_shannon_factor() {
+    // The paper claims distortion within ~2.7x of the Shannon lower
+    // bound 2^{-2b}. Validate the ratio stays below 3.0 across every
+    // (bits, dim) pair turbovec cares about.
+    for &bits in &[2usize, 3, 4] {
+        for &dim in &[256usize, 768, 1536] {
+            let (boundaries, centroids) = codebook(bits, dim);
+            let mse = compute_codebook_mse(&boundaries, &centroids, dim);
+            let shannon_bound = 2f64.powi(-2 * bits as i32) / dim as f64;
+            let ratio = mse / shannon_bound;
+            assert!(
+                ratio < 3.0,
+                "bits={}, dim={}: MSE/Shannon = {:.3} exceeds 3x paper bound",
+                bits,
+                dim,
+                ratio,
+            );
+            // Sanity: MSE must be above the bound, not below (would
+            // indicate a broken test or a result too good to be true).
+            assert!(
+                ratio > 1.0,
+                "bits={}, dim={}: MSE/Shannon = {:.3} below Shannon lower bound",
+                bits,
+                dim,
+                ratio,
+            );
+        }
+    }
+}
+
+/// Analytical MSE of the given (boundaries, centroids) scalar
+/// quantizer against Beta((d-1)/2, (d-1)/2) on [-1, 1].
+///
+/// For each region [b_{i-1}, b_i] with centroid c_i:
+///     contribution = integral_{b_{i-1}}^{b_i} (x - c_i)^2 * p(x) dx
+/// where p is the Beta PDF shifted from [0,1] to [-1,1].
+fn compute_codebook_mse(boundaries: &[f32], centroids: &[f32], dim: usize) -> f64 {
+    let a = (dim as f64 - 1.0) / 2.0;
+    let beta = Beta::new(a, a).unwrap();
+
+    let n = centroids.len();
+    let mut edges = Vec::with_capacity(n + 1);
+    edges.push(-1.0f64);
+    edges.extend(boundaries.iter().map(|&b| b as f64));
+    edges.push(1.0);
+
+    let mut mse = 0.0f64;
+    for i in 0..n {
+        let lo = edges[i];
+        let hi = edges[i + 1];
+        let c = centroids[i] as f64;
+        // pdf on [-1, 1]: beta.pdf((x + 1) / 2) / 2
+        mse += simpson(
+            |x: f64| (x - c).powi(2) * beta.pdf((x + 1.0) / 2.0) / 2.0,
+            lo,
+            hi,
+            4000,
+        );
+    }
+    mse
+}
+
+/// Composite Simpson's rule over `n` intervals. `n` is rounded down
+/// to even; 4000 is enough for 8+ digits on the integrands here.
+fn simpson<F: Fn(f64) -> f64>(f: F, a: f64, b: f64, n: usize) -> f64 {
+    let n = n & !1;
+    let h = (b - a) / n as f64;
+    let mut sum = f(a) + f(b);
+    for i in 1..n {
+        let x = a + i as f64 * h;
+        sum += if i % 2 == 0 { 2.0 * f(x) } else { 4.0 * f(x) };
+    }
+    sum * h / 3.0
+}

--- a/turbovec/tests/encode.rs
+++ b/turbovec/tests/encode.rs
@@ -1,0 +1,109 @@
+//! End-to-end correctness tests for the encoding pipeline.
+//!
+//! `encode::encode` is the direct entry point for normalize ->
+//! rotate -> quantize -> bit-pack. Going through it (rather than
+//! through `TurboQuantIndex`) lets us verify the low-level output
+//! shape and the stored-norm invariant without reaching into private
+//! state.
+
+extern crate blas_src;
+
+use turbovec::codebook::codebook;
+use turbovec::encode::encode;
+use turbovec::rotation::make_rotation_matrix;
+
+fn make_vectors(n: usize, dim: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed.wrapping_mul(0x9E3779B97F4A7C15);
+    let mut out = Vec::with_capacity(n * dim);
+    for _ in 0..(n * dim) {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let bits = (((state >> 32) as u32) & 0x007FFFFF) | 0x3F800000;
+        let uniform = f32::from_bits(bits) - 1.0;
+        out.push(uniform * 2.0 - 1.0);
+    }
+    out
+}
+
+#[test]
+fn produces_expected_shape() {
+    for &bit_width in &[2usize, 4] {
+        let dim = 128;
+        let n = 17;
+        let rotation = make_rotation_matrix(dim);
+        let (boundaries, _) = codebook(bit_width, dim);
+        let vectors = make_vectors(n, dim, 0);
+
+        let (packed, norms) = encode(&vectors, n, dim, &rotation, &boundaries, bit_width);
+
+        let bytes_per_row = bit_width * (dim / 8);
+        assert_eq!(
+            packed.len(),
+            n * bytes_per_row,
+            "wrong packed length for bits={}, dim={}",
+            bit_width,
+            dim
+        );
+        assert_eq!(norms.len(), n);
+    }
+}
+
+#[test]
+fn preserves_input_norms() {
+    let dim = 128;
+    let n = 10;
+    let rotation = make_rotation_matrix(dim);
+    let (boundaries, _) = codebook(4, dim);
+    let vectors = make_vectors(n, dim, 0);
+
+    let (_, norms) = encode(&vectors, n, dim, &rotation, &boundaries, 4);
+
+    for i in 0..n {
+        let input_norm = vectors[i * dim..(i + 1) * dim]
+            .iter()
+            .map(|x| x * x)
+            .sum::<f32>()
+            .sqrt();
+        assert!(
+            (input_norm - norms[i]).abs() < 1e-4,
+            "norm mismatch at i={}: input={}, stored={}",
+            i,
+            input_norm,
+            norms[i]
+        );
+    }
+}
+
+#[test]
+fn deterministic_output() {
+    let dim = 128;
+    let n = 5;
+    let rotation = make_rotation_matrix(dim);
+    let (boundaries, _) = codebook(4, dim);
+    let vectors = make_vectors(n, dim, 0);
+
+    let (p1, n1) = encode(&vectors, n, dim, &rotation, &boundaries, 4);
+    let (p2, n2) = encode(&vectors, n, dim, &rotation, &boundaries, 4);
+
+    assert_eq!(p1, p2);
+    assert_eq!(n1, n2);
+}
+
+#[test]
+fn handles_zero_vector() {
+    // A zero-norm vector must not produce NaN codes.
+    let dim = 128;
+    let rotation = make_rotation_matrix(dim);
+    let (boundaries, _) = codebook(4, dim);
+    let zeros = vec![0.0f32; dim];
+
+    let (packed, norms) = encode(&zeros, 1, dim, &rotation, &boundaries, 4);
+
+    assert_eq!(norms[0], 0.0);
+    // All codes should be finite (specifically, 0 or mid-codebook).
+    // The crucial invariant is no NaN bytes in the packed output
+    // (Vec<u8> can't hold NaN, but we assert length here for sanity).
+    let bytes_per_row = 4 * (dim / 8);
+    assert_eq!(packed.len(), bytes_per_row);
+}

--- a/turbovec/tests/rotation.rs
+++ b/turbovec/tests/rotation.rs
@@ -1,0 +1,160 @@
+//! Correctness tests for the rotation matrix generator.
+//!
+//! The rotation is a deterministic orthogonal matrix derived from a
+//! fixed crate-wide seed via QR decomposition. These tests verify the
+//! mathematical invariants the downstream quantizer depends on:
+//!
+//! - The matrix is orthogonal: `R^T R = I`.
+//! - Rotation preserves vector L2 norms.
+//! - Generation is deterministic across calls.
+//! - `R^T` recovers the input (round-trip via the transpose).
+//!
+//! Tolerances here are generous enough for f32 + faer QR roundoff.
+
+use turbovec::rotation::make_rotation_matrix;
+
+fn mat_mul(a: &[f32], b: &[f32], dim: usize) -> Vec<f32> {
+    let mut out = vec![0.0f32; dim * dim];
+    for i in 0..dim {
+        for j in 0..dim {
+            let mut acc = 0.0f32;
+            for k in 0..dim {
+                acc += a[i * dim + k] * b[k * dim + j];
+            }
+            out[i * dim + j] = acc;
+        }
+    }
+    out
+}
+
+fn transpose(m: &[f32], dim: usize) -> Vec<f32> {
+    let mut t = vec![0.0f32; dim * dim];
+    for i in 0..dim {
+        for j in 0..dim {
+            t[j * dim + i] = m[i * dim + j];
+        }
+    }
+    t
+}
+
+fn mat_vec(m: &[f32], v: &[f32], dim: usize) -> Vec<f32> {
+    let mut out = vec![0.0f32; dim];
+    for i in 0..dim {
+        let mut acc = 0.0f32;
+        for j in 0..dim {
+            acc += m[i * dim + j] * v[j];
+        }
+        out[i] = acc;
+    }
+    out
+}
+
+fn l2_norm(v: &[f32]) -> f32 {
+    v.iter().map(|x| x * x).sum::<f32>().sqrt()
+}
+
+fn rand_vec(dim: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed.wrapping_mul(0x9E3779B97F4A7C15);
+    let mut out = Vec::with_capacity(dim);
+    for _ in 0..dim {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let bits = (((state >> 32) as u32) & 0x007FFFFF) | 0x3F800000;
+        let uniform = f32::from_bits(bits) - 1.0;
+        out.push(uniform * 2.0 - 1.0);
+    }
+    out
+}
+
+#[test]
+fn orthogonal_across_dims() {
+    for &dim in &[32usize, 64, 128, 256] {
+        let r = make_rotation_matrix(dim);
+        let rt = transpose(&r, dim);
+        let product = mat_mul(&rt, &r, dim);
+        for i in 0..dim {
+            for j in 0..dim {
+                let expected = if i == j { 1.0 } else { 0.0 };
+                let got = product[i * dim + j];
+                assert!(
+                    (got - expected).abs() < 1e-3,
+                    "R^T R[{}][{}] = {}, expected {} (dim={})",
+                    i,
+                    j,
+                    got,
+                    expected,
+                    dim
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn preserves_norm() {
+    for &dim in &[32usize, 64, 128] {
+        let r = make_rotation_matrix(dim);
+        for seed in 0..5u64 {
+            let x = rand_vec(dim, seed);
+            let y = mat_vec(&r, &x, dim);
+            let nx = l2_norm(&x);
+            let ny = l2_norm(&y);
+            assert!(
+                (nx - ny).abs() / nx < 1e-3,
+                "norm changed: |Rx|={} vs |x|={} (dim={}, seed={})",
+                ny,
+                nx,
+                dim,
+                seed
+            );
+        }
+    }
+}
+
+#[test]
+fn deterministic_for_same_dim() {
+    let r1 = make_rotation_matrix(128);
+    let r2 = make_rotation_matrix(128);
+    assert_eq!(r1.len(), r2.len());
+    for (i, (a, b)) in r1.iter().zip(r2.iter()).enumerate() {
+        assert_eq!(
+            a.to_bits(),
+            b.to_bits(),
+            "rotation[{}] differs across calls: {} vs {}",
+            i,
+            a,
+            b
+        );
+    }
+}
+
+#[test]
+fn inverse_round_trip_via_transpose() {
+    let dim = 128;
+    let r = make_rotation_matrix(dim);
+    let rt = transpose(&r, dim);
+    for seed in 0..5u64 {
+        let x = rand_vec(dim, seed);
+        let rx = mat_vec(&r, &x, dim);
+        let x_hat = mat_vec(&rt, &rx, dim);
+        for (j, (orig, back)) in x.iter().zip(x_hat.iter()).enumerate() {
+            assert!(
+                (orig - back).abs() < 1e-3,
+                "R^T R x [{}] = {} vs original {} (seed={})",
+                j,
+                back,
+                orig,
+                seed
+            );
+        }
+    }
+}
+
+#[test]
+fn size_matches_dim_squared() {
+    for &dim in &[16usize, 64, 256] {
+        let r = make_rotation_matrix(dim);
+        assert_eq!(r.len(), dim * dim);
+    }
+}


### PR DESCRIPTION
## Summary

Adds **29 new tests** (17 Rust + 12 Python) covering the algorithmic core and the Python binding surface. Maps to the subset of pyturboquant's ~92 tests that applies to turbovec — QJL, Algorithm 2, MRL slicing, and L2 metric tests are deliberately excluded since turbovec doesn't implement those features (RAG scope).

## New Rust tests

| File | Tests | Covers |
|---|---|---|
| \`rotation.rs\` | 5 | orthogonality (\`R^T R = I\`), norm preservation, determinism, inverse round-trip via transpose, shape |
| \`codebook.rs\` | 6 | centroids ascending, boundaries between centroids, 2^bits level counts, symmetry about 0, determinism, centroids in (-1, 1) |
| \`encode.rs\` | 4 | packed output shape, input norm preservation, deterministic output, zero-vector edge case |
| \`distortion.rs\` | 2 | **statistical validation**: Lloyd-Max MSE matches paper's Theorem 1 at d=1536 (<5% rel err); MSE stays within 3x Shannon lower bound across (bits, dim) pairs |

The distortion tests are analytical — they use statrs's Beta PDF with Simpson's rule integration, no sampling. This catches a class of bug that structural tests miss: if Lloyd-Max ever failed to converge (wrong distribution, truncated iteration, broken integration), the codebook would still be well-formed but distortion would drift from the theoretical optimum.

## New Python tests

\`turbovec-python/tests/test_index.py\` (12 tests) — direct coverage of the pyo3 binding, independent of the LangChain/LlamaIndex wrappers:

- Basic state: \`dim\`, \`bit_width\`, \`len\`, \`add\` / incremental \`add\`
- Search: shape, single query, batch consistency
- Recall@1 self-query sanity check across 20 vectors
- Save/load round-trip with score equivalence
- \`prepare()\` idempotency
- Non-contiguous numpy input handling

## Drive-by fix

\`concurrent_search.rs\` was missing \`extern crate blas_src;\`, which caused \`cargo test\` (no filter) to fail at link time. \`kernel_correctness.rs\` already had it; this just restores parity.

## Test plan
- [x] \`cargo test\` — all 28 Rust tests pass (11 preexisting + 17 new)
- [x] \`cd turbovec-python && pytest tests/ -v\` — all 33 Python tests pass (21 preexisting + 12 new)
- [x] Distortion tests pass with tight 5% tolerance against paper Theorem 1 values
- [x] No regressions in existing LangChain / LlamaIndex integration tests

## Totals
- Before: 11 Rust + 21 Python = 32 tests
- After: 28 Rust + 33 Python = 61 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)