### PR TITLE
Extend recall charts to k=64 and reorder recall section by ascending dim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "turbovec-python"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "numpy",
  "pyo3",

--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ let loaded = TurboQuantIndex::load("index.tv").unwrap();
 
 TurboQuant vs FAISS `IndexPQ` (LUT256, nbits=8) — the paper's Section 4.4 baseline. 100K vectors, k=64. FAISS PQ sub-quantizer counts sized to match TurboQuant's bit rate (m=d/4 at 2-bit, m=d/2 at 4-bit).
 
+![Recall GloVe d=200](docs/recall_glove.svg)
+
 ![Recall d=1536](docs/recall_d1536.svg)
 
 ![Recall d=3072](docs/recall_d3072.svg)
-
-![Recall GloVe d=200](docs/recall_glove.svg)
 
 Across OpenAI d=1536 and d=3072, TurboQuant and FAISS are within 0–1 point at R@1 and both converge to 1.0 by k=4–8. GloVe d=200 is a harder regime for rotation-based quantizers (low dim means the Gaussianization assumed by Lloyd-Max is less exact), and TurboQuant trails FAISS by 3–6 points at R@1 there, closing by k≈16 at 4-bit and k≈32 at 2-bit. In a typical search→rerank pipeline the residual gap disappears once you verify the top candidates with exact scores. Full results: [d=1536 2-bit](benchmarks/results/recall_d1536_2bit.json), [d=1536 4-bit](benchmarks/results/recall_d1536_4bit.json), [d=3072 2-bit](benchmarks/results/recall_d3072_2bit.json), [d=3072 4-bit](benchmarks/results/recall_d3072_4bit.json), [GloVe 2-bit](benchmarks/results/recall_glove_2bit.json), [GloVe 4-bit](benchmarks/results/recall_glove_4bit.json).
 

--- a/benchmarks/create_diagrams.py
+++ b/benchmarks/create_diagrams.py
@@ -246,8 +246,8 @@ def write_recall_panel(dim_key, dim_label, filename, y_lo=0.85):
     px = margin["left"]
     py = margin["top"]
 
-    x_values = [1, 2, 4, 8, 16]
-    x_labels = ["1", "2", "4", "8", "16"]
+    x_values = [1, 2, 4, 8, 16, 32, 64]
+    x_labels = ["1", "2", "4", "8", "16", "32", "64"]
 
     series = []
     for bw_key, bw_label in [("2bit", "2-bit"), ("4bit", "4-bit")]:

--- a/docs/recall_d1536.svg
+++ b/docs/recall_d1536.svg
@@ -30,33 +30,43 @@
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">d=1536</text>
 <text x="84.0" y="372" text-anchor="middle" class="label">1</text>
-<text x="280.0" y="372" text-anchor="middle" class="label">2</text>
-<text x="476.0" y="372" text-anchor="middle" class="label">4</text>
-<text x="672.0" y="372" text-anchor="middle" class="label">8</text>
-<text x="868.0" y="372" text-anchor="middle" class="label">16</text>
-<path d="M 84.0,317.2 L 280.0,158.6 L 476.0,94.2 L 672.0,90.7 L 868.0,90.7" fill="none" stroke="#635bff" stroke-width="2.25" />
+<text x="214.7" y="372" text-anchor="middle" class="label">2</text>
+<text x="345.3" y="372" text-anchor="middle" class="label">4</text>
+<text x="476.0" y="372" text-anchor="middle" class="label">8</text>
+<text x="606.7" y="372" text-anchor="middle" class="label">16</text>
+<text x="737.3" y="372" text-anchor="middle" class="label">32</text>
+<text x="868.0" y="372" text-anchor="middle" class="label">64</text>
+<path d="M 84.0,317.2 L 214.7,158.6 L 345.3,94.2 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#635bff" stroke-width="2.25" />
 <circle cx="84.0" cy="317.2" r="3.5" fill="#635bff" />
-<circle cx="280.0" cy="158.6" r="3.5" fill="#635bff" />
-<circle cx="476.0" cy="94.2" r="3.5" fill="#635bff" />
-<circle cx="672.0" cy="90.7" r="3.5" fill="#635bff" />
+<circle cx="214.7" cy="158.6" r="3.5" fill="#635bff" />
+<circle cx="345.3" cy="94.2" r="3.5" fill="#635bff" />
+<circle cx="476.0" cy="90.7" r="3.5" fill="#635bff" />
+<circle cx="606.7" cy="90.7" r="3.5" fill="#635bff" />
+<circle cx="737.3" cy="90.7" r="3.5" fill="#635bff" />
 <circle cx="868.0" cy="90.7" r="3.5" fill="#635bff" />
-<path d="M 84.0,313.7 L 280.0,130.8 L 476.0,95.9 L 672.0,90.7 L 868.0,90.7" fill="none" stroke="#9aa7b6" stroke-width="2.25" stroke-dasharray="6 4" />
+<path d="M 84.0,313.7 L 214.7,130.8 L 345.3,95.9 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#9aa7b6" stroke-width="2.25" stroke-dasharray="6 4" />
 <circle cx="84.0" cy="313.7" r="3.5" fill="#9aa7b6" />
-<circle cx="280.0" cy="130.8" r="3.5" fill="#9aa7b6" />
-<circle cx="476.0" cy="95.9" r="3.5" fill="#9aa7b6" />
-<circle cx="672.0" cy="90.7" r="3.5" fill="#9aa7b6" />
+<circle cx="214.7" cy="130.8" r="3.5" fill="#9aa7b6" />
+<circle cx="345.3" cy="95.9" r="3.5" fill="#9aa7b6" />
+<circle cx="476.0" cy="90.7" r="3.5" fill="#9aa7b6" />
+<circle cx="606.7" cy="90.7" r="3.5" fill="#9aa7b6" />
+<circle cx="737.3" cy="90.7" r="3.5" fill="#9aa7b6" />
 <circle cx="868.0" cy="90.7" r="3.5" fill="#9aa7b6" />
-<path d="M 84.0,169.1 L 280.0,97.7 L 476.0,90.7 L 672.0,90.7 L 868.0,90.7" fill="none" stroke="#0f766e" stroke-width="2.25" />
+<path d="M 84.0,169.1 L 214.7,97.7 L 345.3,90.7 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#0f766e" stroke-width="2.25" />
 <circle cx="84.0" cy="169.1" r="3.5" fill="#0f766e" />
-<circle cx="280.0" cy="97.7" r="3.5" fill="#0f766e" />
+<circle cx="214.7" cy="97.7" r="3.5" fill="#0f766e" />
+<circle cx="345.3" cy="90.7" r="3.5" fill="#0f766e" />
 <circle cx="476.0" cy="90.7" r="3.5" fill="#0f766e" />
-<circle cx="672.0" cy="90.7" r="3.5" fill="#0f766e" />
+<circle cx="606.7" cy="90.7" r="3.5" fill="#0f766e" />
+<circle cx="737.3" cy="90.7" r="3.5" fill="#0f766e" />
 <circle cx="868.0" cy="90.7" r="3.5" fill="#0f766e" />
-<path d="M 84.0,149.9 L 280.0,94.2 L 476.0,90.7 L 672.0,90.7 L 868.0,90.7" fill="none" stroke="#64748b" stroke-width="2.25" stroke-dasharray="6 4" />
+<path d="M 84.0,149.9 L 214.7,94.2 L 345.3,90.7 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#64748b" stroke-width="2.25" stroke-dasharray="6 4" />
 <circle cx="84.0" cy="149.9" r="3.5" fill="#64748b" />
-<circle cx="280.0" cy="94.2" r="3.5" fill="#64748b" />
+<circle cx="214.7" cy="94.2" r="3.5" fill="#64748b" />
+<circle cx="345.3" cy="90.7" r="3.5" fill="#64748b" />
 <circle cx="476.0" cy="90.7" r="3.5" fill="#64748b" />
-<circle cx="672.0" cy="90.7" r="3.5" fill="#64748b" />
+<circle cx="606.7" cy="90.7" r="3.5" fill="#64748b" />
+<circle cx="737.3" cy="90.7" r="3.5" fill="#64748b" />
 <circle cx="868.0" cy="90.7" r="3.5" fill="#64748b" />
 <text x="22" y="217.0" transform="rotate(-90, 22, 217.0)" class="axis">recall@1@k</text>
 <text x="476.0" y="400" text-anchor="middle" class="axis">k</text>

--- a/docs/recall_d3072.svg
+++ b/docs/recall_d3072.svg
@@ -30,33 +30,43 @@
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">d=3072</text>
 <text x="84.0" y="372" text-anchor="middle" class="label">1</text>
-<text x="280.0" y="372" text-anchor="middle" class="label">2</text>
-<text x="476.0" y="372" text-anchor="middle" class="label">4</text>
-<text x="672.0" y="372" text-anchor="middle" class="label">8</text>
-<text x="868.0" y="372" text-anchor="middle" class="label">16</text>
-<path d="M 84.0,244.0 L 280.0,115.1 L 476.0,90.7 L 672.0,90.7 L 868.0,90.7" fill="none" stroke="#635bff" stroke-width="2.25" />
+<text x="214.7" y="372" text-anchor="middle" class="label">2</text>
+<text x="345.3" y="372" text-anchor="middle" class="label">4</text>
+<text x="476.0" y="372" text-anchor="middle" class="label">8</text>
+<text x="606.7" y="372" text-anchor="middle" class="label">16</text>
+<text x="737.3" y="372" text-anchor="middle" class="label">32</text>
+<text x="868.0" y="372" text-anchor="middle" class="label">64</text>
+<path d="M 84.0,244.0 L 214.7,115.1 L 345.3,90.7 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#635bff" stroke-width="2.25" />
 <circle cx="84.0" cy="244.0" r="3.5" fill="#635bff" />
-<circle cx="280.0" cy="115.1" r="3.5" fill="#635bff" />
+<circle cx="214.7" cy="115.1" r="3.5" fill="#635bff" />
+<circle cx="345.3" cy="90.7" r="3.5" fill="#635bff" />
 <circle cx="476.0" cy="90.7" r="3.5" fill="#635bff" />
-<circle cx="672.0" cy="90.7" r="3.5" fill="#635bff" />
+<circle cx="606.7" cy="90.7" r="3.5" fill="#635bff" />
+<circle cx="737.3" cy="90.7" r="3.5" fill="#635bff" />
 <circle cx="868.0" cy="90.7" r="3.5" fill="#635bff" />
-<path d="M 84.0,244.0 L 280.0,115.1 L 476.0,90.7 L 672.0,90.7 L 868.0,90.7" fill="none" stroke="#9aa7b6" stroke-width="2.25" stroke-dasharray="6 4" />
+<path d="M 84.0,244.0 L 214.7,115.1 L 345.3,90.7 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#9aa7b6" stroke-width="2.25" stroke-dasharray="6 4" />
 <circle cx="84.0" cy="244.0" r="3.5" fill="#9aa7b6" />
-<circle cx="280.0" cy="115.1" r="3.5" fill="#9aa7b6" />
+<circle cx="214.7" cy="115.1" r="3.5" fill="#9aa7b6" />
+<circle cx="345.3" cy="90.7" r="3.5" fill="#9aa7b6" />
 <circle cx="476.0" cy="90.7" r="3.5" fill="#9aa7b6" />
-<circle cx="672.0" cy="90.7" r="3.5" fill="#9aa7b6" />
+<circle cx="606.7" cy="90.7" r="3.5" fill="#9aa7b6" />
+<circle cx="737.3" cy="90.7" r="3.5" fill="#9aa7b6" />
 <circle cx="868.0" cy="90.7" r="3.5" fill="#9aa7b6" />
-<path d="M 84.0,148.2 L 280.0,95.9 L 476.0,90.7 L 672.0,90.7 L 868.0,90.7" fill="none" stroke="#0f766e" stroke-width="2.25" />
+<path d="M 84.0,148.2 L 214.7,95.9 L 345.3,90.7 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#0f766e" stroke-width="2.25" />
 <circle cx="84.0" cy="148.2" r="3.5" fill="#0f766e" />
-<circle cx="280.0" cy="95.9" r="3.5" fill="#0f766e" />
+<circle cx="214.7" cy="95.9" r="3.5" fill="#0f766e" />
+<circle cx="345.3" cy="90.7" r="3.5" fill="#0f766e" />
 <circle cx="476.0" cy="90.7" r="3.5" fill="#0f766e" />
-<circle cx="672.0" cy="90.7" r="3.5" fill="#0f766e" />
+<circle cx="606.7" cy="90.7" r="3.5" fill="#0f766e" />
+<circle cx="737.3" cy="90.7" r="3.5" fill="#0f766e" />
 <circle cx="868.0" cy="90.7" r="3.5" fill="#0f766e" />
-<path d="M 84.0,139.5 L 280.0,94.2 L 476.0,90.7 L 672.0,90.7 L 868.0,90.7" fill="none" stroke="#64748b" stroke-width="2.25" stroke-dasharray="6 4" />
+<path d="M 84.0,139.5 L 214.7,94.2 L 345.3,90.7 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#64748b" stroke-width="2.25" stroke-dasharray="6 4" />
 <circle cx="84.0" cy="139.5" r="3.5" fill="#64748b" />
-<circle cx="280.0" cy="94.2" r="3.5" fill="#64748b" />
+<circle cx="214.7" cy="94.2" r="3.5" fill="#64748b" />
+<circle cx="345.3" cy="90.7" r="3.5" fill="#64748b" />
 <circle cx="476.0" cy="90.7" r="3.5" fill="#64748b" />
-<circle cx="672.0" cy="90.7" r="3.5" fill="#64748b" />
+<circle cx="606.7" cy="90.7" r="3.5" fill="#64748b" />
+<circle cx="737.3" cy="90.7" r="3.5" fill="#64748b" />
 <circle cx="868.0" cy="90.7" r="3.5" fill="#64748b" />
 <text x="22" y="217.0" transform="rotate(-90, 22, 217.0)" class="axis">recall@1@k</text>
 <text x="476.0" y="400" text-anchor="middle" class="axis">k</text>

--- a/docs/recall_glove.svg
+++ b/docs/recall_glove.svg
@@ -30,33 +30,43 @@
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">GloVe d=200</text>
 <text x="84.0" y="372" text-anchor="middle" class="label">1</text>
-<text x="280.0" y="372" text-anchor="middle" class="label">2</text>
-<text x="476.0" y="372" text-anchor="middle" class="label">4</text>
-<text x="672.0" y="372" text-anchor="middle" class="label">8</text>
-<text x="868.0" y="372" text-anchor="middle" class="label">16</text>
-<path d="M 84.0,305.0 L 280.0,236.8 L 476.0,178.2 L 672.0,138.1 L 868.0,109.5" fill="none" stroke="#635bff" stroke-width="2.25" />
+<text x="214.7" y="372" text-anchor="middle" class="label">2</text>
+<text x="345.3" y="372" text-anchor="middle" class="label">4</text>
+<text x="476.0" y="372" text-anchor="middle" class="label">8</text>
+<text x="606.7" y="372" text-anchor="middle" class="label">16</text>
+<text x="737.3" y="372" text-anchor="middle" class="label">32</text>
+<text x="868.0" y="372" text-anchor="middle" class="label">64</text>
+<path d="M 84.0,305.0 L 214.7,236.8 L 345.3,178.2 L 476.0,138.1 L 606.7,109.5 L 737.3,94.9 L 868.0,87.8" fill="none" stroke="#635bff" stroke-width="2.25" />
 <circle cx="84.0" cy="305.0" r="3.5" fill="#635bff" />
-<circle cx="280.0" cy="236.8" r="3.5" fill="#635bff" />
-<circle cx="476.0" cy="178.2" r="3.5" fill="#635bff" />
-<circle cx="672.0" cy="138.1" r="3.5" fill="#635bff" />
-<circle cx="868.0" cy="109.5" r="3.5" fill="#635bff" />
-<path d="M 84.0,278.7 L 280.0,209.7 L 476.0,153.6 L 672.0,117.6 L 868.0,97.6" fill="none" stroke="#9aa7b6" stroke-width="2.25" stroke-dasharray="6 4" />
+<circle cx="214.7" cy="236.8" r="3.5" fill="#635bff" />
+<circle cx="345.3" cy="178.2" r="3.5" fill="#635bff" />
+<circle cx="476.0" cy="138.1" r="3.5" fill="#635bff" />
+<circle cx="606.7" cy="109.5" r="3.5" fill="#635bff" />
+<circle cx="737.3" cy="94.9" r="3.5" fill="#635bff" />
+<circle cx="868.0" cy="87.8" r="3.5" fill="#635bff" />
+<path d="M 84.0,278.7 L 214.7,209.7 L 345.3,153.6 L 476.0,117.6 L 606.7,97.6 L 737.3,88.3 L 868.0,85.1" fill="none" stroke="#9aa7b6" stroke-width="2.25" stroke-dasharray="6 4" />
 <circle cx="84.0" cy="278.7" r="3.5" fill="#9aa7b6" />
-<circle cx="280.0" cy="209.7" r="3.5" fill="#9aa7b6" />
-<circle cx="476.0" cy="153.6" r="3.5" fill="#9aa7b6" />
-<circle cx="672.0" cy="117.6" r="3.5" fill="#9aa7b6" />
-<circle cx="868.0" cy="97.6" r="3.5" fill="#9aa7b6" />
-<path d="M 84.0,168.4 L 280.0,114.6 L 476.0,90.4 L 672.0,85.2 L 868.0,84.4" fill="none" stroke="#0f766e" stroke-width="2.25" />
+<circle cx="214.7" cy="209.7" r="3.5" fill="#9aa7b6" />
+<circle cx="345.3" cy="153.6" r="3.5" fill="#9aa7b6" />
+<circle cx="476.0" cy="117.6" r="3.5" fill="#9aa7b6" />
+<circle cx="606.7" cy="97.6" r="3.5" fill="#9aa7b6" />
+<circle cx="737.3" cy="88.3" r="3.5" fill="#9aa7b6" />
+<circle cx="868.0" cy="85.1" r="3.5" fill="#9aa7b6" />
+<path d="M 84.0,168.4 L 214.7,114.6 L 345.3,90.4 L 476.0,85.2 L 606.7,84.4 L 737.3,84.2 L 868.0,84.2" fill="none" stroke="#0f766e" stroke-width="2.25" />
 <circle cx="84.0" cy="168.4" r="3.5" fill="#0f766e" />
-<circle cx="280.0" cy="114.6" r="3.5" fill="#0f766e" />
-<circle cx="476.0" cy="90.4" r="3.5" fill="#0f766e" />
-<circle cx="672.0" cy="85.2" r="3.5" fill="#0f766e" />
-<circle cx="868.0" cy="84.4" r="3.5" fill="#0f766e" />
-<path d="M 84.0,155.2 L 280.0,105.9 L 476.0,88.1 L 672.0,84.9 L 868.0,84.2" fill="none" stroke="#64748b" stroke-width="2.25" stroke-dasharray="6 4" />
+<circle cx="214.7" cy="114.6" r="3.5" fill="#0f766e" />
+<circle cx="345.3" cy="90.4" r="3.5" fill="#0f766e" />
+<circle cx="476.0" cy="85.2" r="3.5" fill="#0f766e" />
+<circle cx="606.7" cy="84.4" r="3.5" fill="#0f766e" />
+<circle cx="737.3" cy="84.2" r="3.5" fill="#0f766e" />
+<circle cx="868.0" cy="84.2" r="3.5" fill="#0f766e" />
+<path d="M 84.0,155.2 L 214.7,105.9 L 345.3,88.1 L 476.0,84.9 L 606.7,84.2 L 737.3,84.2 L 868.0,84.2" fill="none" stroke="#64748b" stroke-width="2.25" stroke-dasharray="6 4" />
 <circle cx="84.0" cy="155.2" r="3.5" fill="#64748b" />
-<circle cx="280.0" cy="105.9" r="3.5" fill="#64748b" />
-<circle cx="476.0" cy="88.1" r="3.5" fill="#64748b" />
-<circle cx="672.0" cy="84.9" r="3.5" fill="#64748b" />
+<circle cx="214.7" cy="105.9" r="3.5" fill="#64748b" />
+<circle cx="345.3" cy="88.1" r="3.5" fill="#64748b" />
+<circle cx="476.0" cy="84.9" r="3.5" fill="#64748b" />
+<circle cx="606.7" cy="84.2" r="3.5" fill="#64748b" />
+<circle cx="737.3" cy="84.2" r="3.5" fill="#64748b" />
 <circle cx="868.0" cy="84.2" r="3.5" fill="#64748b" />
 <text x="22" y="217.0" transform="rotate(-90, 22, 217.0)" class="axis">recall@1@k</text>
 <text x="476.0" y="400" text-anchor="middle" class="axis">k</text>


### PR DESCRIPTION
## Summary

Follow-up to the just-merged #13. Two small things:

- **Extend recall charts to k=64.** JSONs already contain k=32 and k=64; chart generator was clipping at k=16.
- **Reorder README recall section by ascending dim** (GloVe d=200 → d=1536 → d=3072) so the reader walks up the dim ladder instead of jumping around.

Also syncs `Cargo.lock` to the `Cargo.toml` turbovec-python 0.2.0 bump that had drifted.

## Test plan

- [x] `python3 benchmarks/create_diagrams.py` regenerates all 3 recall SVGs with the k=32/64 tail visible
- [x] README diff matches: only the order of the three `![Recall ...](...)` lines changed, plus the `Fastscan → IndexPQ` narrative was already updated in #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)