### PR TITLE
Search-time filtering: mask= / allowlist= kwargs (closes #21)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "worktree": {
+    "bgIsolation": "none"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *.pyc
 *.bak
 *.so
+*.dSYM/
 *.tq
 *.npy
 codebooks.npz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,35 @@ appears under each surface it touches.
   - Threaded through every scoring path: NEON (aarch64), AVX2
     (x86_64), AVX-512BW (x86_64), and the scalar fallback.
 
+- **Lazy index construction.** The dim can now be deferred and inferred
+  from the first batch of vectors, rather than committed at construction
+  time. This is the same ergonomic improvement integration users were
+  already getting through the framework wrappers, pulled down into the
+  core so direct Rust users and any future integration get it for free.
+  - `TurboQuantIndex::new_lazy(bit_width)` and
+    `IdMapIndex::new_lazy(bit_width)` — construct an empty index with
+    no committed dim.
+  - `TurboQuantIndex::add_2d(vectors, dim)` and
+    `IdMapIndex::add_with_ids_2d(vectors, dim, ids)` — add a flat
+    vector batch with an explicit dim; locks the index dim on the
+    first call, validates on subsequent ones. Existing `add(&[f32])` /
+    `add_with_ids(&[f32], &[u64])` still work on a dim-known index and
+    panic with a clear message on a lazy uncommitted one.
+  - `TurboQuantIndex::dim_opt()` / `IdMapIndex::dim_opt()` return
+    `Option<usize>` — `None` for the lazy uncommitted state. The
+    existing `dim() -> usize` getters keep returning `usize`, with `0`
+    as a non-breaking sentinel for the lazy state (the eager
+    constructor asserts `dim >= 8`, so `0` doesn't collide).
+  - File format: `.tv` and `.tvim` headers encode the lazy state via
+    a `dim = 0` sentinel. Files written before this change always have
+    `dim >= 8` and load cleanly into the eager state.
+
+#### Changed
+
+- `search`, `search_with_mask`, and `prepare` on `TurboQuantIndex`
+  return empty results / are no-ops when called on a lazy
+  uncommitted index, rather than panicking.
+
 ### turbovec — Python package (current: 0.3.0 → next: 0.4.0)
 
 #### Added
@@ -47,36 +76,116 @@ appears under each surface it touches.
     surface as `pyo3.PanicException`.
   ([#21](https://github.com/RyanCodrai/turbovec/issues/21))
 
+- **Lazy construction.** `TurboQuantIndex(dim=None, bit_width=4)` and
+  `IdMapIndex(dim=None, bit_width=4)` now accept an optional `dim`.
+  When omitted, the dim is inferred from the first `.add(...)` /
+  `.add_with_ids(...)` call using the input array's shape. The
+  framework integrations all rely on this internally now.
+- `.dim` property on both index types now returns `int | None` (was
+  `int`); `None` means the index hasn't seen its first add yet.
+
 #### Changed
 
-- **Haystack integration** (`turbovec.haystack`): `embedding_retrieval`
-  now resolves `filters` to an allowlist before scoring, replacing the
-  prior `top_k * 10` over-fetch + post-filter pass. Selective filters
-  that previously could return fewer than `top_k` documents now return
-  up to `top_k` matches from the filtered set. The "results may be
-  fewer than `top_k` when filtering is restrictive" caveat in the
-  docstring is gone.
+- **Haystack integration** (`turbovec.haystack`):
+  `TurboQuantDocumentStore` is now a structural drop-in for
+  `haystack.document_stores.in_memory.InMemoryDocumentStore`. Audited
+  against `haystack-ai 2.28.0` and brought up to parity. In addition
+  to the earlier filter-resolution fix:
+  - `dim` is now optional in the constructor; the index is built
+    lazily on the first `write_documents`.
+  - Constructor accepts `embedding_similarity_function`
+    (`"cosine"` default, since turbovec stores unit-normalized
+    vectors), `async_executor`, and `return_embedding` for parity
+    with the reference. `scale_score=True` now uses the right
+    per-similarity-function formula (`(s + 1) / 2` for cosine,
+    `expit(s / 100)` for dot product), fixing a pre-existing bug.
+  - 12 `*_async` variants added (`count_documents_async`,
+    `filter_documents_async`, `write_documents_async`,
+    `delete_documents_async`, `delete_all_documents_async`,
+    `update_by_filter_async`, `count_documents_by_filter_async`,
+    `count_unique_metadata_by_filter_async`,
+    `get_metadata_fields_info_async`, `get_metadata_field_min_max_async`,
+    `get_metadata_field_unique_values_async`, `embedding_retrieval_async`).
+  - 8 utility methods added (`delete_all_documents`,
+    `delete_by_filter`, `update_by_filter`, `count_documents_by_filter`,
+    `count_unique_metadata_by_filter`, `get_metadata_fields_info`,
+    `get_metadata_field_min_max`, `get_metadata_field_unique_values`),
+    plus a `storage` property and `shutdown()`.
+  - `write_documents` now validates its input and raises
+    `ValueError("Please provide a list of Documents.")` on bad input
+    instead of an opaque `AttributeError`.
+  - Persistence methods renamed to match the reference:
+    `save → save_to_disk`, `load → load_from_disk`. (No deprecation
+    shims — pre-this-change persisted stores load fine, but the method
+    names change.)
+
 - **LangChain integration** (`turbovec.langchain`):
-  `similarity_search`, `similarity_search_with_score` and
-  `similarity_search_by_vector` now accept a `filter` keyword — either
-  a `dict[str, Any]` of metadata key/value pairs (AND of equality), or
-  a `Callable[[Document], bool]` predicate over a langchain_core
-  `Document`. Matches the convention in `langchain_core`'s in-tree
-  `InMemoryVectorStore`. Previously these silently ignored any
-  `filter` argument via `**_`.
-- **LlamaIndex integration** (`turbovec.llama_index`): `query()` now
-  honours `VectorStoreQuery.filters`, `VectorStoreQuery.node_ids` and
-  `VectorStoreQuery.doc_ids`. `node_ids` restricts to specific node
-  ids; `doc_ids` restricts by `ref_doc_id` (source document); all
-  three intersect when more than one is supplied. Operator and
-  missing-key semantics match `SimpleVectorStore`'s reference
-  implementation — notably `NE` returns `False` on missing keys and
-  `TEXT_MATCH` is case-insensitive. Supports `MetadataFilters` with
-  the `EQ`, `NE`, `GT`, `LT`, `GTE`, `LTE`, `IN`, `NIN`, `TEXT_MATCH`,
-  `CONTAINS` and `IS_EMPTY` operators, plus `AND` / `OR` conditions
-  (including nested `MetadataFilters` — which the reference store
-  rejects). Unsupported operators (`ANY`, `ALL`,
-  `TEXT_MATCH_INSENSITIVE`) and the `NOT` condition raise
-  `NotImplementedError` rather than silently mismatching.
+  `TurboQuantVectorStore` is now a structural drop-in for
+  `langchain_core.vectorstores.in_memory.InMemoryVectorStore`. Audited
+  against `langchain_core 0.3.63`. In addition to the earlier filter
+  fixes:
+  - `__init__` no longer requires a pre-built `IdMapIndex`. Lazy
+    construction lets `TurboQuantVectorStore(embedding)` work
+    directly — same no-arg ergonomics as the reference.
+  - `_select_relevance_score_fn` override added — maps the raw cosine
+    similarity into `[0, 1]` so `similarity_search_with_relevance_scores`
+    and `as_retriever(search_type="similarity_score_threshold")` work.
+    Result is clamped to `[0, 1]` to absorb the small overshoot caused
+    by quantization noise.
+  - `get_by_ids` / `aget_by_ids` implemented from the side-car
+    docstore.
+  - `add_documents` overrides the base-class default so partial
+    `Document.id` is honoured per-document (some ids explicit, others
+    UUID-generated) instead of being dropped wholesale.
+  - True async overrides: `aadd_documents`, `aadd_texts` and
+    `asimilarity_search_with_score` use `aembed_documents` /
+    `aembed_query` for genuine async embedding generation;
+    `asimilarity_search`, `asimilarity_search_by_vector`,
+    `amax_marginal_relevance_search`, `afrom_texts`, `adelete` are
+    explicit overrides too.
+  - `delete` now returns `None` (was `bool`) and is a no-op when
+    called with `ids=None` — matches the reference's contract.
+  - `max_marginal_relevance_search` / `_by_vector` /
+    `amax_marginal_relevance_search` raise `NotImplementedError` with
+    a clear message rather than the base class's bare
+    `NotImplementedError`. MMR isn't faithfully implementable on a
+    quantized index because the algorithm requires full-precision
+    candidate vectors that turbovec discards after encoding.
+  - Persistence methods renamed: `save_local → dump`, `load_local →
+    load`, matching the reference.
+
+- **LlamaIndex integration** (`turbovec.llama_index`):
+  `TurboQuantVectorStore` is now a structural drop-in for
+  `llama_index.core.vector_stores.simple.SimpleVectorStore`. Audited
+  against `llama_index.core 0.12.39`. In addition to the earlier
+  filter fixes:
+  - `__init__` no longer requires a pre-built `IdMapIndex`;
+    `TurboQuantVectorStore()` works directly. `from_params(dim=None,
+    bit_width=4)` is also lazy.
+  - `get_nodes(node_ids, filters)` implemented (the reference raises
+    NotImplementedError because it doesn't store nodes; we do).
+    `clear()` resets state while preserving `bit_width`.
+  - `to_dict` / `from_dict` for config round-trip.
+  - `get(text_id)` raises `NotImplementedError` with an explanation —
+    we can't return the original embedding (quantized away).
+  - `delete_nodes(node_ids, filters)` now honours `filters` (previously
+    raised). Both constraints intersect when supplied.
+  - Async overrides for `async_add`, `adelete`, `adelete_nodes`,
+    `aclear`, `aquery`, `aget_nodes`.
+  - **StorageContext compatibility**: new
+    `from_persist_dir(persist_dir, namespace, fs)` matching the
+    reference's namespaced-filename convention, so
+    `StorageContext.from_defaults(persist_dir=...)` works. The
+    `persist` / `from_persist_path` on-disk layout changed within this
+    branch: `persist_path` is now a path *stem* and we write
+    `{stem}.tvim` + `{stem}.pkl` next to each other (was: a directory
+    containing two files at fixed names). This fits StorageContext's
+    file-shaped paths and lets multiple namespaced stores share a
+    directory. **Breaking within the branch** — anyone tracking an
+    earlier commit on this branch must repersist.
+  - Dropped the `allow_dangerous_deserialization` flag on
+    `from_persist_path`. The reference doesn't have one and requiring
+    it broke seamless StorageContext flows. The pickle risk is now
+    documented on `persist` and `from_persist_path` docstrings.
 
 [Unreleased]: https://github.com/RyanCodrai/turbovec/compare/v0.2.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,16 +176,20 @@ appears under each surface it touches.
     `from_persist_dir(persist_dir, namespace, fs)` matching the
     reference's namespaced-filename convention, so
     `StorageContext.from_defaults(persist_dir=...)` works. The
-    `persist` / `from_persist_path` on-disk layout changed within this
-    branch: `persist_path` is now a path *stem* and we write
-    `{stem}.tvim` + `{stem}.pkl` next to each other (was: a directory
-    containing two files at fixed names). This fits StorageContext's
+    `persist` / `from_persist_path` on-disk layout is now stem-based:
+    `persist_path` is a path *stem* and we write `{stem}.tvim` +
+    `{stem}.nodes.json` next to each other. This fits StorageContext's
     file-shaped paths and lets multiple namespaced stores share a
-    directory. **Breaking within the branch** — anyone tracking an
-    earlier commit on this branch must repersist.
-  - Dropped the `allow_dangerous_deserialization` flag on
-    `from_persist_path`. The reference doesn't have one and requiring
-    it broke seamless StorageContext flows. The pickle risk is now
-    documented on `persist` and `from_persist_path` docstrings.
+    directory.
+
+- **JSON side-cars across all three integrations.** Haystack, LangChain
+  and LlamaIndex persistence now writes a plain-JSON side-car next to
+  the binary `IdMapIndex` payload instead of a pickle. The
+  `allow_dangerous_deserialization` flag is gone everywhere — loading
+  is safe regardless of file provenance. Document / node metadata must
+  be JSON-serializable, which matches the constraint the reference
+  in-tree stores already impose. The side-car carries a
+  `schema_version` field; loaders reject unknown versions instead of
+  silently misinterpreting bytes.
 
 [Unreleased]: https://github.com/RyanCodrai/turbovec/compare/v0.2.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,14 +60,23 @@ appears under each surface it touches.
   `similarity_search`, `similarity_search_with_score` and
   `similarity_search_by_vector` now accept a `filter` keyword — either
   a `dict[str, Any]` of metadata key/value pairs (AND of equality), or
-  a `Callable[[dict], bool]` predicate over metadata. Previously these
-  silently ignored any filter argument via `**_`.
+  a `Callable[[Document], bool]` predicate over a langchain_core
+  `Document`. Matches the convention in `langchain_core`'s in-tree
+  `InMemoryVectorStore`. Previously these silently ignored any
+  `filter` argument via `**_`.
 - **LlamaIndex integration** (`turbovec.llama_index`): `query()` now
-  honours `VectorStoreQuery.filters` and `VectorStoreQuery.doc_ids`.
-  Supports `MetadataFilters` with the `EQ`, `NE`, `GT`, `LT`, `GTE`,
-  `LTE`, `IN`, `NIN`, `TEXT_MATCH`, `CONTAINS` and `IS_EMPTY` operators,
-  and `AND` / `OR` conditions (including nested `MetadataFilters`).
-  Unsupported operators raise `NotImplementedError` rather than
-  silently mismatching.
+  honours `VectorStoreQuery.filters`, `VectorStoreQuery.node_ids` and
+  `VectorStoreQuery.doc_ids`. `node_ids` restricts to specific node
+  ids; `doc_ids` restricts by `ref_doc_id` (source document); all
+  three intersect when more than one is supplied. Operator and
+  missing-key semantics match `SimpleVectorStore`'s reference
+  implementation — notably `NE` returns `False` on missing keys and
+  `TEXT_MATCH` is case-insensitive. Supports `MetadataFilters` with
+  the `EQ`, `NE`, `GT`, `LT`, `GTE`, `LTE`, `IN`, `NIN`, `TEXT_MATCH`,
+  `CONTAINS` and `IS_EMPTY` operators, plus `AND` / `OR` conditions
+  (including nested `MetadataFilters` — which the reference store
+  rejects). Unsupported operators (`ANY`, `ALL`,
+  `TEXT_MATCH_INSENSITIVE`) and the `NOT` condition raise
+  `NotImplementedError` rather than silently mismatching.
 
 [Unreleased]: https://github.com/RyanCodrai/turbovec/compare/v0.2.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,41 +4,70 @@ All notable changes to turbovec are recorded here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-The Rust crate (`turbovec`) and the Python distribution (`turbovec` on PyPI)
-version independently; entries note which surface a change applies to.
+The Rust crate (`turbovec` on crates.io) and the Python distribution
+(`turbovec` on PyPI) version independently. Each release section below
+is split by surface — a single feature can affect both, and its bullet
+appears under each surface it touches.
 
 ## [Unreleased]
 
-### Added
+### turbovec — Rust crate (current: 0.2.0 → next: 0.3.0)
 
-- **Search-time filtering** on both index types. Pass an id allowlist (or a
-  slot bitmask) to `search()` and the kernel honours it directly during the
-  top-k heap update — no over-fetch dance, no recall hit on selective filters.
-  Output shape shrinks to `min(k, n_allowed)` when the allowed set is smaller
-  than `k`. ([#21](https://github.com/RyanCodrai/turbovec/issues/21))
-  - Rust: `TurboQuantIndex::search_with_mask(queries, k, Option<&[bool]>)` and
-    `IdMapIndex::search_with_allowlist(queries, k, Option<&[u64]>)`.
-  - Python: keyword-only `mask=` on `TurboQuantIndex.search` and `allowlist=`
-    on `IdMapIndex.search`.
-  - Implemented across the NEON, AVX2, AVX-512BW and scalar scoring paths.
+#### Added
 
-### Changed
+- **Search-time filtering.** New methods restrict the returned top-k to
+  a caller-supplied subset of vectors. The kernel applies the filter at
+  the heap-update site rather than via post-filtering, so selective
+  filters return up to `k` results from the allowed set instead of
+  fewer-than-`k` from an over-fetch pass. Output shape shrinks to
+  `min(k, n_allowed)` — consistent with the existing `k > len(idx)`
+  contract; no sentinel padding.
+  ([#21](https://github.com/RyanCodrai/turbovec/issues/21))
+  - `TurboQuantIndex::search_with_mask(queries, k, mask: Option<&[bool]>)`
+    — slot bitmask, length equal to `len(idx)`.
+  - `IdMapIndex::search_with_allowlist(queries, k, allowlist: Option<&[u64]>)`
+    — external-id allowlist; translated to a slot bitmask internally
+    via the existing `id_to_slot` map. Panics on empty allowlist or
+    unknown ids.
+  - Threaded through every scoring path: NEON (aarch64), AVX2
+    (x86_64), AVX-512BW (x86_64), and the scalar fallback.
 
-- **Haystack integration** (`turbovec.haystack`): `embedding_retrieval` now
-  resolves `filters` to an allowlist before scoring, replacing the prior
-  over-fetch + post-filter pass. Selective filters that previously could
-  return fewer than `top_k` documents now return up to `top_k` matches from
-  the filtered set.
-- **LangChain integration** (`turbovec.langchain`): `similarity_search`,
-  `similarity_search_with_score` and `similarity_search_by_vector` now accept
-  a `filter` keyword — either a `dict[str, Any]` of metadata key/value pairs
-  (AND of equality), or a `Callable[[dict], bool]` predicate over metadata.
-  Previously these silently ignored any filter argument.
-- **LlamaIndex integration** (`turbovec.llama_index`): `query()` now honours
-  `VectorStoreQuery.filters` and `VectorStoreQuery.doc_ids`. Supports
-  `MetadataFilters` with the `EQ`, `NE`, `GT`, `LT`, `GTE`, `LTE`, `IN`,
-  `NIN`, `TEXT_MATCH`, `CONTAINS` and `IS_EMPTY` operators, and `AND` / `OR`
-  conditions (including nested `MetadataFilters`). Unsupported operators
-  raise `NotImplementedError` rather than silently mismatching.
+### turbovec — Python package (current: 0.3.0 → next: 0.4.0)
+
+#### Added
+
+- **Search-time filtering.** Same feature surfaced as keyword-only
+  arguments on `search`:
+  - `TurboQuantIndex.search(queries, k, *, mask=None)` — `mask` is a
+    NumPy `bool` array of shape `(len(idx),)`.
+  - `IdMapIndex.search(queries, k, *, allowlist=None)` — `allowlist`
+    is a NumPy `uint64` array of external ids.
+  - Pre-validates shape, dtype, emptiness and unknown ids and raises
+    `ValueError` / `KeyError` rather than letting the Rust panic
+    surface as `pyo3.PanicException`.
+  ([#21](https://github.com/RyanCodrai/turbovec/issues/21))
+
+#### Changed
+
+- **Haystack integration** (`turbovec.haystack`): `embedding_retrieval`
+  now resolves `filters` to an allowlist before scoring, replacing the
+  prior `top_k * 10` over-fetch + post-filter pass. Selective filters
+  that previously could return fewer than `top_k` documents now return
+  up to `top_k` matches from the filtered set. The "results may be
+  fewer than `top_k` when filtering is restrictive" caveat in the
+  docstring is gone.
+- **LangChain integration** (`turbovec.langchain`):
+  `similarity_search`, `similarity_search_with_score` and
+  `similarity_search_by_vector` now accept a `filter` keyword — either
+  a `dict[str, Any]` of metadata key/value pairs (AND of equality), or
+  a `Callable[[dict], bool]` predicate over metadata. Previously these
+  silently ignored any filter argument via `**_`.
+- **LlamaIndex integration** (`turbovec.llama_index`): `query()` now
+  honours `VectorStoreQuery.filters` and `VectorStoreQuery.doc_ids`.
+  Supports `MetadataFilters` with the `EQ`, `NE`, `GT`, `LT`, `GTE`,
+  `LTE`, `IN`, `NIN`, `TEXT_MATCH`, `CONTAINS` and `IS_EMPTY` operators,
+  and `AND` / `OR` conditions (including nested `MetadataFilters`).
+  Unsupported operators raise `NotImplementedError` rather than
+  silently mismatching.
 
 [Unreleased]: https://github.com/RyanCodrai/turbovec/compare/v0.2.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to turbovec are recorded here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The Rust crate (`turbovec`) and the Python distribution (`turbovec` on PyPI)
+version independently; entries note which surface a change applies to.
+
+## [Unreleased]
+
+### Added
+
+- **Search-time filtering** on both index types. Pass an id allowlist (or a
+  slot bitmask) to `search()` and the kernel honours it directly during the
+  top-k heap update — no over-fetch dance, no recall hit on selective filters.
+  Output shape shrinks to `min(k, n_allowed)` when the allowed set is smaller
+  than `k`. ([#21](https://github.com/RyanCodrai/turbovec/issues/21))
+  - Rust: `TurboQuantIndex::search_with_mask(queries, k, Option<&[bool]>)` and
+    `IdMapIndex::search_with_allowlist(queries, k, Option<&[u64]>)`.
+  - Python: keyword-only `mask=` on `TurboQuantIndex.search` and `allowlist=`
+    on `IdMapIndex.search`.
+  - Implemented across the NEON, AVX2, AVX-512BW and scalar scoring paths.
+
+### Changed
+
+- **Haystack integration** (`turbovec.haystack`): `embedding_retrieval` now
+  resolves `filters` to an allowlist before scoring, replacing the prior
+  over-fetch + post-filter pass. Selective filters that previously could
+  return fewer than `top_k` documents now return up to `top_k` matches from
+  the filtered set.
+- **LangChain integration** (`turbovec.langchain`): `similarity_search`,
+  `similarity_search_with_score` and `similarity_search_by_vector` now accept
+  a `filter` keyword — either a `dict[str, Any]` of metadata key/value pairs
+  (AND of equality), or a `Callable[[dict], bool]` predicate over metadata.
+  Previously these silently ignored any filter argument.
+- **LlamaIndex integration** (`turbovec.llama_index`): `query()` now honours
+  `VectorStoreQuery.filters` and `VectorStoreQuery.doc_ids`. Supports
+  `MetadataFilters` with the `EQ`, `NE`, `GT`, `LT`, `GTE`, `LTE`, `IN`,
+  `NIN`, `TEXT_MATCH`, `CONTAINS` and `IS_EMPTY` operators, and `AND` / `OR`
+  conditions (including nested `MetadataFilters`). Unsupported operators
+  raise `NotImplementedError` rather than silently mismatching.
+
+[Unreleased]: https://github.com/RyanCodrai/turbovec/compare/v0.2.0...HEAD

--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ See [`docs/api.md`](docs/api.md) for the full reference.
 
 ### Framework integrations
 
-- [LangChain](docs/integrations/langchain.md) — `pip install turbovec[langchain]`
-- [LlamaIndex](docs/integrations/llama_index.md) — `pip install turbovec[llama-index]`
-- [Haystack](docs/integrations/haystack.md) — `pip install turbovec[haystack]`
+Drop-in replacements for the in-tree reference vector / document stores in each framework. Same public surface, same persistence semantics, same retriever and pipeline wiring — swap the import and keep your pipeline.
+
+- [LangChain](docs/integrations/langchain.md) — `pip install turbovec[langchain]` · replaces `langchain_core.vectorstores.InMemoryVectorStore`
+- [LlamaIndex](docs/integrations/llama_index.md) — `pip install turbovec[llama-index]` · replaces `llama_index.core.vector_stores.SimpleVectorStore`
+- [Haystack](docs/integrations/haystack.md) — `pip install turbovec[haystack]` · replaces `haystack.document_stores.in_memory.InMemoryDocumentStore`
 
 ## Rust
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ turbovec is a Rust vector index with Python bindings, built on Google Research's
 
 - **No codebook training.** Add vectors, they're indexed. No data-dependent calibration, no rebuilds as the corpus grows.
 - **Faster than FAISS.** Hand-written NEON (ARM) and AVX-512BW (x86) kernels beat FAISS IndexPQFastScan by 12–20% on ARM and match-or-beat it on x86.
+- **Filter at search time.** Pass an id allowlist (or a slot bitmask) to `search()` and the kernel honours it directly. You always get up to `k` results from the allowed set — no over-fetching, no recall hit on selective filters.
 - **Pure local.** No managed service, no data leaving your machine or VPC. Pair with any open-source embedding model for a fully air-gapped RAG stack.
 
 Building RAG where privacy, memory, or latency matters? **You're in the right place.**
@@ -55,6 +56,27 @@ index.remove(1002)                         # O(1) by id
 index.write("my_index.tvim")
 loaded = IdMapIndex.load("my_index.tvim")
 ```
+
+### Hybrid retrieval (filtered search)
+
+Restrict results to a candidate set produced by another system (SQL, BM25, ACL, time window, …):
+
+```python
+import numpy as np
+from turbovec import IdMapIndex
+
+idx = IdMapIndex(dim=1536, bit_width=4)
+idx.add_with_ids(vectors, ids)
+
+# Stage 1: external system narrows to candidate ids.
+allowed = np.array(db.execute("SELECT id FROM docs WHERE tenant=?", (t,)).fetchall(),
+                   dtype=np.uint64)
+
+# Stage 2: dense rerank within the candidate set.
+scores, ids = idx.search(query, k=10, allowlist=allowed)
+```
+
+The kernel only inserts allowed vectors into the per-query heap, so `len(allowed) < k` shrinks the output to `len(allowed)` rather than returning fewer than `k` valid results.
 
 See [`docs/api.md`](docs/api.md) for the full reference.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,17 +27,26 @@ idx.write("index.tv")                   # .tv format
 loaded = TurboQuantIndex.load("index.tv")
 ```
 
+`dim` is optional. Omit it to let the index pick up the dimensionality from the first batch of vectors:
+
+```python
+idx = TurboQuantIndex(bit_width=4)      # dim inferred on first add
+idx.add(vectors)                         # locks dim to vectors.shape[1]
+```
+
+Before the first add, `idx.dim` is `None`, `len(idx)` is `0`, and `search()` returns empty results.
+
 ### Methods
 
 | Method | Notes |
 |---|---|
-| `TurboQuantIndex(dim, bit_width)` | `bit_width ∈ {2, 4}` |
-| `add(vectors)` | `vectors` must be contiguous float32 `(n, dim)`. |
+| `TurboQuantIndex(dim=None, bit_width=4)` | `bit_width ∈ {2, 4}`. `dim` is optional; when omitted it is inferred from the first `add` call. |
+| `add(vectors)` | `vectors` is a contiguous float32 array of shape `(n, dim)`. On a lazy index the first call locks `dim`; subsequent calls must match. |
 | `search(queries, k, *, mask=None)` | Returns `(scores, indices)`, both shape `(nq, effective_k)`. Indices are `int64` slot positions. `mask` is an optional `bool` array of length `len(idx)`; when given, only slots with `mask[i] == True` contribute. `effective_k = min(k, mask.sum())`. |
 | `swap_remove(idx)` | O(1). Moves the last vector into `idx`; returns the previous position of that moved vector (so external refs can be updated if needed). |
-| `prepare()` | Optional. Eagerly builds the rotation matrix, Lloyd-Max centroids and SIMD-blocked layout so the first `search` call doesn't pay the one-time cost. |
+| `prepare()` | Optional. Eagerly builds the rotation matrix, Lloyd-Max centroids and SIMD-blocked layout so the first `search` call doesn't pay the one-time cost. No-op on a lazy index that hasn't seen its first add. |
 | `write(path)` / `load(path)` | `.tv` format. |
-| `len(idx)` / `idx.dim` / `idx.bit_width` | Introspection. |
+| `len(idx)` / `idx.dim` / `idx.bit_width` | Introspection. `idx.dim` returns `int` once committed, or `None` on a lazy index that hasn't seen its first add. |
 
 ### `swap_remove` semantics
 
@@ -67,12 +76,19 @@ idx.write("index.tvim")                    # .tvim format
 loaded = IdMapIndex.load("index.tvim")
 ```
 
+As with [`TurboQuantIndex`](#turboquantindex), `dim` is optional and gets inferred from the first `add_with_ids` call:
+
+```python
+idx = IdMapIndex(bit_width=4)            # dim inferred on first add
+idx.add_with_ids(vectors, ids)           # locks dim to vectors.shape[1]
+```
+
 ### Methods
 
 | Method | Notes |
 |---|---|
-| `IdMapIndex(dim, bit_width)` | |
-| `add_with_ids(vectors, ids)` | `ids` is a `uint64` array with length `vectors.shape[0]`. Rejects duplicate ids (raises). |
+| `IdMapIndex(dim=None, bit_width=4)` | `dim` is optional; when omitted it is inferred from the first `add_with_ids` call. |
+| `add_with_ids(vectors, ids)` | `ids` is a `uint64` array with length `vectors.shape[0]`. Rejects duplicate ids (raises). On a lazy index the first call locks `dim`. |
 | `remove(id) -> bool` | `True` if the id was present and removed, `False` otherwise. O(1). |
 | `search(queries, k, *, allowlist=None)` | Returns `(scores, ids)` — `ids` are `uint64` external ids. `allowlist` is an optional `uint64` array of ids; when given, results are restricted to those ids and `effective_k = min(k, len(allowlist))`. Raises `ValueError` on empty allowlist and `KeyError` on unknown ids. |
 | `contains(id)` / `id in idx` | Membership. |
@@ -146,5 +162,7 @@ Common use cases:
 ```
 
 On load, the reverse `id → slot` map is rebuilt in memory. Duplicate ids in the `slot_to_id` table are rejected as corrupt.
+
+`dim = 0` in the header signals a lazy uncommitted index (the constructor asserts `dim ≥ 8` so this value is unambiguous). `dim = 0` is only valid alongside `n_vectors = 0`; on load it produces an index whose `dim` is `None` until the first `add` / `add_with_ids` call.
 
 Both formats are stable across minor versions. Breaking changes bump the file-format version byte (`.tvim`) or the header length (`.tv`).

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,7 +33,7 @@ loaded = TurboQuantIndex.load("index.tv")
 |---|---|
 | `TurboQuantIndex(dim, bit_width)` | `bit_width ∈ {2, 4}` |
 | `add(vectors)` | `vectors` must be contiguous float32 `(n, dim)`. |
-| `search(queries, k)` | Returns `(scores, indices)`, both shape `(nq, k)`. Indices are `int64` slot positions. |
+| `search(queries, k, *, mask=None)` | Returns `(scores, indices)`, both shape `(nq, effective_k)`. Indices are `int64` slot positions. `mask` is an optional `bool` array of length `len(idx)`; when given, only slots with `mask[i] == True` contribute. `effective_k = min(k, mask.sum())`. |
 | `swap_remove(idx)` | O(1). Moves the last vector into `idx`; returns the previous position of that moved vector (so external refs can be updated if needed). |
 | `prepare()` | Optional. Eagerly builds the rotation matrix, Lloyd-Max centroids and SIMD-blocked layout so the first `search` call doesn't pay the one-time cost. |
 | `write(path)` / `load(path)` | `.tv` format. |
@@ -74,7 +74,7 @@ loaded = IdMapIndex.load("index.tvim")
 | `IdMapIndex(dim, bit_width)` | |
 | `add_with_ids(vectors, ids)` | `ids` is a `uint64` array with length `vectors.shape[0]`. Rejects duplicate ids (raises). |
 | `remove(id) -> bool` | `True` if the id was present and removed, `False` otherwise. O(1). |
-| `search(queries, k)` | Returns `(scores, ids)` — `ids` are `uint64` external ids. |
+| `search(queries, k, *, allowlist=None)` | Returns `(scores, ids)` — `ids` are `uint64` external ids. `allowlist` is an optional `uint64` array of ids; when given, results are restricted to those ids and `effective_k = min(k, len(allowlist))`. Raises `ValueError` on empty allowlist and `KeyError` on unknown ids. |
 | `contains(id)` / `id in idx` | Membership. |
 | `write(path)` / `load(path)` | `.tvim` format. |
 | `len(idx)` / `idx.dim` / `idx.bit_width` / `prepare()` | Same as `TurboQuantIndex`. |
@@ -85,6 +85,32 @@ loaded = IdMapIndex.load("index.tvim")
 - `IdMapIndex` — you need stable external ids (e.g. string-id → vector mapping maintained by the caller).
 
 All the framework integrations (LangChain, LlamaIndex, Haystack) use `IdMapIndex` internally for exactly this reason.
+
+---
+
+## Filtering
+
+Both index types support restricting the returned top-`k` to a caller-supplied subset of vectors. Unlike post-filtering (search then drop), the kernel never inserts disallowed vectors into the per-query heap, so you always get up to `k` results from the allowed set rather than fewer.
+
+```python
+# IdMapIndex — allowlist of external ids (typical use)
+allowed = np.array([1003, 1010, 1042], dtype=np.uint64)
+scores, ids = idx.search(queries, k=10, allowlist=allowed)
+# scores.shape == (nq, min(k, len(allowed))) == (nq, 3)
+
+# TurboQuantIndex — bool mask over slots
+mask = np.ones(len(idx), dtype=bool)
+mask[disabled_slots] = False
+scores, slots = idx.search(queries, k=10, mask=mask)
+```
+
+The output shape is `(nq, min(k, n_allowed))` — same shrinking behaviour you already see when `k > len(idx)`. No `-1` / `NaN` padding; pad on the caller side if you need a fixed-width batch.
+
+Common use cases:
+
+- Hybrid retrieval where a SQL/BM25 stage produces a candidate id set.
+- Access control or multi-tenant queries (only return ids the caller can see).
+- Time-windowed search (e.g. only documents from the last 7 days).
 
 ---
 

--- a/docs/integrations/haystack.md
+++ b/docs/integrations/haystack.md
@@ -1,6 +1,6 @@
 # Haystack integration
 
-`turbovec.haystack.TurboQuantDocumentStore` is a [Haystack 2.x `DocumentStore`](https://docs.haystack.deepset.ai/docs/document-store) backed by an `IdMapIndex`. Supports the full mutation lifecycle (`write_documents`, `delete_documents`) and integrates with `InMemoryEmbeddingRetriever`-style pipelines via `embedding_retrieval`.
+`turbovec.haystack.TurboQuantDocumentStore` is a Haystack 2.x [`DocumentStore`](https://docs.haystack.deepset.ai/docs/document-store) backed by an `IdMapIndex`. It implements the same public surface as `haystack.document_stores.in_memory.InMemoryDocumentStore` and can be used as a drop-in replacement wherever the in-memory store is used.
 
 ## Install
 
@@ -14,7 +14,7 @@ pip install turbovec[haystack]
 from haystack import Document
 from turbovec.haystack import TurboQuantDocumentStore
 
-store = TurboQuantDocumentStore(dim=1536, bit_width=4)
+store = TurboQuantDocumentStore()
 store.write_documents([
     Document(content="...", embedding=[...], meta={"source": "a"}),
     Document(content="...", embedding=[...], meta={"source": "b"}),
@@ -25,6 +25,27 @@ results = store.embedding_retrieval(query_embedding=[...], top_k=5)
 
 Documents must have pre-computed embeddings — `TurboQuantDocumentStore` doesn't invoke an embedder. Pipe a Haystack embedder component upstream if your documents arrive without embeddings.
 
+## Constructor
+
+```python
+TurboQuantDocumentStore(
+    dim: Optional[int] = None,
+    bit_width: int = 4,
+    *,
+    embedding_similarity_function: Literal["dot_product", "cosine"] = "cosine",
+    async_executor: Optional[ThreadPoolExecutor] = None,
+    return_embedding: bool = False,
+)
+```
+
+| Parameter | Notes |
+|---|---|
+| `dim` | Optional. When omitted the vector dimensionality is inferred from the first `write_documents` call. |
+| `bit_width` | Quantization width per coordinate; one of `{2, 4}`. |
+| `embedding_similarity_function` | Drives the `scale_score=True` formula on retrieval. Defaults to `"cosine"` (right for unit-normalized embeddings); `"dot_product"` uses Haystack's `expit(s / 100)` formula. |
+| `async_executor` | Optional `ThreadPoolExecutor` for the `*_async` methods. If omitted, a single-threaded executor is created and cleaned up with the store. |
+| `return_embedding` | Accepted for API parity with `InMemoryDocumentStore`. The full-precision embedding is never available (quantized away), so `Document.embedding` on retrieved docs is always `None` regardless of the flag. |
+
 ## `DuplicatePolicy`
 
 `write_documents` takes a `policy` argument controlling how id collisions are handled:
@@ -32,7 +53,7 @@ Documents must have pre-computed embeddings — `TurboQuantDocumentStore` doesn'
 ```python
 from haystack.document_stores.types import DuplicatePolicy
 
-store.write_documents(docs, policy=DuplicatePolicy.FAIL)      # default — raise if any id collides
+store.write_documents(docs, policy=DuplicatePolicy.FAIL)      # raise if any id collides
 store.write_documents(docs, policy=DuplicatePolicy.SKIP)      # silently skip colliding ids
 store.write_documents(docs, policy=DuplicatePolicy.OVERWRITE) # remove-then-re-add colliding ids
 # DuplicatePolicy.NONE is treated as FAIL.
@@ -43,14 +64,16 @@ Returns the number of documents actually written (so `SKIP` may return less than
 ## Delete
 
 ```python
-store.delete_documents(["id-1", "id-2"])
+store.delete_documents(["id-1", "id-2"])     # by id; missing ids are silently ignored
+store.delete_by_filter(filters)               # by filter; returns count
+store.delete_all_documents()                  # clear everything
 ```
 
-O(1) per id. Missing ids are silently ignored (per Haystack convention).
+`delete_documents` and `delete_by_filter` are O(1) per matching document via the inner `IdMapIndex`.
 
 ## Filters
 
-`filter_documents(filters)` and `embedding_retrieval(..., filters=...)` accept the full [Haystack filter DSL](https://docs.haystack.deepset.ai/docs/metadata-filtering):
+`filter_documents(filters)`, `embedding_retrieval(..., filters=...)`, and the other filter-aware helpers accept the full [Haystack filter DSL](https://docs.haystack.deepset.ai/docs/metadata-filtering):
 
 ```python
 filters = {
@@ -74,28 +97,57 @@ results = store.embedding_retrieval(
 
 Filter evaluation is delegated to `haystack.utils.filters.document_matches_filter` — anything Haystack's own stores support, we support.
 
-On `embedding_retrieval`, filters are applied **after** vector search. We over-fetch internally to keep the returned top-k at its requested size even with restrictive filters.
+For `embedding_retrieval`, filters are resolved to an allowlist **before** scoring rather than via post-filtering. Selective filters return up to `top_k` matches from the filtered set; you never get fewer than `top_k` results just because the filter happened to exclude the top-scoring candidates.
+
+## Metadata helpers
+
+```python
+store.count_documents_by_filter(filters)                          # int
+store.count_unique_metadata_by_filter(filters, ["source", "tag"]) # dict[str, int]
+store.update_by_filter(filters, {"reviewed": True})               # bulk metadata update; returns count
+
+store.get_metadata_fields_info()
+# {"source": {"type": "keyword"}, "version": {"type": "int"}, ...}
+
+store.get_metadata_field_min_max("version")     # {"min": 1, "max": 5}
+store.get_metadata_field_unique_values("source")
+# (["a", "b", "c"], 3)
+```
+
+`update_by_filter` updates metadata only — embeddings are quantized at write time and not re-encoded.
+
+## Async
+
+Every public method has an `*_async` variant:
+
+```python
+await store.write_documents_async(docs)
+results = await store.embedding_retrieval_async(query_embedding=q, top_k=5)
+await store.delete_documents_async(["id-1"])
+```
+
+By default they run on a single-threaded executor owned by the store. Pass an `async_executor=` to the constructor to share an executor across stores (or to use more workers).
 
 ## Save / load
 
 ```python
-store.save("./my-store")
+store.save_to_disk("./my-store")
 # ... later ...
-store = TurboQuantDocumentStore.load(
+store = TurboQuantDocumentStore.load_from_disk(
     "./my-store",
     allow_dangerous_deserialization=True,
 )
 ```
 
-Produces two files:
-- `index.tvim` — the `IdMapIndex` payload
-- `docstore.pkl` — pickled document text/metadata plus id maps
+Writes two files under the given folder path:
+- `index.tvim` — the `IdMapIndex` payload (quantized vectors + id maps).
+- `docstore.pkl` — pickled document text and metadata.
 
 The `allow_dangerous_deserialization` flag is required because unpickling untrusted data is unsafe.
 
 ## Using in a Haystack Pipeline
 
-`TurboQuantDocumentStore` implements `to_dict` / `from_dict` so it can be serialized as part of a Haystack `Pipeline`. `to_dict` captures the component *config* (`dim`, `bit_width`); persisting the stored documents is the job of `save`/`load`.
+`TurboQuantDocumentStore` implements `to_dict` / `from_dict` so it can be serialized as part of a Haystack `Pipeline`. `to_dict` captures the component *config* (`dim`, `bit_width`, `embedding_similarity_function`, `return_embedding`); persisting the stored documents is the job of `save_to_disk` / `load_from_disk`.
 
 Plug into a standard RAG pipeline the same way you'd use `InMemoryDocumentStore`:
 
@@ -104,8 +156,7 @@ from haystack import Pipeline
 from haystack.components.embedders import SentenceTransformersDocumentEmbedder
 from haystack.components.writers import DocumentWriter
 
-store = TurboQuantDocumentStore(dim=384, bit_width=4)
-
+store = TurboQuantDocumentStore()                 # dim inferred from first batch
 indexing = Pipeline()
 indexing.add_component("embedder", SentenceTransformersDocumentEmbedder(
     model="sentence-transformers/all-MiniLM-L6-v2",
@@ -118,6 +169,6 @@ indexing.run({"embedder": {"documents": my_docs}})
 
 ## Known limitations
 
-- **Embeddings are dropped after quantization.** `embedding_retrieval(..., return_embedding=True)` is accepted for signature compatibility but returns `None` on the `embedding` field of each returned document.
-- **`scale_score=True`** uses a sigmoid squash of the inner-product score. If you need `(score + 1) / 2` (Haystack's `InMemoryDocumentStore` default for cosine), post-process on the caller side.
-- **Side-car is pickle.** `allow_dangerous_deserialization=True` required on load.
+- **Embeddings are not retained.** `embedding_retrieval(..., return_embedding=True)` is accepted for signature compatibility but `Document.embedding` is always `None` on retrieved docs — turbovec discards the full-precision vector after quantization.
+- **Pickle side-car.** `load_from_disk` requires `allow_dangerous_deserialization=True` because the document side-car is pickled.
+- **`dim` is locked on the first add.** Subsequent calls with a different shape raise `ValueError`. If you need to change `dim`, construct a fresh store.

--- a/docs/integrations/haystack.md
+++ b/docs/integrations/haystack.md
@@ -133,17 +133,14 @@ By default they run on a single-threaded executor owned by the store. Pass an `a
 ```python
 store.save_to_disk("./my-store")
 # ... later ...
-store = TurboQuantDocumentStore.load_from_disk(
-    "./my-store",
-    allow_dangerous_deserialization=True,
-)
+store = TurboQuantDocumentStore.load_from_disk("./my-store")
 ```
 
 Writes two files under the given folder path:
 - `index.tvim` — the `IdMapIndex` payload (quantized vectors + id maps).
-- `docstore.pkl` — pickled document text and metadata.
+- `docstore.json` — JSON-encoded document text, metadata, and id maps.
 
-The `allow_dangerous_deserialization` flag is required because unpickling untrusted data is unsafe.
+Document metadata must be JSON-serializable — the same constraint `InMemoryDocumentStore.save_to_disk` imposes.
 
 ## Using in a Haystack Pipeline
 
@@ -170,5 +167,5 @@ indexing.run({"embedder": {"documents": my_docs}})
 ## Known limitations
 
 - **Embeddings are not retained.** `embedding_retrieval(..., return_embedding=True)` is accepted for signature compatibility but `Document.embedding` is always `None` on retrieved docs — turbovec discards the full-precision vector after quantization.
-- **Pickle side-car.** `load_from_disk` requires `allow_dangerous_deserialization=True` because the document side-car is pickled.
+- **JSON-serializable metadata only.** Document metadata is stored as JSON in the side-car. Non-JSON-serializable values (custom objects, sets, etc.) fail at save time — the same constraint `InMemoryDocumentStore.save_to_disk` imposes.
 - **`dim` is locked on the first add.** Subsequent calls with a different shape raise `ValueError`. If you need to change `dim`, construct a fresh store.

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -1,6 +1,6 @@
 # LangChain integration
 
-`turbovec.langchain.TurboQuantVectorStore` is a [LangChain `VectorStore`](https://python.langchain.com/docs/integrations/vectorstores/) backed by an `IdMapIndex`, so it supports O(1) delete by document id and full save/load.
+`turbovec.langchain.TurboQuantVectorStore` is a [LangChain `VectorStore`](https://python.langchain.com/docs/integrations/vectorstores/) backed by an `IdMapIndex`. It implements the same public surface as `langchain_core.vectorstores.in_memory.InMemoryVectorStore` and can be used as a drop-in replacement wherever the in-memory store is used.
 
 ## Install
 
@@ -25,7 +25,23 @@ store = TurboQuantVectorStore.from_texts(
 retriever = store.as_retriever(search_kwargs={"k": 5})
 ```
 
-`bit_width` is `2` or `4`. `dim` is inferred from the first embedding by default; pass `dim=...` explicitly if starting from an empty store.
+The dimensionality of the underlying quantized index is inferred from the embedding model on the first `add_*` call — no need to specify it up front.
+
+## Construction
+
+```python
+# No-arg: lazy. dim is inferred from the first add.
+store = TurboQuantVectorStore(embeddings)
+
+# from_texts: same lazy behaviour, plus immediate ingest.
+store = TurboQuantVectorStore.from_texts(texts, embeddings, bit_width=4)
+
+# Pre-built index: bring your own IdMapIndex (e.g. one loaded from disk).
+from turbovec import IdMapIndex
+store = TurboQuantVectorStore(embeddings, index=IdMapIndex(1536, 4))
+```
+
+`bit_width` is `2` or `4` and is fixed once the index is created.
 
 ## Adding with explicit ids
 
@@ -35,35 +51,18 @@ store.add_texts(
     ids=["doc-a", "doc-b", "doc-c"],
     metadatas=[{"source": "x"}, {"source": "y"}, {"source": "z"}],
 )
+
+# add_documents honours per-Document.id, falling back to a UUID per
+# document if .id is missing — partial ids are not dropped wholesale.
+store.add_documents([
+    Document(id="explicit", page_content="..."),
+    Document(page_content="..."),                  # gets a UUID
+])
 ```
 
 If an id is already present, `add_texts` **upserts** — the existing entry is removed and the new one added with the same id. This matches the typical user expectation that re-indexing a document with the same id should replace it, not duplicate it.
 
-## Delete
-
-```python
-store.delete(["doc-a", "doc-b"])  # True if all ids were present, False if any was missing
-```
-
-Delete is O(1) per id. Passing `ids=None` raises `ValueError` — the LangChain protocol allows `None` to mean "delete all", but we require an explicit list to avoid accidental wipes.
-
-## Save / load
-
-```python
-store.save_local("./my-store")
-# ... later ...
-store = TurboQuantVectorStore.load_local(
-    "./my-store",
-    embedding=embeddings,
-    allow_dangerous_deserialization=True,  # required — side-car is pickle
-)
-```
-
-Produces two files:
-- `index.tvim` — the `IdMapIndex` payload (see [api.md](../api.md#tvim--idmapindex))
-- `docstore.pkl` — a pickled dictionary of document text, metadata, and id maps
-
-The `allow_dangerous_deserialization` flag is required because unpickling untrusted data is unsafe. Only load files you produced yourself or trust the source of.
+Async equivalents (`aadd_texts`, `aadd_documents`) use the embedding model's `aembed_documents` so they benefit from concurrent embedding generation when the model supports it.
 
 ## Search
 
@@ -83,8 +82,67 @@ docs = store.similarity_search_by_vector(qvec.tolist(), k=5)
 
 Scores are raw inner products. Because vectors are L2-normalized on insert, inner product equals cosine similarity — higher is better, range `[-1, 1]`.
 
+`similarity_search_with_relevance_scores` and `as_retriever(search_type="similarity_score_threshold")` work: the raw cosine is mapped to `[0, 1]` via `(sim + 1) / 2` (clamped to absorb the tiny overshoot caused by quantization noise).
+
+Async equivalents (`asimilarity_search`, `asimilarity_search_with_score`, `asimilarity_search_by_vector`, `aget_by_ids`) are all implemented.
+
+## Filters
+
+`similarity_search`, `similarity_search_with_score`, and `similarity_search_by_vector` all accept a `filter` keyword:
+
+```python
+# Dict — AND of exact equality on Document.metadata.
+docs = store.similarity_search(
+    "query", k=5, filter={"source": "manual", "version": 2},
+)
+
+# Callable — predicate over the Document.
+docs = store.similarity_search(
+    "query", k=5, filter=lambda doc: doc.metadata.get("score", 0) > 0.8,
+)
+```
+
+The callable form matches the `Callable[[Document], bool]` convention used by `InMemoryVectorStore`, so predicates ported from there work unchanged.
+
+Filters are resolved to an id allowlist **before** scoring; the kernel only ever inserts allowed documents into the per-query heap. You get up to `k` results from the filtered set, never fewer than `k` because the filter happened to exclude the top-scoring candidates.
+
+## Document retrieval by id
+
+```python
+docs = store.get_by_ids(["doc-a", "doc-c"])
+# Missing ids are silently skipped.
+```
+
+`aget_by_ids` is also available.
+
+## Delete
+
+```python
+store.delete(["doc-a", "doc-b"])  # missing ids silently skipped, returns None
+```
+
+Delete is O(1) per id. `delete(None)` is a no-op (matches the `InMemoryVectorStore` contract).
+
+## Save / load
+
+```python
+store.dump("./my-store")
+# ... later ...
+store = TurboQuantVectorStore.load(
+    "./my-store",
+    embedding=embeddings,
+    allow_dangerous_deserialization=True,  # required — side-car is pickle
+)
+```
+
+Writes two files under the given folder path:
+- `index.tvim` — the `IdMapIndex` payload (see [api.md](../api.md#tvim--idmapindex)).
+- `docstore.pkl` — a pickled dictionary of document text, metadata, and id maps.
+
+The `allow_dangerous_deserialization` flag is required because unpickling untrusted data is unsafe. Only load files you produced yourself or trust the source of.
+
 ## Known limitations
 
-- **No first-class metadata filtering.** LangChain's `VectorStore` interface doesn't standardize filter predicates. If you need filtered search, use the Haystack integration (which exposes a filter DSL).
-- **Embeddings are dropped after quantization.** `search` returns `Document` objects with `page_content` and `metadata`, but not the original embedding.
-- **Side-car is pickle.** We may migrate to a safer format in a future major version; for now, treat `allow_dangerous_deserialization=True` as mandatory reading.
+- **Max-marginal-relevance search is not supported.** `max_marginal_relevance_search` and its variants raise `NotImplementedError` with an explanation. MMR requires the full-precision embedding of each candidate to compute pairwise diversity; turbovec discards full-precision vectors after quantization. If you need MMR, keep a parallel store with the raw embeddings and run MMR over that.
+- **Embeddings are not retained.** `search` returns `Document` objects with `page_content` and `metadata`, but the original embedding is not recoverable.
+- **Pickle side-car.** `load` requires `allow_dangerous_deserialization=True` because the document side-car is pickled. We may migrate to a safer format in a future major version.

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -128,21 +128,17 @@ Delete is O(1) per id. `delete(None)` is a no-op (matches the `InMemoryVectorSto
 ```python
 store.dump("./my-store")
 # ... later ...
-store = TurboQuantVectorStore.load(
-    "./my-store",
-    embedding=embeddings,
-    allow_dangerous_deserialization=True,  # required — side-car is pickle
-)
+store = TurboQuantVectorStore.load("./my-store", embedding=embeddings)
 ```
 
 Writes two files under the given folder path:
 - `index.tvim` — the `IdMapIndex` payload (see [api.md](../api.md#tvim--idmapindex)).
-- `docstore.pkl` — a pickled dictionary of document text, metadata, and id maps.
+- `docstore.json` — JSON-encoded document text, metadata, and id maps.
 
-The `allow_dangerous_deserialization` flag is required because unpickling untrusted data is unsafe. Only load files you produced yourself or trust the source of.
+Document metadata must be JSON-serializable — the same constraint `InMemoryVectorStore.dump` imposes.
 
 ## Known limitations
 
 - **Max-marginal-relevance search is not supported.** `max_marginal_relevance_search` and its variants raise `NotImplementedError` with an explanation. MMR requires the full-precision embedding of each candidate to compute pairwise diversity; turbovec discards full-precision vectors after quantization. If you need MMR, keep a parallel store with the raw embeddings and run MMR over that.
 - **Embeddings are not retained.** `search` returns `Document` objects with `page_content` and `metadata`, but the original embedding is not recoverable.
-- **Pickle side-car.** `load` requires `allow_dangerous_deserialization=True` because the document side-car is pickled. We may migrate to a safer format in a future major version.
+- **JSON-serializable metadata only.** Non-JSON-serializable values (custom objects, sets, etc.) fail at save time — same constraint as the in-tree reference store.

--- a/docs/integrations/llama_index.md
+++ b/docs/integrations/llama_index.md
@@ -178,7 +178,7 @@ vector_store.persist("./store/vectors.json")
 vector_store = TurboQuantVectorStore.from_persist_path("./store/vectors.json")
 ```
 
-`persist_path` is treated as a path *stem* — the binary index and pickle side-car are written next to each other as `{stem}.tvim` and `{stem}.pkl`. The extension on `persist_path` (e.g. `.json`, as LlamaIndex's StorageContext default uses) is replaced.
+`persist_path` is treated as a path *stem* — the binary index and JSON side-car are written next to each other as `{stem}.tvim` and `{stem}.nodes.json`. The extension on `persist_path` (e.g. `.json`, as LlamaIndex's StorageContext default uses) is replaced. Node metadata must be JSON-serializable.
 
 ### Via `StorageContext`
 
@@ -212,5 +212,5 @@ fresh = TurboQuantVectorStore.from_dict(config)                   # empty store 
 - **MMR is not supported.** Max-marginal-relevance retrieval requires the full-precision embedding of each candidate to compute pairwise diversity; turbovec discards full-precision vectors after quantization.
 - **`get(text_id)` raises** rather than returning a vector — same reason. The full-precision embedding is not recoverable.
 - **`fsspec` filesystems are not supported.** `persist`, `from_persist_path`, and `from_persist_dir` accept a local path. Pass `fs=None` (the default).
-- **Pickle side-car.** The node side-car is pickled. The pickle risk is real — only load persist paths you produced yourself or trust the source of.
+- **JSON-serializable metadata only.** Node metadata is stored as JSON in the side-car. Non-JSON-serializable values fail at persist time — same constraint as `SimpleVectorStore.persist`.
 - **`stores_text = True`.** Unlike `SimpleVectorStore`, we keep node text in the side-car so query results return populated `TextNode`s without depending on a separate docstore. If you're swapping this in for `SimpleVectorStore` and your pipeline expects text to live elsewhere, the difference is harmless — the framework treats `stores_text` as informational.

--- a/docs/integrations/llama_index.md
+++ b/docs/integrations/llama_index.md
@@ -1,6 +1,6 @@
 # LlamaIndex integration
 
-`turbovec.llama_index.TurboQuantVectorStore` is a [LlamaIndex `BasePydanticVectorStore`](https://docs.llamaindex.ai/en/stable/module_guides/storing/vector_stores/) backed by an `IdMapIndex`. Supports O(1) delete (both `delete(ref_doc_id)` and `delete_nodes(node_ids)`) and full `persist`/`from_persist_path`.
+`turbovec.llama_index.TurboQuantVectorStore` is a LlamaIndex [`BasePydanticVectorStore`](https://docs.llamaindex.ai/en/stable/module_guides/storing/vector_stores/) backed by an `IdMapIndex`. It implements the same public surface as `llama_index.core.vector_stores.simple.SimpleVectorStore` and can be used as a drop-in replacement wherever the simple in-memory store is used.
 
 ## Install
 
@@ -14,12 +14,30 @@ pip install turbovec[llama-index]
 from llama_index.core import VectorStoreIndex, StorageContext
 from turbovec.llama_index import TurboQuantVectorStore
 
-vector_store = TurboQuantVectorStore.from_params(dim=768, bit_width=4)
+vector_store = TurboQuantVectorStore()
 storage_context = StorageContext.from_defaults(vector_store=vector_store)
 
 index = VectorStoreIndex.from_documents(documents, storage_context=storage_context)
 retriever = index.as_retriever(similarity_top_k=5)
 ```
+
+The vector dimensionality is inferred from the embedding model on the first `add()` call.
+
+## Construction
+
+```python
+# No-arg: lazy. dim is inferred from the first add.
+vector_store = TurboQuantVectorStore()
+
+# from_params: same lazy behaviour, plus an explicit bit_width.
+vector_store = TurboQuantVectorStore.from_params(bit_width=4)
+
+# Pre-built index: bring your own IdMapIndex (e.g. one you loaded from disk).
+from turbovec import IdMapIndex
+vector_store = TurboQuantVectorStore(index=IdMapIndex(1536, 4))
+```
+
+`bit_width` is `2` or `4` and is fixed once the index is created.
 
 ## The two `delete` signatures
 
@@ -33,50 +51,36 @@ Removes **every node** whose `ref_doc_id` matches. Use this when you want to del
 vector_store.delete("my-source-document-123")
 ```
 
-Missing `ref_doc_id`s are silently ignored (per LlamaIndex's convention).
+Missing `ref_doc_id`s are silently ignored.
 
-### `delete_nodes(node_ids: list[str])` — remove specific chunks
+### `delete_nodes(node_ids, filters)` — remove specific chunks
 
-Removes specific nodes by `node_id`. Use this when you've identified individual chunks you want to evict (e.g. after a rerank filter).
-
-```python
-vector_store.delete_nodes(["abc-123", "def-456"])
-```
-
-Missing `node_id`s are silently ignored. `filters=` is not supported and raises `NotImplementedError`.
-
-## Persist / load
+Removes nodes matching either `node_ids`, `filters`, or both (intersected). Missing `node_id`s are silently ignored.
 
 ```python
-vector_store.persist("./my-store")
-# ... later ...
-vector_store = TurboQuantVectorStore.from_persist_path(
-    "./my-store",
-    allow_dangerous_deserialization=True,
+# By node_id
+vector_store.delete_nodes(node_ids=["abc-123", "def-456"])
+
+# By metadata filter
+from llama_index.core.vector_stores.types import (
+    MetadataFilter, MetadataFilters, FilterOperator,
 )
+filters = MetadataFilters(
+    filters=[MetadataFilter(key="tier", value="archived", operator=FilterOperator.EQ)],
+)
+vector_store.delete_nodes(filters=filters)
+
+# Both: intersect — delete only nodes in this list that ALSO match the filter
+vector_store.delete_nodes(node_ids=["abc-123"], filters=filters)
 ```
 
-Produces two files:
-- `index.tvim` — the `IdMapIndex` payload
-- `nodes.pkl` — pickled node data (text, metadata, `ref_doc_id`) plus id maps
-
-The `allow_dangerous_deserialization` flag is required because unpickling untrusted data is unsafe.
-
-`fs=` (fsspec filesystem objects) is not supported yet; pass a local path.
-
-## Upsert semantics
-
-Calling `add()` with a node whose `node_id` already exists **replaces** the existing entry. Matches LlamaIndex user expectation when re-indexing the same chunks.
+### `clear()` — drop everything
 
 ```python
-node = TextNode(text="v1", embedding=[...])
-vector_store.add([node])
-
-# Same node_id, different text/embedding → replaces.
-updated = TextNode(text="v2", id_=node.node_id, embedding=[...])
-vector_store.add([updated])
-assert len(vector_store._index) == 1
+vector_store.clear()
 ```
+
+Resets the store while preserving the configured `bit_width`. The cleared store is immediately usable for new adds; `dim` is inferred again from the next batch.
 
 ## Query
 
@@ -94,8 +98,119 @@ result = vector_store.query(VectorStoreQuery(
 
 `query_embedding` is **required**. turbovec doesn't embed query text itself; the calling component (retriever / query engine) is responsible for that.
 
+### Filtered query
+
+`VectorStoreQuery` accepts `filters`, `node_ids`, and `doc_ids`. All three intersect when more than one is supplied:
+
+```python
+from llama_index.core.vector_stores.types import (
+    MetadataFilter, MetadataFilters, FilterCondition, FilterOperator,
+    VectorStoreQuery,
+)
+
+filters = MetadataFilters(
+    filters=[
+        MetadataFilter(key="tier", value="pro", operator=FilterOperator.EQ),
+        MetadataFilter(key="year", value=2024, operator=FilterOperator.GTE),
+    ],
+    condition=FilterCondition.AND,
+)
+
+result = vector_store.query(VectorStoreQuery(
+    query_embedding=[...],
+    similarity_top_k=5,
+    filters=filters,
+    node_ids=["chunk-1", "chunk-2", "chunk-3"],   # restrict to these chunks
+    doc_ids=["src-doc-42"],                        # restrict to chunks of this source doc
+))
+```
+
+Supported operators on `MetadataFilter`: `EQ`, `NE`, `GT`, `LT`, `GTE`, `LTE`, `IN`, `NIN`, `TEXT_MATCH`, `CONTAINS`, `IS_EMPTY`. Conditions: `AND`, `OR`. Nested `MetadataFilters` work. `NOT` and the array-membership operators (`ANY`, `ALL`, `TEXT_MATCH_INSENSITIVE`) are not supported and raise `NotImplementedError`.
+
+Filter semantics match `SimpleVectorStore`'s reference implementation — notably, every operator except `IS_EMPTY` returns `False` when the filter key is missing from the document's metadata, and `TEXT_MATCH` is case-insensitive.
+
+Filters are resolved to a handle allowlist **before** scoring. Selective filters return up to `similarity_top_k` matches from the filtered set; you never get fewer just because the filter happened to exclude the top-scoring candidates.
+
+## Get nodes
+
+```python
+nodes = vector_store.get_nodes(node_ids=["chunk-1", "chunk-2"])
+nodes = vector_store.get_nodes(filters=filters)
+nodes = vector_store.get_nodes(node_ids=["chunk-1", "chunk-2"], filters=filters)  # intersect
+```
+
+Returns a `List[BaseNode]` reconstructed from the side-car. Missing `node_id`s are silently skipped.
+
+## Upsert semantics
+
+Calling `add()` with a node whose `node_id` already exists **replaces** the existing entry. Matches LlamaIndex user expectation when re-indexing the same chunks.
+
+```python
+node = TextNode(text="v1", embedding=[...])
+vector_store.add([node])
+
+# Same node_id, different text/embedding → replaces.
+updated = TextNode(text="v2", id_=node.node_id, embedding=[...])
+vector_store.add([updated])
+assert len(vector_store._index) == 1
+```
+
+## Async
+
+Every public method has an async counterpart, suitable for use in LlamaIndex's async retriever / query-engine paths:
+
+```python
+await vector_store.async_add(nodes)
+result = await vector_store.aquery(VectorStoreQuery(...))
+fetched = await vector_store.aget_nodes(node_ids=[...])
+await vector_store.adelete("ref-doc-id")
+await vector_store.adelete_nodes(node_ids=[...])
+await vector_store.aclear()
+```
+
+## Persist / load
+
+### Direct (file-stem) interface
+
+```python
+vector_store.persist("./store/vectors.json")
+# ... later ...
+vector_store = TurboQuantVectorStore.from_persist_path("./store/vectors.json")
+```
+
+`persist_path` is treated as a path *stem* — the binary index and pickle side-car are written next to each other as `{stem}.tvim` and `{stem}.pkl`. The extension on `persist_path` (e.g. `.json`, as LlamaIndex's StorageContext default uses) is replaced.
+
+### Via `StorageContext`
+
+The store works with `StorageContext.from_defaults(persist_dir=...)` the same way `SimpleVectorStore` does:
+
+```python
+# Persist
+storage_context.persist(persist_dir="./store")
+
+# Load
+vector_store = TurboQuantVectorStore.from_persist_dir(persist_dir="./store")
+storage_context = StorageContext.from_defaults(
+    vector_store=vector_store,
+    persist_dir="./store",
+)
+```
+
+`from_persist_dir(persist_dir, namespace="default", fs=None)` constructs the namespaced filename (`{persist_dir}/{namespace}__vector_store.json`) and delegates to `from_persist_path`. Multiple namespaced stores can share a persist directory.
+
+### Config-only round-trip
+
+```python
+config = vector_store.to_dict()                                   # {"bit_width": 4, "dim": 1536}
+fresh = TurboQuantVectorStore.from_dict(config)                   # empty store with the same config
+```
+
+`to_dict` / `from_dict` serialize only the store's configuration. Node data round-trips through `persist` / `from_persist_path`.
+
 ## Known limitations
 
-- **Embeddings are dropped after quantization.** Query results return `TextNode`s with text, metadata, and `ref_doc_id`, but not the original embedding.
-- **No `fsspec` support in persist**. Local paths only.
-- **Side-car is pickle.** `allow_dangerous_deserialization=True` required on load.
+- **MMR is not supported.** Max-marginal-relevance retrieval requires the full-precision embedding of each candidate to compute pairwise diversity; turbovec discards full-precision vectors after quantization.
+- **`get(text_id)` raises** rather than returning a vector — same reason. The full-precision embedding is not recoverable.
+- **`fsspec` filesystems are not supported.** `persist`, `from_persist_path`, and `from_persist_dir` accept a local path. Pass `fs=None` (the default).
+- **Pickle side-car.** The node side-car is pickled. The pickle risk is real — only load persist paths you produced yourself or trust the source of.
+- **`stores_text = True`.** Unlike `SimpleVectorStore`, we keep node text in the side-car so query results return populated `TextNode`s without depending on a separate docstore. If you're swapping this in for `SimpleVectorStore` and your pipeline expects text to live elsewhere, the difference is harmless — the framework treats `stores_text` as informational.

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -12,8 +12,8 @@ full-precision embeddings after compression — callers that rely on
 from __future__ import annotations
 
 import asyncio
+import json
 import math
-import pickle
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
@@ -555,48 +555,57 @@ class TurboQuantDocumentStore:
 
     # ---- Persistence -------------------------------------------------
 
+    # Side-car schema. Bump when the on-disk shape changes; loader
+    # checks it and refuses to deserialize unknown versions.
+    _DOCSTORE_SCHEMA_VERSION = 1
+
     def save_to_disk(self, folder_path: str | Path) -> None:
         """Persist the quantized index plus the Haystack side-car to disk.
 
         Writes into ``folder_path``:
           - ``index.tvim`` — the :class:`IdMapIndex` payload. On a lazy
             store that has never seen a write the file encodes the
-            uncommitted state via a ``dim=0`` sentinel; no special-case
-            handling needed here.
-          - ``docstore.pkl`` — the str-id ↔ Document mapping and store
-            init parameters.
+            uncommitted state via a ``dim=0`` sentinel.
+          - ``docstore.json`` — the str-id ↔ Document mapping and store
+            init parameters, JSON-encoded. Document metadata must be
+            JSON-serializable (the same constraint as
+            ``InMemoryDocumentStore.save_to_disk``).
         """
         folder = Path(folder_path)
         folder.mkdir(parents=True, exist_ok=True)
         self._index.write(str(folder / "index.tvim"))
-        with open(folder / "docstore.pkl", "wb") as f:
-            pickle.dump(
-                {
-                    "u64_to_doc": self._u64_to_doc,
-                    "next_u64": self._next_u64,
-                    "bit_width": self._bit_width,
-                    "embedding_similarity_function": self.embedding_similarity_function,
-                    "return_embedding": self.return_embedding,
-                },
-                f,
-            )
+        # Keys in `_u64_to_doc` are ints (u64 handles); JSON object keys
+        # must be strings. Serialize as a list of [handle, data] pairs
+        # so we don't lose type fidelity on the round-trip.
+        payload = {
+            "schema_version": self._DOCSTORE_SCHEMA_VERSION,
+            "u64_to_doc": [[h, d] for h, d in self._u64_to_doc.items()],
+            "next_u64": self._next_u64,
+            "bit_width": self._bit_width,
+            "embedding_similarity_function": self.embedding_similarity_function,
+            "return_embedding": self.return_embedding,
+        }
+        with open(folder / "docstore.json", "w") as f:
+            json.dump(payload, f)
 
     @classmethod
     def load_from_disk(
         cls,
         folder_path: str | Path,
-        *,
-        allow_dangerous_deserialization: bool = False,
     ) -> "TurboQuantDocumentStore":
-        if not allow_dangerous_deserialization:
-            raise ValueError(
-                "load_from_disk uses pickle, which is unsafe with untrusted input. "
-                "Pass allow_dangerous_deserialization=True to confirm you "
-                "trust the source of folder_path."
-            )
+        """Reload a store from a folder previously written by
+        :meth:`save_to_disk`. Safe to call on any path — the side-car is
+        plain JSON, never pickle, so there's no deserialization-of-code
+        risk."""
         folder = Path(folder_path)
-        with open(folder / "docstore.pkl", "rb") as f:
-            state = pickle.load(f)
+        with open(folder / "docstore.json") as f:
+            state = json.load(f)
+        version = state.get("schema_version", 0)
+        if version != cls._DOCSTORE_SCHEMA_VERSION:
+            raise ValueError(
+                f"docstore.json has schema version {version}; "
+                f"this turbovec expects version {cls._DOCSTORE_SCHEMA_VERSION}"
+            )
         store = cls(
             bit_width=state["bit_width"],
             embedding_similarity_function=state.get(
@@ -607,7 +616,8 @@ class TurboQuantDocumentStore:
         # Reload the index — it carries dim internally (None for lazy
         # uncommitted, int otherwise).
         store._index = IdMapIndex.load(str(folder / "index.tvim"))
-        store._u64_to_doc = state["u64_to_doc"]
+        # Reconstruct {int handle: doc data} from the list-of-pairs form.
+        store._u64_to_doc = {int(h): d for h, d in state["u64_to_doc"]}
         store._next_u64 = state["next_u64"]
         # Rebuild str_to_u64 from the reloaded doc table.
         store._str_to_u64 = {

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -2,26 +2,21 @@
 
 Install with: ``pip install turbovec[haystack]``.
 
-Implements the Haystack 2.x ``DocumentStore`` protocol:
-``count_documents``, ``filter_documents``, ``write_documents``,
-``delete_documents``, plus ``to_dict`` / ``from_dict`` for pipeline
-serialization.
-
-Adds ``embedding_retrieval`` with a signature matching
-``InMemoryDocumentStore`` so it can back an
-``InMemoryEmbeddingRetriever``-style pipeline.
-
-Delete is O(1) via the inner :class:`~turbovec.IdMapIndex`, so this
-store can be used in pipelines that mutate their document set over
-time — unlike the LangChain / LlamaIndex integrations that require
-rebuilding.
+Implements the Haystack 2.x ``DocumentStore`` protocol and matches the
+public surface of ``InMemoryDocumentStore`` so this store can be swapped
+in wherever the in-memory store is used. The quantized index discards
+full-precision embeddings after compression — callers that rely on
+``Document.embedding`` after retrieval will see ``None``.
 """
 
 from __future__ import annotations
 
+import asyncio
+import math
 import pickle
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
 
 import numpy as np
 
@@ -45,7 +40,7 @@ class TurboQuantDocumentStore:
     Vectors are quantized to 2–4 bits per dimension. Full-precision
     embeddings are dropped after quantization — callers requesting
     ``return_embedding=True`` on retrieval will see ``None`` on the
-    returned documents' ``embedding`` field.
+    returned documents' ``embedding`` field regardless of the flag.
 
     Example::
 
@@ -60,9 +55,36 @@ class TurboQuantDocumentStore:
         results = store.embedding_retrieval(query_embedding=[...], top_k=5)
     """
 
-    def __init__(self, dim: int, bit_width: int = 4) -> None:
+    def __init__(
+        self,
+        dim: int,
+        bit_width: int = 4,
+        *,
+        embedding_similarity_function: Literal["dot_product", "cosine"] = "cosine",
+        async_executor: Optional[ThreadPoolExecutor] = None,
+        return_embedding: bool = False,
+    ) -> None:
+        """
+        :param dim: Vector dimensionality.
+        :param bit_width: Quantization width per coordinate (2 or 4).
+        :param embedding_similarity_function: ``"cosine"`` (default) or
+            ``"dot_product"``. Used to choose the ``scale_score`` formula
+            during retrieval. Defaults to ``"cosine"`` because turbovec
+            stores unit-normalized vectors.
+        :param async_executor: Optional executor for the ``*_async``
+            methods. If omitted, a single-threaded executor is created
+            and cleaned up on instance destruction.
+        :param return_embedding: Whether retrieval methods should leave
+            the ``embedding`` field populated on returned Documents.
+            turbovec never has the full-precision embedding available, so
+            this is always ``None`` either way; the flag is accepted for
+            API parity with ``InMemoryDocumentStore``.
+        """
         self._dim = dim
         self._bit_width = bit_width
+        self.embedding_similarity_function = embedding_similarity_function
+        self.return_embedding = return_embedding
+
         self._index = IdMapIndex(dim, bit_width)
         # Haystack doc_id (str) -> u64 handle
         self._str_to_u64: Dict[str, int] = {}
@@ -73,9 +95,39 @@ class TurboQuantDocumentStore:
         # can round-trip it directly.
         self._next_u64: int = 0
 
+        # Executor lifecycle mirrors InMemoryDocumentStore: own one when
+        # the caller didn't pass one in, and shut it down in __del__.
+        self._owns_executor = async_executor is None
+        self.executor = async_executor or ThreadPoolExecutor(
+            thread_name_prefix=f"async-turbovec-docstore-executor-{id(self)}",
+            max_workers=1,
+        )
+
+    def __del__(self) -> None:
+        if (
+            hasattr(self, "_owns_executor")
+            and self._owns_executor
+            and hasattr(self, "executor")
+        ):
+            self.executor.shutdown(wait=True)
+
+    def shutdown(self) -> None:
+        """Explicitly shut down the async executor if this store owns it."""
+        if self._owns_executor:
+            self.executor.shutdown(wait=True)
+
     def _issue_handle(self) -> int:
         self._next_u64 += 1
         return self._next_u64
+
+    @property
+    def storage(self) -> Dict[str, Document]:
+        """Map of ``doc_id -> Document`` for the currently stored documents.
+
+        Documents are reconstructed on every access; the
+        ``embedding`` field is always ``None``.
+        """
+        return {data["id"]: self._reconstruct(data) for data in self._u64_to_doc.values()}
 
     # ---- DocumentStore protocol ---------------------------------------
 
@@ -85,16 +137,33 @@ class TurboQuantDocumentStore:
     def filter_documents(
         self, filters: Optional[Dict[str, Any]] = None
     ) -> List[Document]:
-        docs = [self._reconstruct(data) for data in self._u64_to_doc.values()]
-        if filters is None:
-            return docs
-        return [doc for doc in docs if document_matches_filter(filters, doc)]
+        if filters:
+            self._validate_filters(filters)
+            docs = [
+                self._reconstruct(data)
+                for data in self._u64_to_doc.values()
+                if document_matches_filter(filters=filters, document=self._reconstruct(data))
+            ]
+        else:
+            docs = [self._reconstruct(data) for data in self._u64_to_doc.values()]
+        # `return_embedding` is informational here — we never have the
+        # full-precision embedding to begin with. Kept for parity.
+        return docs
 
     def write_documents(
         self,
         documents: List[Document],
-        policy: DuplicatePolicy = DuplicatePolicy.FAIL,
+        policy: DuplicatePolicy = DuplicatePolicy.NONE,
     ) -> int:
+        # Match InMemoryDocumentStore's input-shape validation rather
+        # than letting a bad input AttributeError on `.embedding`.
+        if (
+            not isinstance(documents, Iterable)
+            or isinstance(documents, str)
+            or any(not isinstance(doc, Document) for doc in documents)
+        ):
+            raise ValueError("Please provide a list of Documents.")
+
         if policy == DuplicatePolicy.NONE:
             policy = DuplicatePolicy.FAIL
 
@@ -152,6 +221,146 @@ class TurboQuantDocumentStore:
         for doc_id in document_ids:
             self._remove_one(doc_id)
 
+    # ---- Utility methods (InMemoryDocumentStore parity) ---------------
+
+    def delete_all_documents(self) -> None:
+        """Delete every document in the store."""
+        for doc_id in list(self._str_to_u64.keys()):
+            self._remove_one(doc_id)
+
+    def update_by_filter(
+        self, filters: Dict[str, Any], meta: Dict[str, Any]
+    ) -> int:
+        """Update metadata on every document matching ``filters``.
+
+        The new ``meta`` is merged into each matching document's existing
+        metadata. Embeddings are not touched — we never had them at full
+        precision anyway. Returns the number of documents updated.
+        """
+        self._validate_filters(filters)
+        updated = 0
+        for data in self._u64_to_doc.values():
+            if document_matches_filter(filters=filters, document=self._reconstruct(data)):
+                data["meta"].update(meta)
+                updated += 1
+        return updated
+
+    def delete_by_filter(self, filters: Dict[str, Any]) -> int:
+        """Delete every document matching ``filters``. Returns the count."""
+        self._validate_filters(filters)
+        matching_ids = [
+            data["id"]
+            for data in self._u64_to_doc.values()
+            if document_matches_filter(filters=filters, document=self._reconstruct(data))
+        ]
+        for doc_id in matching_ids:
+            self._remove_one(doc_id)
+        return len(matching_ids)
+
+    def count_documents_by_filter(self, filters: Dict[str, Any]) -> int:
+        if filters:
+            self._validate_filters(filters)
+            return sum(
+                1
+                for data in self._u64_to_doc.values()
+                if document_matches_filter(filters=filters, document=self._reconstruct(data))
+            )
+        return self.count_documents()
+
+    def count_unique_metadata_by_filter(
+        self, filters: Dict[str, Any], metadata_fields: List[str]
+    ) -> Dict[str, int]:
+        if filters:
+            self._validate_filters(filters)
+            docs_meta = [
+                data["meta"]
+                for data in self._u64_to_doc.values()
+                if document_matches_filter(filters=filters, document=self._reconstruct(data))
+            ]
+        else:
+            docs_meta = [data["meta"] for data in self._u64_to_doc.values()]
+
+        result: Dict[str, int] = {}
+        for field in metadata_fields:
+            key = field.removeprefix("meta.") if field.startswith("meta.") else field
+            values = {meta.get(key) for meta in docs_meta if key in meta and meta[key] is not None}
+            result[key] = len(values)
+        return result
+
+    def get_metadata_fields_info(self) -> Dict[str, Dict[str, str]]:
+        type_map: Dict[str, str] = {}
+        for data in self._u64_to_doc.values():
+            for key, value in data["meta"].items():
+                if value is None:
+                    continue
+                if isinstance(value, bool):
+                    type_map[key] = "boolean"
+                elif isinstance(value, int):
+                    type_map[key] = "int"
+                elif isinstance(value, float):
+                    type_map[key] = "float"
+                else:
+                    type_map[key] = "keyword"
+        return {k: {"type": v} for k, v in type_map.items()}
+
+    def get_metadata_field_min_max(self, metadata_field: str) -> Dict[str, Any]:
+        key = (
+            metadata_field.removeprefix("meta.")
+            if metadata_field.startswith("meta.")
+            else metadata_field
+        )
+        values = [
+            data["meta"][key]
+            for data in self._u64_to_doc.values()
+            if key in data["meta"]
+            and data["meta"][key] is not None
+            and isinstance(data["meta"][key], (int, float, str))
+        ]
+        if not values:
+            return {"min": None, "max": None}
+        try:
+            return {"min": min(values), "max": max(values)}
+        except TypeError:
+            return {"min": None, "max": None}
+
+    def get_metadata_field_unique_values(
+        self, metadata_field: str, search_term: Optional[str] = None
+    ) -> Tuple[List[str], int]:
+        key = (
+            metadata_field.removeprefix("meta.")
+            if metadata_field.startswith("meta.")
+            else metadata_field
+        )
+        if search_term:
+            docs_data = [
+                data
+                for data in self._u64_to_doc.values()
+                if data["content"] and search_term.lower() in data["content"].lower()
+            ]
+        else:
+            docs_data = list(self._u64_to_doc.values())
+        values = sorted(
+            {
+                str(data["meta"][key])
+                for data in docs_data
+                if key in data["meta"] and data["meta"][key] is not None
+            },
+            key=str,
+        )
+        return values, len(values)
+
+    @staticmethod
+    def _validate_filters(filters: Optional[Dict[str, Any]]) -> None:
+        if (
+            filters
+            and "operator" not in filters
+            and "conditions" not in filters
+            and "field" not in filters
+        ):
+            raise ValueError(
+                "Invalid filter syntax. See https://docs.haystack.deepset.ai/docs/metadata-filtering for details."
+            )
+
     # ---- Retrieval (not in core protocol but expected) ----------------
 
     def embedding_retrieval(
@@ -160,24 +369,23 @@ class TurboQuantDocumentStore:
         filters: Optional[Dict[str, Any]] = None,
         top_k: int = 10,
         scale_score: bool = False,
-        return_embedding: bool = False,
+        return_embedding: Optional[bool] = None,
     ) -> List[Document]:
         """Return the ``top_k`` documents most similar to ``query_embedding``.
 
-        ``return_embedding`` is accepted for signature compatibility but
-        always returns ``None`` on the ``embedding`` field — full-precision
-        embeddings are discarded after quantization.
+        ``return_embedding=None`` (default) honours the store-level
+        ``return_embedding`` set in the constructor. turbovec never has
+        the full-precision embedding either way — the parameter is here
+        for API parity with ``InMemoryDocumentStore``.
 
         ``filters`` are resolved to an allowlist before scoring, so the
         kernel never wastes work on non-matching documents and the result
         count is always ``min(top_k, n_matches)`` rather than ``< top_k``
         when the filter is selective.
         """
-        if return_embedding:
-            # Signature-compatible — but we warn once, could cause regressions
-            # in callers that expect embeddings. We keep silent rather than
-            # raising so pipelines run.
-            pass
+        # `return_embedding` is accepted but we never have the full
+        # embedding to populate; left as-is for signature parity.
+        _ = return_embedding  # noqa: F841
 
         if self.count_documents() == 0:
             return []
@@ -196,6 +404,7 @@ class TurboQuantDocumentStore:
             fetch_k = min(top_k, self.count_documents())
             scores, handles = self._index.search(qvec, fetch_k)
         else:
+            self._validate_filters(filters)
             # Resolve filter → handle allowlist by walking the in-memory
             # doc table once. This is the same O(N) cost as the old
             # post-filter pass, just moved upfront so the kernel can score
@@ -216,6 +425,101 @@ class TurboQuantDocumentStore:
             out.append(self._reconstruct(data, score=float(score), scale_score=scale_score))
         return out
 
+    # ---- Async variants ----------------------------------------------
+
+    async def count_documents_async(self) -> int:
+        return self.count_documents()
+
+    async def filter_documents_async(
+        self, filters: Optional[Dict[str, Any]] = None
+    ) -> List[Document]:
+        return await asyncio.get_running_loop().run_in_executor(
+            self.executor, lambda: self.filter_documents(filters=filters)
+        )
+
+    async def write_documents_async(
+        self,
+        documents: List[Document],
+        policy: DuplicatePolicy = DuplicatePolicy.NONE,
+    ) -> int:
+        return await asyncio.get_running_loop().run_in_executor(
+            self.executor, lambda: self.write_documents(documents=documents, policy=policy)
+        )
+
+    async def delete_documents_async(self, document_ids: List[str]) -> None:
+        await asyncio.get_running_loop().run_in_executor(
+            self.executor, lambda: self.delete_documents(document_ids=document_ids)
+        )
+
+    async def delete_all_documents_async(self) -> None:
+        await asyncio.get_running_loop().run_in_executor(
+            self.executor, self.delete_all_documents
+        )
+
+    async def update_by_filter_async(
+        self, filters: Dict[str, Any], meta: Dict[str, Any]
+    ) -> int:
+        return await asyncio.get_running_loop().run_in_executor(
+            self.executor, lambda: self.update_by_filter(filters=filters, meta=meta)
+        )
+
+    async def count_documents_by_filter_async(self, filters: Dict[str, Any]) -> int:
+        return await asyncio.get_running_loop().run_in_executor(
+            self.executor, lambda: self.count_documents_by_filter(filters=filters)
+        )
+
+    async def count_unique_metadata_by_filter_async(
+        self, filters: Dict[str, Any], metadata_fields: List[str]
+    ) -> Dict[str, int]:
+        return await asyncio.get_running_loop().run_in_executor(
+            self.executor,
+            lambda: self.count_unique_metadata_by_filter(
+                filters=filters, metadata_fields=metadata_fields
+            ),
+        )
+
+    async def get_metadata_fields_info_async(self) -> Dict[str, Dict[str, str]]:
+        return await asyncio.get_running_loop().run_in_executor(
+            self.executor, self.get_metadata_fields_info
+        )
+
+    async def get_metadata_field_min_max_async(
+        self, metadata_field: str
+    ) -> Dict[str, Any]:
+        return await asyncio.get_running_loop().run_in_executor(
+            self.executor,
+            lambda: self.get_metadata_field_min_max(metadata_field=metadata_field),
+        )
+
+    async def get_metadata_field_unique_values_async(
+        self, metadata_field: str, search_term: Optional[str] = None
+    ) -> Tuple[List[str], int]:
+        return await asyncio.get_running_loop().run_in_executor(
+            self.executor,
+            lambda: self.get_metadata_field_unique_values(
+                metadata_field=metadata_field, search_term=search_term
+            ),
+        )
+
+    async def embedding_retrieval_async(
+        self,
+        query_embedding: List[float],
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: int = 10,
+        scale_score: bool = False,
+        return_embedding: Optional[bool] = None,
+    ) -> List[Document]:
+        return await asyncio.get_running_loop().run_in_executor(
+            self.executor,
+            lambda: self.embedding_retrieval(
+                query_embedding=query_embedding,
+                filters=filters,
+                top_k=top_k,
+                scale_score=scale_score,
+                return_embedding=return_embedding,
+            ),
+        )
+
     # ---- Serialization (Pipeline to_dict / from_dict) -----------------
 
     def to_dict(self) -> Dict[str, Any]:
@@ -224,6 +528,8 @@ class TurboQuantDocumentStore:
             "init_parameters": {
                 "dim": self._dim,
                 "bit_width": self._bit_width,
+                "embedding_similarity_function": self.embedding_similarity_function,
+                "return_embedding": self.return_embedding,
             },
         }
 
@@ -234,12 +540,13 @@ class TurboQuantDocumentStore:
 
     # ---- Persistence -------------------------------------------------
 
-    def save(self, folder_path: str | Path) -> None:
+    def save_to_disk(self, folder_path: str | Path) -> None:
         """Persist the quantized index plus the Haystack side-car to disk.
 
         Writes two files into ``folder_path``:
           - ``index.tvim`` — the :class:`IdMapIndex` payload.
-          - ``docstore.pkl`` — the str-id ↔ Document mapping.
+          - ``docstore.pkl`` — the str-id ↔ Document mapping and store
+            init parameters.
         """
         folder = Path(folder_path)
         folder.mkdir(parents=True, exist_ok=True)
@@ -251,12 +558,14 @@ class TurboQuantDocumentStore:
                     "next_u64": self._next_u64,
                     "dim": self._dim,
                     "bit_width": self._bit_width,
+                    "embedding_similarity_function": self.embedding_similarity_function,
+                    "return_embedding": self.return_embedding,
                 },
                 f,
             )
 
     @classmethod
-    def load(
+    def load_from_disk(
         cls,
         folder_path: str | Path,
         *,
@@ -264,14 +573,21 @@ class TurboQuantDocumentStore:
     ) -> "TurboQuantDocumentStore":
         if not allow_dangerous_deserialization:
             raise ValueError(
-                "load uses pickle, which is unsafe with untrusted input. "
+                "load_from_disk uses pickle, which is unsafe with untrusted input. "
                 "Pass allow_dangerous_deserialization=True to confirm you "
                 "trust the source of folder_path."
             )
         folder = Path(folder_path)
         with open(folder / "docstore.pkl", "rb") as f:
             state = pickle.load(f)
-        store = cls(dim=state["dim"], bit_width=state["bit_width"])
+        store = cls(
+            dim=state["dim"],
+            bit_width=state["bit_width"],
+            embedding_similarity_function=state.get(
+                "embedding_similarity_function", "cosine"
+            ),
+            return_embedding=state.get("return_embedding", False),
+        )
         store._index = IdMapIndex.load(str(folder / "index.tvim"))
         store._u64_to_doc = state["u64_to_doc"]
         store._next_u64 = state["next_u64"]
@@ -298,9 +614,14 @@ class TurboQuantDocumentStore:
         scale_score: bool = False,
     ) -> Document:
         if score is not None and scale_score:
-            # Scale raw inner-product score to [0, 1] — cheap linear squash,
-            # matches Haystack's InMemoryDocumentStore default behaviour.
-            score = 1.0 / (1.0 + np.exp(-score))
+            # Match Haystack's InMemoryDocumentStore._compute_query_embedding_similarity_scores
+            # (document_store.py:818-822): different formula per similarity
+            # function. turbovec uses unit-normalized vectors so the cosine
+            # branch is the natural default.
+            if self.embedding_similarity_function == "dot_product":
+                score = 1.0 / (1.0 + math.exp(-score / 100.0))
+            elif self.embedding_similarity_function == "cosine":
+                score = (score + 1.0) / 2.0
         return Document(
             id=data["id"],
             content=data["content"],

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -57,7 +57,7 @@ class TurboQuantDocumentStore:
 
     def __init__(
         self,
-        dim: int,
+        dim: Optional[int] = None,
         bit_width: int = 4,
         *,
         embedding_similarity_function: Literal["dot_product", "cosine"] = "cosine",
@@ -65,8 +65,13 @@ class TurboQuantDocumentStore:
         return_embedding: bool = False,
     ) -> None:
         """
-        :param dim: Vector dimensionality.
+        :param dim: Vector dimensionality. When omitted, the underlying
+            quantized index is created lazily on the first
+            ``write_documents`` call, using the embedding shape from the
+            first batch — matches the no-``dim`` ergonomics of
+            ``InMemoryDocumentStore``.
         :param bit_width: Quantization width per coordinate (2 or 4).
+            Used when the index is created lazily.
         :param embedding_similarity_function: ``"cosine"`` (default) or
             ``"dot_product"``. Used to choose the ``scale_score`` formula
             during retrieval. Defaults to ``"cosine"`` because turbovec
@@ -80,12 +85,15 @@ class TurboQuantDocumentStore:
             this is always ``None`` either way; the flag is accepted for
             API parity with ``InMemoryDocumentStore``.
         """
-        self._dim = dim
+        self._dim: Optional[int] = dim
         self._bit_width = bit_width
         self.embedding_similarity_function = embedding_similarity_function
         self.return_embedding = return_embedding
 
-        self._index = IdMapIndex(dim, bit_width)
+        # Eager creation when `dim` is supplied; otherwise lazy on first add.
+        self._index: Optional[IdMapIndex] = (
+            IdMapIndex(dim, bit_width) if dim is not None else None
+        )
         # Haystack doc_id (str) -> u64 handle
         self._str_to_u64: Dict[str, int] = {}
         # u64 handle -> stored doc data {id, content, meta}
@@ -194,7 +202,15 @@ class TurboQuantDocumentStore:
         vectors = np.asarray(
             [doc.embedding for doc in to_write], dtype=np.float32
         )
-        if vectors.ndim != 2 or vectors.shape[1] != self._dim:
+        if vectors.ndim != 2:
+            raise ValueError(
+                f"expected 2D embedding batch, got {vectors.ndim}D"
+            )
+        if self._dim is None:
+            # Lazy creation on the first write: infer dim from this batch.
+            self._dim = int(vectors.shape[1])
+            self._index = IdMapIndex(self._dim, self._bit_width)
+        elif vectors.shape[1] != self._dim:
             raise ValueError(
                 f"embedding dim {vectors.shape[1]} does not match store dim {self._dim}"
             )
@@ -204,6 +220,9 @@ class TurboQuantDocumentStore:
         handles = np.array(
             [self._issue_handle() for _ in to_write], dtype=np.uint64
         )
+        # `self._index` is non-None either because `dim` was supplied
+        # eagerly or because the lazy branch above just created it.
+        assert self._index is not None
         self._index.add_with_ids(vectors, handles)
 
         for doc, handle in zip(to_write, handles):
@@ -387,7 +406,7 @@ class TurboQuantDocumentStore:
         # embedding to populate; left as-is for signature parity.
         _ = return_embedding  # noqa: F841
 
-        if self.count_documents() == 0:
+        if self.count_documents() == 0 or self._index is None:
             return []
 
         qvec = np.asarray(query_embedding, dtype=np.float32)
@@ -543,14 +562,18 @@ class TurboQuantDocumentStore:
     def save_to_disk(self, folder_path: str | Path) -> None:
         """Persist the quantized index plus the Haystack side-car to disk.
 
-        Writes two files into ``folder_path``:
-          - ``index.tvim`` — the :class:`IdMapIndex` payload.
+        Writes into ``folder_path``:
+          - ``index.tvim`` — the :class:`IdMapIndex` payload (omitted if
+            the store has not yet seen its first write and the index
+            hasn't been created).
           - ``docstore.pkl`` — the str-id ↔ Document mapping and store
             init parameters.
         """
         folder = Path(folder_path)
         folder.mkdir(parents=True, exist_ok=True)
-        self._index.write(str(folder / "index.tvim"))
+        has_index = self._index is not None
+        if has_index:
+            self._index.write(str(folder / "index.tvim"))
         with open(folder / "docstore.pkl", "wb") as f:
             pickle.dump(
                 {
@@ -560,6 +583,7 @@ class TurboQuantDocumentStore:
                     "bit_width": self._bit_width,
                     "embedding_similarity_function": self.embedding_similarity_function,
                     "return_embedding": self.return_embedding,
+                    "has_index": has_index,
                 },
                 f,
             )
@@ -588,7 +612,13 @@ class TurboQuantDocumentStore:
             ),
             return_embedding=state.get("return_embedding", False),
         )
-        store._index = IdMapIndex.load(str(folder / "index.tvim"))
+        # Pre-Tier-4 dumps always wrote an index file and didn't track
+        # `has_index` — assume True so old archives still load.
+        has_index = state.get("has_index", True)
+        if has_index:
+            store._index = IdMapIndex.load(str(folder / "index.tvim"))
+        else:
+            store._index = None
         store._u64_to_doc = state["u64_to_doc"]
         store._next_u64 = state["next_u64"]
         # Rebuild str_to_u64 from the reloaded doc table.
@@ -604,7 +634,11 @@ class TurboQuantDocumentStore:
         if handle is None:
             return False
         del self._u64_to_doc[handle]
-        self._index.remove(handle)
+        # An entry in `_str_to_u64` implies a previous successful write,
+        # which means `_index` must exist. Guard anyway in case lazy
+        # state ever drifts.
+        if self._index is not None:
+            self._index.remove(handle)
         return True
 
     def _reconstruct(

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -66,12 +66,10 @@ class TurboQuantDocumentStore:
     ) -> None:
         """
         :param dim: Vector dimensionality. When omitted, the underlying
-            quantized index is created lazily on the first
-            ``write_documents`` call, using the embedding shape from the
-            first batch — matches the no-``dim`` ergonomics of
-            ``InMemoryDocumentStore``.
+            quantized index is created lazily by ``IdMapIndex`` itself on
+            the first ``write_documents`` call — matches the no-``dim``
+            ergonomics of ``InMemoryDocumentStore``.
         :param bit_width: Quantization width per coordinate (2 or 4).
-            Used when the index is created lazily.
         :param embedding_similarity_function: ``"cosine"`` (default) or
             ``"dot_product"``. Used to choose the ``scale_score`` formula
             during retrieval. Defaults to ``"cosine"`` because turbovec
@@ -85,15 +83,12 @@ class TurboQuantDocumentStore:
             this is always ``None`` either way; the flag is accepted for
             API parity with ``InMemoryDocumentStore``.
         """
-        self._dim: Optional[int] = dim
         self._bit_width = bit_width
         self.embedding_similarity_function = embedding_similarity_function
         self.return_embedding = return_embedding
-
-        # Eager creation when `dim` is supplied; otherwise lazy on first add.
-        self._index: Optional[IdMapIndex] = (
-            IdMapIndex(dim, bit_width) if dim is not None else None
-        )
+        # IdMapIndex itself supports lazy construction — pass dim through
+        # and let it handle eager vs lazy. No per-store lazy wrapping.
+        self._index = IdMapIndex(dim, bit_width)
         # Haystack doc_id (str) -> u64 handle
         self._str_to_u64: Dict[str, int] = {}
         # u64 handle -> stored doc data {id, content, meta}
@@ -206,13 +201,13 @@ class TurboQuantDocumentStore:
             raise ValueError(
                 f"expected 2D embedding batch, got {vectors.ndim}D"
             )
-        if self._dim is None:
-            # Lazy creation on the first write: infer dim from this batch.
-            self._dim = int(vectors.shape[1])
-            self._index = IdMapIndex(self._dim, self._bit_width)
-        elif vectors.shape[1] != self._dim:
+        # IdMapIndex.add_with_ids handles both eager (dim must match) and
+        # lazy (locks dim on first call) cases. Surface its mismatch
+        # panic as a clean ValueError for parity with previous behaviour.
+        existing_dim = self._index.dim
+        if existing_dim is not None and vectors.shape[1] != existing_dim:
             raise ValueError(
-                f"embedding dim {vectors.shape[1]} does not match store dim {self._dim}"
+                f"embedding dim {vectors.shape[1]} does not match store dim {existing_dim}"
             )
         if not vectors.flags["C_CONTIGUOUS"]:
             vectors = np.ascontiguousarray(vectors)
@@ -220,9 +215,6 @@ class TurboQuantDocumentStore:
         handles = np.array(
             [self._issue_handle() for _ in to_write], dtype=np.uint64
         )
-        # `self._index` is non-None either because `dim` was supplied
-        # eagerly or because the lazy branch above just created it.
-        assert self._index is not None
         self._index.add_with_ids(vectors, handles)
 
         for doc, handle in zip(to_write, handles):
@@ -406,15 +398,17 @@ class TurboQuantDocumentStore:
         # embedding to populate; left as-is for signature parity.
         _ = return_embedding  # noqa: F841
 
-        if self.count_documents() == 0 or self._index is None:
+        if self.count_documents() == 0:
             return []
 
         qvec = np.asarray(query_embedding, dtype=np.float32)
         if qvec.ndim == 1:
             qvec = qvec[None, :]
-        if qvec.shape[1] != self._dim:
+        # By this point n_documents > 0, so the index has a committed dim.
+        expected_dim = self._index.dim
+        if qvec.shape[1] != expected_dim:
             raise ValueError(
-                f"query_embedding dim {qvec.shape[1]} does not match store dim {self._dim}"
+                f"query_embedding dim {qvec.shape[1]} does not match store dim {expected_dim}"
             )
         if not qvec.flags["C_CONTIGUOUS"]:
             qvec = np.ascontiguousarray(qvec)
@@ -545,7 +539,9 @@ class TurboQuantDocumentStore:
         return {
             "type": f"{self.__class__.__module__}.{self.__class__.__name__}",
             "init_parameters": {
-                "dim": self._dim,
+                # `_index.dim` is None on a lazy uncommitted store and an
+                # int once an add has locked the dim — both round-trip cleanly.
+                "dim": self._index.dim,
                 "bit_width": self._bit_width,
                 "embedding_similarity_function": self.embedding_similarity_function,
                 "return_embedding": self.return_embedding,
@@ -563,27 +559,24 @@ class TurboQuantDocumentStore:
         """Persist the quantized index plus the Haystack side-car to disk.
 
         Writes into ``folder_path``:
-          - ``index.tvim`` — the :class:`IdMapIndex` payload (omitted if
-            the store has not yet seen its first write and the index
-            hasn't been created).
+          - ``index.tvim`` — the :class:`IdMapIndex` payload. On a lazy
+            store that has never seen a write the file encodes the
+            uncommitted state via a ``dim=0`` sentinel; no special-case
+            handling needed here.
           - ``docstore.pkl`` — the str-id ↔ Document mapping and store
             init parameters.
         """
         folder = Path(folder_path)
         folder.mkdir(parents=True, exist_ok=True)
-        has_index = self._index is not None
-        if has_index:
-            self._index.write(str(folder / "index.tvim"))
+        self._index.write(str(folder / "index.tvim"))
         with open(folder / "docstore.pkl", "wb") as f:
             pickle.dump(
                 {
                     "u64_to_doc": self._u64_to_doc,
                     "next_u64": self._next_u64,
-                    "dim": self._dim,
                     "bit_width": self._bit_width,
                     "embedding_similarity_function": self.embedding_similarity_function,
                     "return_embedding": self.return_embedding,
-                    "has_index": has_index,
                 },
                 f,
             )
@@ -605,20 +598,15 @@ class TurboQuantDocumentStore:
         with open(folder / "docstore.pkl", "rb") as f:
             state = pickle.load(f)
         store = cls(
-            dim=state["dim"],
             bit_width=state["bit_width"],
             embedding_similarity_function=state.get(
                 "embedding_similarity_function", "cosine"
             ),
             return_embedding=state.get("return_embedding", False),
         )
-        # Pre-Tier-4 dumps always wrote an index file and didn't track
-        # `has_index` — assume True so old archives still load.
-        has_index = state.get("has_index", True)
-        if has_index:
-            store._index = IdMapIndex.load(str(folder / "index.tvim"))
-        else:
-            store._index = None
+        # Reload the index — it carries dim internally (None for lazy
+        # uncommitted, int otherwise).
+        store._index = IdMapIndex.load(str(folder / "index.tvim"))
         store._u64_to_doc = state["u64_to_doc"]
         store._next_u64 = state["next_u64"]
         # Rebuild str_to_u64 from the reloaded doc table.
@@ -634,11 +622,7 @@ class TurboQuantDocumentStore:
         if handle is None:
             return False
         del self._u64_to_doc[handle]
-        # An entry in `_str_to_u64` implies a previous successful write,
-        # which means `_index` must exist. Guard anyway in case lazy
-        # state ever drifts.
-        if self._index is not None:
-            self._index.remove(handle)
+        self._index.remove(handle)
         return True
 
     def _reconstruct(

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -168,8 +168,10 @@ class TurboQuantDocumentStore:
         always returns ``None`` on the ``embedding`` field — full-precision
         embeddings are discarded after quantization.
 
-        ``filters`` are applied post-retrieval, so results may be fewer
-        than ``top_k`` when filtering is restrictive.
+        ``filters`` are resolved to an allowlist before scoring, so the
+        kernel never wastes work on non-matching documents and the result
+        count is always ``min(top_k, n_matches)`` rather than ``< top_k``
+        when the filter is selective.
         """
         if return_embedding:
             # Signature-compatible — but we warn once, could cause regressions
@@ -190,20 +192,28 @@ class TurboQuantDocumentStore:
         if not qvec.flags["C_CONTIGUOUS"]:
             qvec = np.ascontiguousarray(qvec)
 
-        # Over-fetch if we're going to post-filter so we still have
-        # ~top_k results after dropping non-matches.
-        fetch_k = top_k if filters is None else min(top_k * 10, self.count_documents())
-        fetch_k = min(fetch_k, self.count_documents())
-        scores, handles = self._index.search(qvec, fetch_k)
+        if filters is None:
+            fetch_k = min(top_k, self.count_documents())
+            scores, handles = self._index.search(qvec, fetch_k)
+        else:
+            # Resolve filter → handle allowlist by walking the in-memory
+            # doc table once. This is the same O(N) cost as the old
+            # post-filter pass, just moved upfront so the kernel can score
+            # only matching vectors.
+            allowed_handles = [
+                handle
+                for handle, data in self._u64_to_doc.items()
+                if document_matches_filter(filters, self._reconstruct(data))
+            ]
+            if not allowed_handles:
+                return []
+            allowlist = np.asarray(allowed_handles, dtype=np.uint64)
+            scores, handles = self._index.search(qvec, top_k, allowlist=allowlist)
 
         out: List[Document] = []
         for score, handle in zip(scores[0], handles[0]):
             data = self._u64_to_doc[int(handle)]
-            doc = self._reconstruct(data, score=float(score), scale_score=scale_score)
-            if filters is None or document_matches_filter(filters, doc):
-                out.append(doc)
-                if len(out) >= top_k:
-                    break
+            out.append(self._reconstruct(data, score=float(score), scale_score=scale_score))
         return out
 
     # ---- Serialization (Pipeline to_dict / from_dict) -----------------

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -8,7 +8,7 @@ so this store can be swapped in wherever the in-memory store is used.
 
 from __future__ import annotations
 
-import pickle
+import json
 import uuid
 from pathlib import Path
 from typing import Any, Callable, Iterable, Sequence
@@ -29,7 +29,10 @@ except ImportError as exc:
 
 
 _INDEX_FILENAME = "index.tvim"
-_STORE_FILENAME = "docstore.pkl"
+_STORE_FILENAME = "docstore.json"
+# Bump when the docstore.json shape changes; loader refuses to deserialize
+# unknown versions.
+_DOCSTORE_SCHEMA_VERSION = 1
 
 
 class TurboQuantVectorStore(VectorStore):
@@ -451,64 +454,79 @@ class TurboQuantVectorStore(VectorStore):
     # ---- Persistence --------------------------------------------------
     #
     # Method names match the InMemoryVectorStore reference (`dump`/`load`),
-    # but the on-disk layout is a directory containing the binary index
-    # file plus a pickle side-car (we can't embed the binary Rust index in
-    # a single JSON file the way the reference can with its raw-vector
+    # but the on-disk layout is a folder containing the binary index file
+    # plus a JSON side-car (we can't embed the binary Rust index in a
+    # single JSON file the way the reference does with its raw-vector
     # store).
 
     def dump(self, folder_path: str | Path) -> None:
         """Persist the quantized index plus the side-car to disk.
 
-        ``folder_path`` is a directory; turbovec writes ``index.tvim`` and
-        ``docstore.pkl`` inside it. This differs from the
-        ``InMemoryVectorStore`` reference (which writes a single JSON
-        file) because the binary index can't be losslessly embedded in
-        JSON. A lazy-uncommitted index encodes its state via the index
-        file's own dim=0 sentinel; no special-case handling needed here.
+        ``folder_path`` is a directory; turbovec writes ``index.tvim``
+        and ``docstore.json`` inside it. Document metadata must be
+        JSON-serializable (same constraint as ``InMemoryVectorStore``).
+        A lazy uncommitted index encodes its state via the index file's
+        own ``dim = 0`` sentinel; no special-case handling needed here.
         """
         folder = Path(folder_path)
         folder.mkdir(parents=True, exist_ok=True)
         self._index.write(str(folder / _INDEX_FILENAME))
-        with open(folder / _STORE_FILENAME, "wb") as f:
-            pickle.dump(
-                {
-                    "docs": self._docs,
-                    "str_to_u64": self._str_to_u64,
-                    "next_u64": self._next_u64,
-                    # Pull bit_width off the live index — same value
-                    # whether the index was eager or lazy.
-                    "bit_width": self._index.bit_width,
-                },
-                f,
-            )
+        # `_docs` stores tuples `(text, metadata)` — JSON would drop the
+        # tuple-ness on round-trip, so serialize each entry as an explicit
+        # `{"text": ..., "metadata": ...}` dict.
+        docs_payload = {
+            sid: {"text": text, "metadata": meta}
+            for sid, (text, meta) in self._docs.items()
+        }
+        payload = {
+            "schema_version": _DOCSTORE_SCHEMA_VERSION,
+            "docs": docs_payload,
+            "str_to_u64": self._str_to_u64,
+            "next_u64": self._next_u64,
+            # Pull bit_width off the live index — same value whether
+            # the index was constructed eagerly or lazily.
+            "bit_width": self._index.bit_width,
+        }
+        with open(folder / _STORE_FILENAME, "w") as f:
+            json.dump(payload, f)
 
     @classmethod
     def load(
         cls,
         folder_path: str | Path,
         embedding: Embeddings,
-        *,
-        allow_dangerous_deserialization: bool = False,
     ) -> "TurboQuantVectorStore":
-        if not allow_dangerous_deserialization:
-            raise ValueError(
-                "load uses pickle to deserialize the document store, which is "
-                "unsafe with untrusted input. Pass allow_dangerous_deserialization=True "
-                "to confirm you trust the source of folder_path."
-            )
+        """Reload a store from a folder previously written by :meth:`dump`.
+        Safe to call on any path — the side-car is plain JSON, never
+        pickle, so there's no deserialization-of-code risk."""
         folder = Path(folder_path)
-        with open(folder / _STORE_FILENAME, "rb") as f:
-            state = pickle.load(f)
+        with open(folder / _STORE_FILENAME) as f:
+            state = json.load(f)
+        version = state.get("schema_version", 0)
+        if version != _DOCSTORE_SCHEMA_VERSION:
+            raise ValueError(
+                f"docstore.json has schema version {version}; "
+                f"this turbovec expects version {_DOCSTORE_SCHEMA_VERSION}"
+            )
         # IdMapIndex.load handles the dim=0 (lazy-uncommitted) sentinel
         # internally and reconstructs the index in the right state.
         index = IdMapIndex.load(str(folder / _INDEX_FILENAME))
+        # Rehydrate `_docs` from the explicit `{"text", "metadata"}` form
+        # back into the internal tuple representation.
+        docs = {
+            sid: (entry["text"], entry["metadata"])
+            for sid, entry in state["docs"].items()
+        }
+        # JSON object keys are strings; the str_to_u64 values are already
+        # ints in the payload, just need to confirm.
+        str_to_u64 = {sid: int(h) for sid, h in state["str_to_u64"].items()}
         return cls(
             embedding=embedding,
             index=index,
             bit_width=state.get("bit_width", 4),
-            docs=state["docs"],
-            str_to_u64=state["str_to_u64"],
-            next_u64=state["next_u64"],
+            docs=docs,
+            str_to_u64=str_to_u64,
+            next_u64=int(state["next_u64"]),
         )
 
 

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -113,7 +113,7 @@ class TurboQuantVectorStore(VectorStore):
         self,
         query: str,
         k: int = 4,
-        filter: dict[str, Any] | Callable[[dict[str, Any]], bool] | None = None,
+        filter: dict[str, Any] | Callable[[Document], bool] | None = None,
         **_: Any,
     ) -> list[Document]:
         return [
@@ -125,7 +125,7 @@ class TurboQuantVectorStore(VectorStore):
         self,
         query: str,
         k: int = 4,
-        filter: dict[str, Any] | Callable[[dict[str, Any]], bool] | None = None,
+        filter: dict[str, Any] | Callable[[Document], bool] | None = None,
         **_: Any,
     ) -> list[tuple[Document, float]]:
         qvec = np.asarray(self._embedding.embed_query(query), dtype=np.float32)
@@ -135,7 +135,7 @@ class TurboQuantVectorStore(VectorStore):
         self,
         embedding: list[float],
         k: int = 4,
-        filter: dict[str, Any] | Callable[[dict[str, Any]], bool] | None = None,
+        filter: dict[str, Any] | Callable[[Document], bool] | None = None,
         **_: Any,
     ) -> list[Document]:
         qvec = np.asarray(embedding, dtype=np.float32)
@@ -145,7 +145,7 @@ class TurboQuantVectorStore(VectorStore):
         self,
         qvec: np.ndarray,
         k: int,
-        filter: dict[str, Any] | Callable[[dict[str, Any]], bool] | None = None,
+        filter: dict[str, Any] | Callable[[Document], bool] | None = None,
     ) -> list[tuple[Document, float]]:
         if qvec.ndim == 1:
             qvec = qvec[None, :]
@@ -161,8 +161,8 @@ class TurboQuantVectorStore(VectorStore):
             predicate = self._compile_filter(filter)
             allowed_handles = [
                 self._str_to_u64[sid]
-                for sid, (_text, meta) in self._docs.items()
-                if predicate(meta)
+                for sid, (text, meta) in self._docs.items()
+                if predicate(Document(page_content=text, metadata=dict(meta)))
             ]
             if not allowed_handles:
                 return []
@@ -178,16 +178,19 @@ class TurboQuantVectorStore(VectorStore):
 
     @staticmethod
     def _compile_filter(
-        filter: dict[str, Any] | Callable[[dict[str, Any]], bool],
-    ) -> Callable[[dict[str, Any]], bool]:
+        filter: dict[str, Any] | Callable[[Document], bool],
+    ) -> Callable[[Document], bool]:
+        # Match the in-tree InMemoryVectorStore convention: callable filters
+        # receive a Document, not a metadata dict
+        # (langchain_core/vectorstores/in_memory.py).
         if callable(filter):
             return filter
         if isinstance(filter, dict):
             items = list(filter.items())
-            return lambda meta: all(meta.get(k) == v for k, v in items)
+            return lambda doc: all(doc.metadata.get(k) == v for k, v in items)
         raise TypeError(
             "filter must be a dict of metadata key/value pairs or a callable "
-            f"taking a metadata dict, got {type(filter).__name__}"
+            f"taking a Document, got {type(filter).__name__}"
         )
 
     def delete(self, ids: list[str] | None = None, **_: Any) -> bool | None:

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -1,6 +1,9 @@
 """LangChain VectorStore backed by turbovec's quantized index.
 
 Install with: ``pip install turbovec[langchain]``.
+
+The public surface mirrors langchain_core's in-tree ``InMemoryVectorStore``
+so this store can be swapped in wherever the in-memory store is used.
 """
 
 from __future__ import annotations
@@ -8,7 +11,7 @@ from __future__ import annotations
 import pickle
 import uuid
 from pathlib import Path
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, Sequence
 
 import numpy as np
 
@@ -40,14 +43,27 @@ class TurboQuantVectorStore(VectorStore):
     def __init__(
         self,
         embedding: Embeddings,
-        index: IdMapIndex,
+        index: IdMapIndex | None = None,
         *,
+        bit_width: int = 4,
         docs: dict[str, tuple[str, dict[str, Any]]] | None = None,
         str_to_u64: dict[str, int] | None = None,
         next_u64: int = 0,
     ) -> None:
+        """
+        :param embedding: LangChain ``Embeddings`` instance used to encode
+            documents and queries.
+        :param index: Optional pre-built :class:`IdMapIndex`. When omitted,
+            the index is created lazily on the first ``add_*`` call using
+            the dimension of the first batch of embeddings. This matches
+            the no-arg constructor pattern of langchain_core's
+            ``InMemoryVectorStore``.
+        :param bit_width: Quantization width (2 or 4) used when the index
+            is created lazily. Ignored if ``index`` is supplied.
+        """
         self._embedding = embedding
-        self._index = index
+        self._index: IdMapIndex | None = index
+        self._bit_width = bit_width
         self._docs: dict[str, tuple[str, dict[str, Any]]] = docs if docs is not None else {}
         self._str_to_u64: dict[str, int] = str_to_u64 if str_to_u64 is not None else {}
         # Reverse map (u64 handle → str id) kept in sync so search results
@@ -64,6 +80,18 @@ class TurboQuantVectorStore(VectorStore):
     @property
     def embeddings(self) -> Embeddings:
         return self._embedding
+
+    # ---- Relevance score normalization --------------------------------
+
+    def _select_relevance_score_fn(self) -> Callable[[float], float]:
+        # turbovec returns the raw inner product of unit-normalized vectors —
+        # i.e. cosine similarity in [-1, 1]. Map to LangChain's [0, 1]
+        # relevance scale via (sim + 1) / 2. This is what enables
+        # `similarity_search_with_relevance_scores` and
+        # `as_retriever(search_type="similarity_score_threshold")` to work.
+        return lambda sim: (sim + 1.0) / 2.0
+
+    # ---- Write path ---------------------------------------------------
 
     def add_texts(
         self,
@@ -82,6 +110,67 @@ class TurboQuantVectorStore(VectorStore):
         if len(metadatas) != len(texts_list) or len(ids) != len(texts_list):
             raise ValueError("texts, metadatas, and ids must all have the same length")
 
+        vectors = np.asarray(self._embedding.embed_documents(texts_list), dtype=np.float32)
+        return self._store_texts_and_vectors(texts_list, vectors, metadatas, ids)
+
+    async def aadd_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: list[dict] | None = None,
+        ids: list[str] | None = None,
+        **_: Any,
+    ) -> list[str]:
+        texts_list = list(texts)
+        if not texts_list:
+            return []
+        if metadatas is None:
+            metadatas = [{} for _ in texts_list]
+        if ids is None:
+            ids = [str(uuid.uuid4()) for _ in texts_list]
+        if len(metadatas) != len(texts_list) or len(ids) != len(texts_list):
+            raise ValueError("texts, metadatas, and ids must all have the same length")
+
+        vectors = np.asarray(
+            await self._embedding.aembed_documents(texts_list), dtype=np.float32
+        )
+        return self._store_texts_and_vectors(texts_list, vectors, metadatas, ids)
+
+    def add_documents(
+        self,
+        documents: list[Document],
+        ids: list[str] | None = None,
+        **kwargs: Any,
+    ) -> list[str]:
+        # Override the base class default which drops the entire `ids` array
+        # if any Document has a None id. The reference InMemoryVectorStore
+        # falls back per-document so partial ids are honoured.
+        texts = [doc.page_content for doc in documents]
+        metadatas = [doc.metadata for doc in documents]
+        if ids is None:
+            ids = [doc.id or str(uuid.uuid4()) for doc in documents]
+        return self.add_texts(texts=texts, metadatas=metadatas, ids=ids, **kwargs)
+
+    async def aadd_documents(
+        self,
+        documents: list[Document],
+        ids: list[str] | None = None,
+        **kwargs: Any,
+    ) -> list[str]:
+        texts = [doc.page_content for doc in documents]
+        metadatas = [doc.metadata for doc in documents]
+        if ids is None:
+            ids = [doc.id or str(uuid.uuid4()) for doc in documents]
+        return await self.aadd_texts(
+            texts=texts, metadatas=metadatas, ids=ids, **kwargs
+        )
+
+    def _store_texts_and_vectors(
+        self,
+        texts_list: list[str],
+        vectors: np.ndarray,
+        metadatas: list[dict],
+        ids: list[str],
+    ) -> list[str]:
         # Upsert: any id that already exists is removed so the re-added
         # vector wins. Matches LangChain user expectation that `add_texts`
         # with an existing id updates in place.
@@ -89,8 +178,15 @@ class TurboQuantVectorStore(VectorStore):
         if duplicates:
             self.delete(duplicates)
 
-        vectors = np.asarray(self._embedding.embed_documents(texts_list), dtype=np.float32)
-        if vectors.ndim != 2 or vectors.shape[1] != self._index.dim:
+        if vectors.ndim != 2:
+            raise ValueError(f"expected 2D embedding batch, got {vectors.ndim}D")
+
+        if self._index is None:
+            # Lazy creation on the first add — pick up dim from this batch
+            # so callers can construct the store as `TurboQuantVectorStore(embedding)`
+            # without specifying dim up front.
+            self._index = IdMapIndex(int(vectors.shape[1]), self._bit_width)
+        elif vectors.shape[1] != self._index.dim:
             raise ValueError(
                 f"embedding dimension {vectors.shape[1]} does not match index dim {self._index.dim}"
             )
@@ -109,6 +205,8 @@ class TurboQuantVectorStore(VectorStore):
             self._docs[id_] = (text, dict(meta))
         return ids
 
+    # ---- Read path (similarity search) --------------------------------
+
     def similarity_search(
         self,
         query: str,
@@ -121,6 +219,20 @@ class TurboQuantVectorStore(VectorStore):
             for doc, _score in self.similarity_search_with_score(query, k=k, filter=filter)
         ]
 
+    async def asimilarity_search(
+        self,
+        query: str,
+        k: int = 4,
+        filter: dict[str, Any] | Callable[[Document], bool] | None = None,
+        **_: Any,
+    ) -> list[Document]:
+        return [
+            doc
+            for doc, _score in await self.asimilarity_search_with_score(
+                query, k=k, filter=filter
+            )
+        ]
+
     def similarity_search_with_score(
         self,
         query: str,
@@ -129,6 +241,18 @@ class TurboQuantVectorStore(VectorStore):
         **_: Any,
     ) -> list[tuple[Document, float]]:
         qvec = np.asarray(self._embedding.embed_query(query), dtype=np.float32)
+        return self._search_vector(qvec, k, filter=filter)
+
+    async def asimilarity_search_with_score(
+        self,
+        query: str,
+        k: int = 4,
+        filter: dict[str, Any] | Callable[[Document], bool] | None = None,
+        **_: Any,
+    ) -> list[tuple[Document, float]]:
+        qvec = np.asarray(
+            await self._embedding.aembed_query(query), dtype=np.float32
+        )
         return self._search_vector(qvec, k, filter=filter)
 
     def similarity_search_by_vector(
@@ -141,6 +265,16 @@ class TurboQuantVectorStore(VectorStore):
         qvec = np.asarray(embedding, dtype=np.float32)
         return [doc for doc, _score in self._search_vector(qvec, k, filter=filter)]
 
+    async def asimilarity_search_by_vector(
+        self,
+        embedding: list[float],
+        k: int = 4,
+        filter: dict[str, Any] | Callable[[Document], bool] | None = None,
+        **_: Any,
+    ) -> list[Document]:
+        # The search itself is sync (no embedding step). Delegate.
+        return self.similarity_search_by_vector(embedding, k=k, filter=filter)
+
     def _search_vector(
         self,
         qvec: np.ndarray,
@@ -151,7 +285,8 @@ class TurboQuantVectorStore(VectorStore):
             qvec = qvec[None, :]
         if not qvec.flags["C_CONTIGUOUS"]:
             qvec = np.ascontiguousarray(qvec)
-        if len(self._index) == 0:
+        # Lazy: if no docs have been added yet the index doesn't exist.
+        if self._index is None or len(self._index) == 0:
             return []
 
         if filter is None:
@@ -193,21 +328,90 @@ class TurboQuantVectorStore(VectorStore):
             f"taking a Document, got {type(filter).__name__}"
         )
 
-    def delete(self, ids: list[str] | None = None, **_: Any) -> bool | None:
-        """Remove documents by id. Returns ``True`` if every given id was
-        present and removed; ``False`` if any was missing."""
-        if ids is None:
-            raise ValueError("delete() requires an explicit list of ids")
-        all_ok = True
+    # ---- Max marginal relevance ---------------------------------------
+    #
+    # MMR requires the full-precision vector of every candidate to compute
+    # pairwise diversity scores. turbovec discards full vectors after
+    # quantization (that's the point), so we can't faithfully implement
+    # MMR. Raise loudly with a useful message rather than silently fall
+    # back to the base class's bare NotImplementedError.
+
+    _MMR_MSG = (
+        "TurboQuantVectorStore does not support max-marginal-relevance "
+        "search because the underlying quantized index discards "
+        "full-precision vectors after compression. MMR requires the "
+        "original embedding for every candidate to compute pairwise "
+        "diversity. Use `similarity_search` / `similarity_search_with_score` "
+        "instead, or maintain a parallel store with full-precision "
+        "embeddings if you need MMR specifically."
+    )
+
+    def max_marginal_relevance_search(
+        self,
+        query: str,
+        k: int = 4,
+        fetch_k: int = 20,
+        lambda_mult: float = 0.5,
+        **kwargs: Any,
+    ) -> list[Document]:
+        raise NotImplementedError(self._MMR_MSG)
+
+    def max_marginal_relevance_search_by_vector(
+        self,
+        embedding: list[float],
+        k: int = 4,
+        fetch_k: int = 20,
+        lambda_mult: float = 0.5,
+        *,
+        filter: Callable[[Document], bool] | None = None,
+        **kwargs: Any,
+    ) -> list[Document]:
+        raise NotImplementedError(self._MMR_MSG)
+
+    async def amax_marginal_relevance_search(
+        self,
+        query: str,
+        k: int = 4,
+        fetch_k: int = 20,
+        lambda_mult: float = 0.5,
+        **kwargs: Any,
+    ) -> list[Document]:
+        raise NotImplementedError(self._MMR_MSG)
+
+    # ---- Get / delete -------------------------------------------------
+
+    def get_by_ids(self, ids: Sequence[str], /) -> list[Document]:
+        """Return Documents for the given ids. Missing ids are silently skipped
+        (matches the InMemoryVectorStore reference)."""
+        out: list[Document] = []
+        for sid in ids:
+            if sid in self._docs:
+                text, meta = self._docs[sid]
+                out.append(Document(id=sid, page_content=text, metadata=dict(meta)))
+        return out
+
+    async def aget_by_ids(self, ids: Sequence[str], /) -> list[Document]:
+        return self.get_by_ids(ids)
+
+    def delete(self, ids: list[str] | None = None, **_: Any) -> None:
+        """Remove documents by id. Missing ids are silently skipped — matches
+        the InMemoryVectorStore reference (which also accepts ``ids=None``
+        as a no-op)."""
+        if not ids:
+            return
         for sid in ids:
             handle = self._str_to_u64.pop(sid, None)
             if handle is None:
-                all_ok = False
                 continue
             self._u64_to_str.pop(handle, None)
             self._docs.pop(sid, None)
-            self._index.remove(handle)
-        return all_ok
+            if self._index is not None:
+                self._index.remove(handle)
+
+    async def adelete(self, ids: list[str] | None = None, **_: Any) -> None:
+        self.delete(ids)
+
+    # ---- Construction helpers -----------------------------------------
 
     @classmethod
     def from_texts(
@@ -216,37 +420,70 @@ class TurboQuantVectorStore(VectorStore):
         embedding: Embeddings,
         metadatas: list[dict] | None = None,
         *,
-        dim: int | None = None,
         bit_width: int = 4,
         ids: list[str] | None = None,
         **_: Any,
     ) -> "TurboQuantVectorStore":
-        if dim is None:
-            probe_text = texts[0] if texts else "probe"
-            probe = np.asarray(embedding.embed_documents([probe_text]), dtype=np.float32)
-            dim = int(probe.shape[1])
-        index = IdMapIndex(dim, bit_width)
-        store = cls(embedding=embedding, index=index)
+        # The underlying index is created lazily on the first `add_texts`
+        # call, picking up `dim` from the first batch of embeddings — same
+        # no-`dim` ergonomics as InMemoryVectorStore.
+        store = cls(embedding=embedding, bit_width=bit_width)
         if texts:
             store.add_texts(texts, metadatas=metadatas, ids=ids)
         return store
 
-    def save_local(self, folder_path: str | Path) -> None:
+    @classmethod
+    async def afrom_texts(
+        cls,
+        texts: list[str],
+        embedding: Embeddings,
+        metadatas: list[dict] | None = None,
+        *,
+        bit_width: int = 4,
+        ids: list[str] | None = None,
+        **_: Any,
+    ) -> "TurboQuantVectorStore":
+        store = cls(embedding=embedding, bit_width=bit_width)
+        if texts:
+            await store.aadd_texts(texts, metadatas=metadatas, ids=ids)
+        return store
+
+    # ---- Persistence --------------------------------------------------
+    #
+    # Method names match the InMemoryVectorStore reference (`dump`/`load`),
+    # but the on-disk layout is a directory containing the binary index
+    # file plus a pickle side-car (we can't embed the binary Rust index in
+    # a single JSON file the way the reference can with its raw-vector
+    # store).
+
+    def dump(self, folder_path: str | Path) -> None:
+        """Persist the quantized index plus the side-car to disk.
+
+        ``folder_path`` is a directory; turbovec writes ``index.tvim`` and
+        ``docstore.pkl`` inside it. This differs from the
+        ``InMemoryVectorStore`` reference (which writes a single JSON
+        file) because the binary index can't be losslessly embedded in
+        JSON.
+        """
         folder = Path(folder_path)
         folder.mkdir(parents=True, exist_ok=True)
-        self._index.write(str(folder / _INDEX_FILENAME))
+        has_index = self._index is not None
+        if has_index:
+            self._index.write(str(folder / _INDEX_FILENAME))
         with open(folder / _STORE_FILENAME, "wb") as f:
             pickle.dump(
                 {
                     "docs": self._docs,
                     "str_to_u64": self._str_to_u64,
                     "next_u64": self._next_u64,
+                    "bit_width": self._bit_width,
+                    "has_index": has_index,
                 },
                 f,
             )
 
     @classmethod
-    def load_local(
+    def load(
         cls,
         folder_path: str | Path,
         embedding: Embeddings,
@@ -255,17 +492,21 @@ class TurboQuantVectorStore(VectorStore):
     ) -> "TurboQuantVectorStore":
         if not allow_dangerous_deserialization:
             raise ValueError(
-                "load_local uses pickle to deserialize the document store, which is "
+                "load uses pickle to deserialize the document store, which is "
                 "unsafe with untrusted input. Pass allow_dangerous_deserialization=True "
                 "to confirm you trust the source of folder_path."
             )
         folder = Path(folder_path)
-        index = IdMapIndex.load(str(folder / _INDEX_FILENAME))
         with open(folder / _STORE_FILENAME, "rb") as f:
             state = pickle.load(f)
+        # Pre-Tier-4 dumps always wrote an index file and didn't track
+        # the `has_index` flag — assume True so old archives still load.
+        has_index = state.get("has_index", True)
+        index = IdMapIndex.load(str(folder / _INDEX_FILENAME)) if has_index else None
         return cls(
             embedding=embedding,
             index=index,
+            bit_width=state.get("bit_width", 4),
             docs=state["docs"],
             str_to_u64=state["str_to_u64"],
             next_u64=state["next_u64"],

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import pickle
 import uuid
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 import numpy as np
 
@@ -109,36 +109,86 @@ class TurboQuantVectorStore(VectorStore):
             self._docs[id_] = (text, dict(meta))
         return ids
 
-    def similarity_search(self, query: str, k: int = 4, **_: Any) -> list[Document]:
-        return [doc for doc, _score in self.similarity_search_with_score(query, k=k)]
+    def similarity_search(
+        self,
+        query: str,
+        k: int = 4,
+        filter: dict[str, Any] | Callable[[dict[str, Any]], bool] | None = None,
+        **_: Any,
+    ) -> list[Document]:
+        return [
+            doc
+            for doc, _score in self.similarity_search_with_score(query, k=k, filter=filter)
+        ]
 
     def similarity_search_with_score(
-        self, query: str, k: int = 4, **_: Any
+        self,
+        query: str,
+        k: int = 4,
+        filter: dict[str, Any] | Callable[[dict[str, Any]], bool] | None = None,
+        **_: Any,
     ) -> list[tuple[Document, float]]:
         qvec = np.asarray(self._embedding.embed_query(query), dtype=np.float32)
-        return self._search_vector(qvec, k)
+        return self._search_vector(qvec, k, filter=filter)
 
     def similarity_search_by_vector(
-        self, embedding: list[float], k: int = 4, **_: Any
+        self,
+        embedding: list[float],
+        k: int = 4,
+        filter: dict[str, Any] | Callable[[dict[str, Any]], bool] | None = None,
+        **_: Any,
     ) -> list[Document]:
         qvec = np.asarray(embedding, dtype=np.float32)
-        return [doc for doc, _score in self._search_vector(qvec, k)]
+        return [doc for doc, _score in self._search_vector(qvec, k, filter=filter)]
 
-    def _search_vector(self, qvec: np.ndarray, k: int) -> list[tuple[Document, float]]:
+    def _search_vector(
+        self,
+        qvec: np.ndarray,
+        k: int,
+        filter: dict[str, Any] | Callable[[dict[str, Any]], bool] | None = None,
+    ) -> list[tuple[Document, float]]:
         if qvec.ndim == 1:
             qvec = qvec[None, :]
         if not qvec.flags["C_CONTIGUOUS"]:
             qvec = np.ascontiguousarray(qvec)
-        k = min(k, len(self._index))
-        if k == 0:
+        if len(self._index) == 0:
             return []
-        scores, handles = self._index.search(qvec, k)
+
+        if filter is None:
+            search_k = min(k, len(self._index))
+            scores, handles = self._index.search(qvec, search_k)
+        else:
+            predicate = self._compile_filter(filter)
+            allowed_handles = [
+                self._str_to_u64[sid]
+                for sid, (_text, meta) in self._docs.items()
+                if predicate(meta)
+            ]
+            if not allowed_handles:
+                return []
+            allowlist = np.asarray(allowed_handles, dtype=np.uint64)
+            scores, handles = self._index.search(qvec, k, allowlist=allowlist)
+
         results: list[tuple[Document, float]] = []
         for score, handle in zip(scores[0], handles[0]):
             sid = self._u64_to_str[int(handle)]
             text, meta = self._docs[sid]
             results.append((Document(page_content=text, metadata=dict(meta)), float(score)))
         return results
+
+    @staticmethod
+    def _compile_filter(
+        filter: dict[str, Any] | Callable[[dict[str, Any]], bool],
+    ) -> Callable[[dict[str, Any]], bool]:
+        if callable(filter):
+            return filter
+        if isinstance(filter, dict):
+            items = list(filter.items())
+            return lambda meta: all(meta.get(k) == v for k, v in items)
+        raise TypeError(
+            "filter must be a dict of metadata key/value pairs or a callable "
+            f"taking a metadata dict, got {type(filter).__name__}"
+        )
 
     def delete(self, ids: list[str] | None = None, **_: Any) -> bool | None:
         """Remove documents by id. Returns ``True`` if every given id was

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -54,16 +54,17 @@ class TurboQuantVectorStore(VectorStore):
         :param embedding: LangChain ``Embeddings`` instance used to encode
             documents and queries.
         :param index: Optional pre-built :class:`IdMapIndex`. When omitted,
-            the index is created lazily on the first ``add_*`` call using
-            the dimension of the first batch of embeddings. This matches
-            the no-arg constructor pattern of langchain_core's
-            ``InMemoryVectorStore``.
+            a lazy ``IdMapIndex`` is created — it commits to a dim on the
+            first add and lets us match the no-arg constructor pattern of
+            langchain_core's ``InMemoryVectorStore``.
         :param bit_width: Quantization width (2 or 4) used when the index
-            is created lazily. Ignored if ``index`` is supplied.
+            is created from scratch. Ignored if ``index`` is supplied.
         """
         self._embedding = embedding
-        self._index: IdMapIndex | None = index
-        self._bit_width = bit_width
+        # IdMapIndex itself supports lazy construction now — no per-store
+        # lazy wrapping needed. When `index` is None we create a lazy
+        # IdMapIndex(dim=None, bit_width) and let it handle the rest.
+        self._index = index if index is not None else IdMapIndex(bit_width=bit_width)
         self._docs: dict[str, tuple[str, dict[str, Any]]] = docs if docs is not None else {}
         self._str_to_u64: dict[str, int] = str_to_u64 if str_to_u64 is not None else {}
         # Reverse map (u64 handle → str id) kept in sync so search results
@@ -85,11 +86,10 @@ class TurboQuantVectorStore(VectorStore):
 
     def _select_relevance_score_fn(self) -> Callable[[float], float]:
         # turbovec returns the raw inner product of unit-normalized vectors —
-        # i.e. cosine similarity in [-1, 1]. Map to LangChain's [0, 1]
-        # relevance scale via (sim + 1) / 2. This is what enables
-        # `similarity_search_with_relevance_scores` and
-        # `as_retriever(search_type="similarity_score_threshold")` to work.
-        return lambda sim: (sim + 1.0) / 2.0
+        # ideally cosine similarity in [-1, 1]. Quantization noise can
+        # push that very slightly outside the bounds, so clamp after
+        # mapping to LangChain's [0, 1] relevance scale via (sim + 1) / 2.
+        return lambda sim: max(0.0, min(1.0, (sim + 1.0) / 2.0))
 
     # ---- Write path ---------------------------------------------------
 
@@ -181,14 +181,13 @@ class TurboQuantVectorStore(VectorStore):
         if vectors.ndim != 2:
             raise ValueError(f"expected 2D embedding batch, got {vectors.ndim}D")
 
-        if self._index is None:
-            # Lazy creation on the first add — pick up dim from this batch
-            # so callers can construct the store as `TurboQuantVectorStore(embedding)`
-            # without specifying dim up front.
-            self._index = IdMapIndex(int(vectors.shape[1]), self._bit_width)
-        elif vectors.shape[1] != self._index.dim:
+        # IdMapIndex.add_with_ids handles both eager (dim must match) and
+        # lazy (locks dim on first call) cases. Pre-check the eager case
+        # so we surface a clean ValueError rather than a Rust panic.
+        existing_dim = self._index.dim
+        if existing_dim is not None and vectors.shape[1] != existing_dim:
             raise ValueError(
-                f"embedding dimension {vectors.shape[1]} does not match index dim {self._index.dim}"
+                f"embedding dimension {vectors.shape[1]} does not match index dim {existing_dim}"
             )
         if not vectors.flags["C_CONTIGUOUS"]:
             vectors = np.ascontiguousarray(vectors)
@@ -285,8 +284,10 @@ class TurboQuantVectorStore(VectorStore):
             qvec = qvec[None, :]
         if not qvec.flags["C_CONTIGUOUS"]:
             qvec = np.ascontiguousarray(qvec)
-        # Lazy: if no docs have been added yet the index doesn't exist.
-        if self._index is None or len(self._index) == 0:
+        # IdMapIndex handles the lazy-uncommitted case internally (returns
+        # empty search results). A len-zero check covers both that and
+        # the eager-but-empty case.
+        if len(self._index) == 0:
             return []
 
         if filter is None:
@@ -405,8 +406,7 @@ class TurboQuantVectorStore(VectorStore):
                 continue
             self._u64_to_str.pop(handle, None)
             self._docs.pop(sid, None)
-            if self._index is not None:
-                self._index.remove(handle)
+            self._index.remove(handle)
 
     async def adelete(self, ids: list[str] | None = None, **_: Any) -> None:
         self.delete(ids)
@@ -463,21 +463,21 @@ class TurboQuantVectorStore(VectorStore):
         ``docstore.pkl`` inside it. This differs from the
         ``InMemoryVectorStore`` reference (which writes a single JSON
         file) because the binary index can't be losslessly embedded in
-        JSON.
+        JSON. A lazy-uncommitted index encodes its state via the index
+        file's own dim=0 sentinel; no special-case handling needed here.
         """
         folder = Path(folder_path)
         folder.mkdir(parents=True, exist_ok=True)
-        has_index = self._index is not None
-        if has_index:
-            self._index.write(str(folder / _INDEX_FILENAME))
+        self._index.write(str(folder / _INDEX_FILENAME))
         with open(folder / _STORE_FILENAME, "wb") as f:
             pickle.dump(
                 {
                     "docs": self._docs,
                     "str_to_u64": self._str_to_u64,
                     "next_u64": self._next_u64,
-                    "bit_width": self._bit_width,
-                    "has_index": has_index,
+                    # Pull bit_width off the live index — same value
+                    # whether the index was eager or lazy.
+                    "bit_width": self._index.bit_width,
                 },
                 f,
             )
@@ -499,10 +499,9 @@ class TurboQuantVectorStore(VectorStore):
         folder = Path(folder_path)
         with open(folder / _STORE_FILENAME, "rb") as f:
             state = pickle.load(f)
-        # Pre-Tier-4 dumps always wrote an index file and didn't track
-        # the `has_index` flag — assume True so old archives still load.
-        has_index = state.get("has_index", True)
-        index = IdMapIndex.load(str(folder / _INDEX_FILENAME)) if has_index else None
+        # IdMapIndex.load handles the dim=0 (lazy-uncommitted) sentinel
+        # internally and reconstructs the index in the right state.
+        index = IdMapIndex.load(str(folder / _INDEX_FILENAME))
         return cls(
             embedding=embedding,
             index=index,

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -155,21 +155,32 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
     def _resolve_allowed_handles(
         self,
         filters: MetadataFilters | None,
+        node_ids: list[str] | None,
         doc_ids: list[str] | None,
     ) -> list[int]:
-        """Resolve ``query.filters`` and ``query.doc_ids`` to the list of
-        internal u64 handles that satisfy the filter. Empty list means no
-        node matches."""
+        """Resolve ``query.filters``, ``query.node_ids`` and ``query.doc_ids``
+        to the list of internal u64 handles that satisfy the filter. Empty
+        list means no node matches.
+
+        Semantics (matching the SimpleVectorStore reference where applicable):
+          - ``node_ids``: filter by node_id (set membership).
+          - ``doc_ids``: filter by ``ref_doc_id`` only (source document id).
+          - ``filters``: apply metadata filters.
+        All three intersect when more than one is supplied.
+        """
+        candidates = self._nodes.items()
+
+        if node_ids:
+            node_id_set = set(node_ids)
+            candidates = [(nid, data) for nid, data in candidates if nid in node_id_set]
+
         if doc_ids:
             doc_id_set = set(doc_ids)
             candidates = [
                 (nid, data)
-                for nid, data in self._nodes.items()
-                if nid in doc_id_set
-                or data.get("ref_doc_id") in doc_id_set
+                for nid, data in candidates
+                if data.get("ref_doc_id") in doc_id_set
             ]
-        else:
-            candidates = list(self._nodes.items())
 
         if filters is None:
             return [self._node_id_to_u64[nid] for nid, _ in candidates]
@@ -202,34 +213,44 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
 
     @staticmethod
     def _single_filter_match(metadata: dict[str, Any], f: MetadataFilter) -> bool:
+        # Semantics mirror SimpleVectorStore's _build_metadata_filter_fn
+        # (llama_index/core/vector_stores/simple.py) so that filtered
+        # results agree with the in-tree reference store.
         op = f.operator
-        key = f.key
         target = f.value
-        present = key in metadata
-        value = metadata.get(key)
+        value = metadata.get(f.key)
+
+        # IS_EMPTY is the only operator that treats a missing key as a hit.
+        if op == FilterOperator.IS_EMPTY:
+            return value is None or value == "" or value == []
+
+        # Every other operator returns False when the key is absent — this
+        # matches the reference implementation (notably NE returns False on
+        # missing, not True).
+        if value is None:
+            return False
 
         if op == FilterOperator.EQ:
-            return present and value == target
+            return value == target
         if op == FilterOperator.NE:
-            return (not present) or value != target
+            return value != target
         if op == FilterOperator.GT:
-            return present and value > target
+            return value > target
         if op == FilterOperator.LT:
-            return present and value < target
+            return value < target
         if op == FilterOperator.GTE:
-            return present and value >= target
+            return value >= target
         if op == FilterOperator.LTE:
-            return present and value <= target
+            return value <= target
         if op == FilterOperator.IN:
-            return present and value in target
+            return value in target
         if op == FilterOperator.NIN:
-            return (not present) or value not in target
+            return value not in target
         if op == FilterOperator.TEXT_MATCH:
-            return present and str(target) in str(value)
+            # Case-insensitive, like the reference impl.
+            return str(target).lower() in str(value).lower()
         if op == FilterOperator.CONTAINS:
-            return present and target in value
-        if op == FilterOperator.IS_EMPTY:
-            return (not present) or value in (None, "", [], {}, ())
+            return target in value
         raise NotImplementedError(
             f"filter operator {op!r} not supported by TurboQuantVectorStore"
         )
@@ -249,13 +270,17 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         if len(self._index) == 0:
             return VectorStoreQueryResult(nodes=[], similarities=[], ids=[])
 
-        has_filters = query.filters is not None or bool(query.doc_ids)
+        has_filters = (
+            query.filters is not None
+            or bool(query.node_ids)
+            or bool(query.doc_ids)
+        )
         if not has_filters:
             k = min(query.similarity_top_k, len(self._index))
             scores, handles = self._index.search(qvec, k)
         else:
             allowed_handles = self._resolve_allowed_handles(
-                query.filters, query.doc_ids
+                query.filters, query.node_ids, query.doc_ids
             )
             if not allowed_handles:
                 return VectorStoreQueryResult(nodes=[], similarities=[], ids=[])

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -5,8 +5,8 @@ Install with: ``pip install turbovec[llama-index]``.
 
 from __future__ import annotations
 
+import json
 import os
-import pickle
 from pathlib import Path
 from typing import Any, List, Optional, Sequence
 
@@ -41,25 +41,29 @@ except ImportError as exc:
 
 # Persistence layout: a single user-facing ``persist_path`` (the file the
 # framework asks us to write) is split into two files by extension —
-# ``{base}.tvim`` for the binary IdMapIndex and ``{base}.pkl`` for the
-# node side-car. Both live next to each other so the layout fits the
+# ``{base}.tvim`` for the binary IdMapIndex and ``{base}.nodes.json`` for
+# the node side-car. Both live next to each other so the layout fits the
 # directory-of-namespaced-files pattern used by StorageContext.
 _INDEX_EXT = ".tvim"
-_STORE_EXT = ".pkl"
+_STORE_EXT = ".nodes.json"
 # Filename template used by SimpleVectorStore for namespace lookup —
 # mirrored here so `from_persist_dir` works the same way.
 _NAMESPACE_SEP = "__"
 _DEFAULT_PERSIST_FNAME = "vector_store.json"
 _DEFAULT_VECTOR_STORE = "default"
+# Bump when the nodes.json shape changes; loader refuses to deserialize
+# unknown versions.
+_NODES_SCHEMA_VERSION = 1
 
 
 def _split_persist_base(persist_path: str | Path) -> Path:
     """Strip the framework-provided extension off `persist_path` so the
-    binary index and pickle side-car can sit next to each other under a
-    shared base. We then append our own extensions in dump / load."""
+    binary index and JSON side-car can sit next to each other under a
+    shared base. We then append our own extensions in persist / load."""
     p = Path(persist_path)
-    # Use the path without its suffix so both .tvim and .pkl share a base.
-    # If the input has no suffix (e.g. a bare folder-like name), use it as-is.
+    # Use the path without its suffix so both .tvim and .nodes.json share
+    # a base. If the input has no suffix (e.g. a bare folder-like name),
+    # use it as-is.
     return p.with_suffix("") if p.suffix else p
 
 
@@ -482,16 +486,16 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
     def persist(self, persist_path: str, fs: Any = None) -> None:
         """Persist the store. ``persist_path`` is treated as a path *stem*:
         the binary index goes to ``{stem}.tvim`` and the node side-car to
-        ``{stem}.pkl``. Any extension on ``persist_path`` (e.g. ``.json``
-        from a StorageContext default) is replaced.
+        ``{stem}.nodes.json``. Any extension on ``persist_path`` (e.g.
+        ``.json`` from a StorageContext default) is replaced.
 
         This matches the layout assumed by ``StorageContext.persist`` —
         which calls us with ``persist_path = {persist_dir}/{namespace}__vector_store.json`` —
         and lets multiple namespaced stores coexist in the same directory.
 
-        ``fs`` (fsspec) is not yet supported; pass a local path.
-
-        Note: the pickle side-car is unsafe to load from untrusted sources.
+        Node metadata must be JSON-serializable (same constraint as
+        ``SimpleVectorStore``). ``fs`` (fsspec) is not yet supported;
+        pass a local path.
         """
         if fs is not None:
             raise NotImplementedError(
@@ -500,15 +504,17 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         base = _split_persist_base(persist_path)
         base.parent.mkdir(parents=True, exist_ok=True)
         self._index.write(str(base.with_suffix(_INDEX_EXT)))
-        with open(base.with_suffix(_STORE_EXT), "wb") as f:
-            pickle.dump(
-                {
-                    "nodes": self._nodes,
-                    "node_id_to_u64": self._node_id_to_u64,
-                    "next_u64": self._next_u64,
-                },
-                f,
-            )
+        payload = {
+            "schema_version": _NODES_SCHEMA_VERSION,
+            "nodes": self._nodes,
+            # JSON object keys must be strings; round-trip int keys via
+            # an explicit list of [node_id, handle] pairs to preserve
+            # type fidelity.
+            "node_id_to_u64": list(self._node_id_to_u64.items()),
+            "next_u64": self._next_u64,
+        }
+        with open(base.with_suffix(_STORE_EXT), "w") as f:
+            json.dump(payload, f)
 
     @classmethod
     def from_persist_path(
@@ -518,11 +524,10 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
     ) -> "TurboQuantVectorStore":
         """Load a previously-persisted store. ``persist_path`` is the same
         path that was passed to :meth:`persist` (extension is ignored;
-        ``{stem}.tvim`` and ``{stem}.pkl`` are read).
+        ``{stem}.tvim`` and ``{stem}.nodes.json`` are read).
 
-        Note: this deserializes a pickle side-car, which is unsafe to load
-        from untrusted sources. Only call on persist paths produced by
-        ``persist`` on a store you control.
+        Safe to call on any path — the side-car is plain JSON, never
+        pickle, so there's no deserialization-of-code risk.
         """
         if fs is not None:
             raise NotImplementedError(
@@ -530,13 +535,20 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
             )
         base = _split_persist_base(persist_path)
         index = IdMapIndex.load(str(base.with_suffix(_INDEX_EXT)))
-        with open(base.with_suffix(_STORE_EXT), "rb") as f:
-            state = pickle.load(f)
+        with open(base.with_suffix(_STORE_EXT)) as f:
+            state = json.load(f)
+        version = state.get("schema_version", 0)
+        if version != _NODES_SCHEMA_VERSION:
+            raise ValueError(
+                f"{_STORE_EXT.lstrip('.')} has schema version {version}; "
+                f"this turbovec expects version {_NODES_SCHEMA_VERSION}"
+            )
         store = cls(index=index)
         store._nodes = state["nodes"]
-        store._node_id_to_u64 = state["node_id_to_u64"]
-        store._u64_to_node_id = {h: nid for nid, h in state["node_id_to_u64"].items()}
-        store._next_u64 = state["next_u64"]
+        # Reconstruct {node_id: int handle} from the list-of-pairs form.
+        store._node_id_to_u64 = {nid: int(h) for nid, h in state["node_id_to_u64"]}
+        store._u64_to_node_id = {h: nid for nid, h in store._node_id_to_u64.items()}
+        store._next_u64 = int(state["next_u64"])
         return store
 
     @classmethod

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -61,9 +61,21 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
     _u64_to_node_id: dict[int, str] = PrivateAttr()
     _next_u64: int = PrivateAttr()
 
-    def __init__(self, index: IdMapIndex, **kwargs: Any) -> None:
+    def __init__(self, index: IdMapIndex | None = None, *, bit_width: int = 4, **kwargs: Any) -> None:
+        """Construct the vector store.
+
+        :param index: Optional pre-built :class:`IdMapIndex`. When omitted,
+            a lazy ``IdMapIndex`` is created — it commits to a dim on the
+            first add and lets callers use the no-arg construction pattern
+            common to LlamaIndex's other vector stores (e.g. via
+            ``StorageContext.from_defaults(vector_store=TurboQuantVectorStore())``).
+        :param bit_width: Quantization width used when constructing the
+            lazy index. Ignored if ``index`` is supplied.
+        """
         super().__init__(**kwargs)
-        self._index = index
+        # IdMapIndex itself supports lazy construction now — no per-store
+        # lazy wrapping needed.
+        self._index = index if index is not None else IdMapIndex(bit_width=bit_width)
         self._nodes = {}
         self._node_id_to_u64 = {}
         self._u64_to_node_id = {}
@@ -78,7 +90,9 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         return "TurboQuantVectorStore"
 
     @classmethod
-    def from_params(cls, dim: int, bit_width: int = 4) -> "TurboQuantVectorStore":
+    def from_params(cls, dim: int | None = None, bit_width: int = 4) -> "TurboQuantVectorStore":
+        """Build a store with a known ``dim`` (eager) or lazy when ``dim``
+        is omitted."""
         return cls(index=IdMapIndex(dim, bit_width))
 
     @property
@@ -97,9 +111,17 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
 
         embeddings = [node.get_embedding() for node in nodes]
         vectors = np.asarray(embeddings, dtype=np.float32)
-        if vectors.ndim != 2 or vectors.shape[1] != self._index.dim:
+        if vectors.ndim != 2:
             raise ValueError(
-                f"node embedding dim {vectors.shape[1]} does not match index dim {self._index.dim}"
+                f"expected 2D embedding batch, got {vectors.ndim}D"
+            )
+        # IdMapIndex.add_with_ids handles eager (dim must match) and lazy
+        # (locks dim on first add) — pre-check the eager case so we
+        # surface a clean ValueError rather than a Rust panic.
+        existing_dim = self._index.dim
+        if existing_dim is not None and vectors.shape[1] != existing_dim:
+            raise ValueError(
+                f"node embedding dim {vectors.shape[1]} does not match index dim {existing_dim}"
             )
         if not vectors.flags["C_CONTIGUOUS"]:
             vectors = np.ascontiguousarray(vectors)

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -5,9 +5,10 @@ Install with: ``pip install turbovec[llama-index]``.
 
 from __future__ import annotations
 
+import os
 import pickle
 from pathlib import Path
-from typing import Any
+from typing import Any, List, Optional, Sequence
 
 import numpy as np
 
@@ -38,8 +39,28 @@ except ImportError as exc:
     ) from exc
 
 
-_INDEX_FILENAME = "index.tvim"
-_STORE_FILENAME = "nodes.pkl"
+# Persistence layout: a single user-facing ``persist_path`` (the file the
+# framework asks us to write) is split into two files by extension —
+# ``{base}.tvim`` for the binary IdMapIndex and ``{base}.pkl`` for the
+# node side-car. Both live next to each other so the layout fits the
+# directory-of-namespaced-files pattern used by StorageContext.
+_INDEX_EXT = ".tvim"
+_STORE_EXT = ".pkl"
+# Filename template used by SimpleVectorStore for namespace lookup —
+# mirrored here so `from_persist_dir` works the same way.
+_NAMESPACE_SEP = "__"
+_DEFAULT_PERSIST_FNAME = "vector_store.json"
+_DEFAULT_VECTOR_STORE = "default"
+
+
+def _split_persist_base(persist_path: str | Path) -> Path:
+    """Strip the framework-provided extension off `persist_path` so the
+    binary index and pickle side-car can sit next to each other under a
+    shared base. We then append our own extensions in dump / load."""
+    p = Path(persist_path)
+    # Use the path without its suffix so both .tvim and .pkl share a base.
+    # If the input has no suffix (e.g. a bare folder-like name), use it as-is.
+    return p.with_suffix("") if p.suffix else p
 
 
 class TurboQuantVectorStore(BasePydanticVectorStore):
@@ -153,17 +174,93 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
 
     def delete_nodes(
         self,
-        node_ids: list[str],
-        filters: Any = None,
+        node_ids: Optional[List[str]] = None,
+        filters: Optional[MetadataFilters] = None,
         **_: Any,
     ) -> None:
-        """Delete specific nodes by their ``node_id``. Missing ids are ignored."""
+        """Delete every node matching ``node_ids`` and/or ``filters``. Both
+        constraints intersect when supplied. Missing node_ids are ignored.
+        Matches the signature and semantics of ``SimpleVectorStore.delete_nodes``.
+        """
+        if not node_ids and filters is None:
+            return
+        candidates = list(self._nodes.items())
+        if node_ids is not None:
+            node_id_set = set(node_ids)
+            candidates = [(nid, data) for nid, data in candidates if nid in node_id_set]
         if filters is not None:
-            raise NotImplementedError(
-                "TurboQuantVectorStore does not support metadata filtering on delete_nodes."
-            )
-        for nid in node_ids:
+            candidates = [
+                (nid, data)
+                for nid, data in candidates
+                if self._filters_match(data["metadata"], filters)
+            ]
+        for nid, _data in candidates:
             self._remove_node_by_id(nid)
+
+    def clear(self) -> None:
+        """Drop every node from the store and reset to a fresh lazy index.
+
+        The new index keeps the same ``bit_width`` so subsequent adds
+        commit a new ``dim`` lazily.
+        """
+        bw = self._index.bit_width
+        self._index = IdMapIndex(bit_width=bw)
+        self._nodes = {}
+        self._node_id_to_u64 = {}
+        self._u64_to_node_id = {}
+        self._next_u64 = 0
+
+    def get(self, text_id: str) -> List[float]:
+        """LlamaIndex's protocol expects this to return the full-precision
+        embedding for a given node id. turbovec discards full-precision
+        embeddings after quantization, so we raise loudly with an
+        explanation rather than return a lossy reconstruction or zeroes.
+        """
+        raise NotImplementedError(
+            "TurboQuantVectorStore.get(text_id) cannot return the original "
+            "embedding because turbovec quantizes vectors to 2-4 bits per "
+            "dimension and discards full precision after encoding. Keep a "
+            "parallel docstore if you need the raw embedding."
+        )
+
+    def get_nodes(
+        self,
+        node_ids: Optional[List[str]] = None,
+        filters: Optional[MetadataFilters] = None,
+    ) -> List[BaseNode]:
+        """Return the nodes matching ``node_ids`` and/or ``filters``. Both
+        constraints intersect when supplied; missing node_ids are
+        silently skipped.
+
+        Unlike ``SimpleVectorStore`` (which raises NotImplementedError
+        here because it doesn't store nodes), turbovec keeps node text
+        and metadata in a side-car so this can return populated
+        ``TextNode`` objects directly.
+        """
+        candidates = list(self._nodes.items())
+        if node_ids is not None:
+            node_id_set = set(node_ids)
+            candidates = [(nid, data) for nid, data in candidates if nid in node_id_set]
+        if filters is not None:
+            candidates = [
+                (nid, data)
+                for nid, data in candidates
+                if self._filters_match(data["metadata"], filters)
+            ]
+        return [self._reconstruct_node(nid, data) for nid, data in candidates]
+
+    @staticmethod
+    def _reconstruct_node(nid: str, data: dict[str, Any]) -> TextNode:
+        node = TextNode(
+            id_=nid,
+            text=data["text"],
+            metadata=dict(data["metadata"]),
+        )
+        if data.get("ref_doc_id") is not None:
+            node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(
+                node_id=data["ref_doc_id"]
+            )
+        return node
 
     def _remove_node_by_id(self, node_id: str) -> bool:
         handle = self._node_id_to_u64.pop(node_id, None)
@@ -316,29 +413,94 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         ids: list[str] = []
         for score, handle in zip(scores[0], handles[0]):
             nid = self._u64_to_node_id[int(handle)]
-            state = self._nodes[nid]
-            node = TextNode(
-                id_=nid,
-                text=state["text"],
-                metadata=dict(state["metadata"]),
-            )
-            if state["ref_doc_id"] is not None:
-                node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(
-                    node_id=state["ref_doc_id"]
-                )
-            result_nodes.append(node)
+            data = self._nodes[nid]
+            result_nodes.append(self._reconstruct_node(nid, data))
             similarities.append(float(score))
             ids.append(nid)
 
         return VectorStoreQueryResult(nodes=result_nodes, similarities=similarities, ids=ids)
 
+    # ---- Async overrides --------------------------------------------------
+    #
+    # The base class provides default async impls that delegate to sync via
+    # `return self.<sync>(...)`. We override them explicitly so the signature
+    # is visible on the class and an autodoc tool / IDE doesn't make
+    # callers chase the abstract base class for the documentation.
+
+    async def async_add(
+        self, nodes: Sequence[BaseNode], **kwargs: Any
+    ) -> List[str]:
+        return self.add(list(nodes), **kwargs)
+
+    async def adelete(self, ref_doc_id: str, **kwargs: Any) -> None:
+        self.delete(ref_doc_id, **kwargs)
+
+    async def adelete_nodes(
+        self,
+        node_ids: Optional[List[str]] = None,
+        filters: Optional[MetadataFilters] = None,
+        **kwargs: Any,
+    ) -> None:
+        self.delete_nodes(node_ids=node_ids, filters=filters, **kwargs)
+
+    async def aclear(self) -> None:
+        self.clear()
+
+    async def aquery(
+        self, query: VectorStoreQuery, **kwargs: Any
+    ) -> VectorStoreQueryResult:
+        return self.query(query, **kwargs)
+
+    async def aget_nodes(
+        self,
+        node_ids: Optional[List[str]] = None,
+        filters: Optional[MetadataFilters] = None,
+    ) -> List[BaseNode]:
+        return self.get_nodes(node_ids=node_ids, filters=filters)
+
+    # ---- Config serialization ---------------------------------------------
+
+    def to_dict(self, **_: Any) -> dict[str, Any]:
+        """Serialize the store's *configuration* (not its data) so a
+        fresh instance can be reconstructed via ``from_dict``. Mirrors
+        the contract of ``SimpleVectorStore.to_dict`` — config-only;
+        node data round-trips through ``persist`` / ``from_persist_path``.
+        """
+        return {
+            "bit_width": self._index.bit_width,
+            "dim": self._index.dim,  # may be None (lazy uncommitted)
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any], **_: Any) -> "TurboQuantVectorStore":
+        """Construct an empty store from a config dict produced by
+        ``to_dict``. To restore data, use ``from_persist_path``."""
+        dim = data.get("dim")
+        bit_width = data.get("bit_width", 4)
+        return cls(index=IdMapIndex(dim, bit_width))
+
     def persist(self, persist_path: str, fs: Any = None) -> None:
+        """Persist the store. ``persist_path`` is treated as a path *stem*:
+        the binary index goes to ``{stem}.tvim`` and the node side-car to
+        ``{stem}.pkl``. Any extension on ``persist_path`` (e.g. ``.json``
+        from a StorageContext default) is replaced.
+
+        This matches the layout assumed by ``StorageContext.persist`` —
+        which calls us with ``persist_path = {persist_dir}/{namespace}__vector_store.json`` —
+        and lets multiple namespaced stores coexist in the same directory.
+
+        ``fs`` (fsspec) is not yet supported; pass a local path.
+
+        Note: the pickle side-car is unsafe to load from untrusted sources.
+        """
         if fs is not None:
-            raise NotImplementedError("fsspec filesystems are not supported yet; pass a local path.")
-        folder = Path(persist_path)
-        folder.mkdir(parents=True, exist_ok=True)
-        self._index.write(str(folder / _INDEX_FILENAME))
-        with open(folder / _STORE_FILENAME, "wb") as f:
+            raise NotImplementedError(
+                "fsspec filesystems are not supported yet; pass a local path."
+            )
+        base = _split_persist_base(persist_path)
+        base.parent.mkdir(parents=True, exist_ok=True)
+        self._index.write(str(base.with_suffix(_INDEX_EXT)))
+        with open(base.with_suffix(_STORE_EXT), "wb") as f:
             pickle.dump(
                 {
                     "nodes": self._nodes,
@@ -353,20 +515,22 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         cls,
         persist_path: str,
         fs: Any = None,
-        *,
-        allow_dangerous_deserialization: bool = False,
     ) -> "TurboQuantVectorStore":
+        """Load a previously-persisted store. ``persist_path`` is the same
+        path that was passed to :meth:`persist` (extension is ignored;
+        ``{stem}.tvim`` and ``{stem}.pkl`` are read).
+
+        Note: this deserializes a pickle side-car, which is unsafe to load
+        from untrusted sources. Only call on persist paths produced by
+        ``persist`` on a store you control.
+        """
         if fs is not None:
-            raise NotImplementedError("fsspec filesystems are not supported yet; pass a local path.")
-        if not allow_dangerous_deserialization:
-            raise ValueError(
-                "from_persist_path uses pickle to deserialize the node store, which is "
-                "unsafe with untrusted input. Pass allow_dangerous_deserialization=True "
-                "to confirm you trust the source of persist_path."
+            raise NotImplementedError(
+                "fsspec filesystems are not supported yet; pass a local path."
             )
-        folder = Path(persist_path)
-        index = IdMapIndex.load(str(folder / _INDEX_FILENAME))
-        with open(folder / _STORE_FILENAME, "rb") as f:
+        base = _split_persist_base(persist_path)
+        index = IdMapIndex.load(str(base.with_suffix(_INDEX_EXT)))
+        with open(base.with_suffix(_STORE_EXT), "rb") as f:
             state = pickle.load(f)
         store = cls(index=index)
         store._nodes = state["nodes"]
@@ -374,6 +538,25 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         store._u64_to_node_id = {h: nid for nid, h in state["node_id_to_u64"].items()}
         store._next_u64 = state["next_u64"]
         return store
+
+    @classmethod
+    def from_persist_dir(
+        cls,
+        persist_dir: str,
+        namespace: str = _DEFAULT_VECTOR_STORE,
+        fs: Any = None,
+    ) -> "TurboQuantVectorStore":
+        """Load a store from a ``StorageContext``-style persist directory.
+
+        Builds the namespaced filename
+        ``{persist_dir}/{namespace}__vector_store.json`` and forwards to
+        :meth:`from_persist_path`. The ``.json`` suffix is conventional —
+        our actual on-disk files use ``.tvim`` and ``.pkl`` extensions
+        derived from the same stem.
+        """
+        persist_fname = f"{namespace}{_NAMESPACE_SEP}{_DEFAULT_PERSIST_FNAME}"
+        persist_path = os.path.join(persist_dir, persist_fname)
+        return cls.from_persist_path(persist_path, fs=fs)
 
 
 __all__ = ["TurboQuantVectorStore"]

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -24,6 +24,10 @@ try:
     )
     from llama_index.core.vector_stores.types import (
         BasePydanticVectorStore,
+        FilterCondition,
+        FilterOperator,
+        MetadataFilter,
+        MetadataFilters,
         VectorStoreQuery,
         VectorStoreQueryResult,
     )
@@ -148,6 +152,88 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         self._index.remove(handle)
         return True
 
+    def _resolve_allowed_handles(
+        self,
+        filters: MetadataFilters | None,
+        doc_ids: list[str] | None,
+    ) -> list[int]:
+        """Resolve ``query.filters`` and ``query.doc_ids`` to the list of
+        internal u64 handles that satisfy the filter. Empty list means no
+        node matches."""
+        if doc_ids:
+            doc_id_set = set(doc_ids)
+            candidates = [
+                (nid, data)
+                for nid, data in self._nodes.items()
+                if nid in doc_id_set
+                or data.get("ref_doc_id") in doc_id_set
+            ]
+        else:
+            candidates = list(self._nodes.items())
+
+        if filters is None:
+            return [self._node_id_to_u64[nid] for nid, _ in candidates]
+
+        return [
+            self._node_id_to_u64[nid]
+            for nid, data in candidates
+            if self._filters_match(data["metadata"], filters)
+        ]
+
+    @classmethod
+    def _filters_match(
+        cls, metadata: dict[str, Any], filters: MetadataFilters
+    ) -> bool:
+        condition = getattr(filters, "condition", None) or FilterCondition.AND
+        results: list[bool] = []
+        for f in filters.filters:
+            if isinstance(f, MetadataFilters):
+                results.append(cls._filters_match(metadata, f))
+            else:
+                results.append(cls._single_filter_match(metadata, f))
+        if condition == FilterCondition.AND:
+            return all(results) if results else True
+        if condition == FilterCondition.OR:
+            return any(results) if results else True
+        raise NotImplementedError(
+            f"filter condition {condition!r} not supported by TurboQuantVectorStore "
+            "(supported: AND, OR)"
+        )
+
+    @staticmethod
+    def _single_filter_match(metadata: dict[str, Any], f: MetadataFilter) -> bool:
+        op = f.operator
+        key = f.key
+        target = f.value
+        present = key in metadata
+        value = metadata.get(key)
+
+        if op == FilterOperator.EQ:
+            return present and value == target
+        if op == FilterOperator.NE:
+            return (not present) or value != target
+        if op == FilterOperator.GT:
+            return present and value > target
+        if op == FilterOperator.LT:
+            return present and value < target
+        if op == FilterOperator.GTE:
+            return present and value >= target
+        if op == FilterOperator.LTE:
+            return present and value <= target
+        if op == FilterOperator.IN:
+            return present and value in target
+        if op == FilterOperator.NIN:
+            return (not present) or value not in target
+        if op == FilterOperator.TEXT_MATCH:
+            return present and str(target) in str(value)
+        if op == FilterOperator.CONTAINS:
+            return present and target in value
+        if op == FilterOperator.IS_EMPTY:
+            return (not present) or value in (None, "", [], {}, ())
+        raise NotImplementedError(
+            f"filter operator {op!r} not supported by TurboQuantVectorStore"
+        )
+
     def query(self, query: VectorStoreQuery, **_: Any) -> VectorStoreQueryResult:
         if query.query_embedding is None:
             raise ValueError(
@@ -160,11 +246,23 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         if not qvec.flags["C_CONTIGUOUS"]:
             qvec = np.ascontiguousarray(qvec)
 
-        k = min(query.similarity_top_k, len(self._index))
-        if k == 0:
+        if len(self._index) == 0:
             return VectorStoreQueryResult(nodes=[], similarities=[], ids=[])
 
-        scores, handles = self._index.search(qvec, k)
+        has_filters = query.filters is not None or bool(query.doc_ids)
+        if not has_filters:
+            k = min(query.similarity_top_k, len(self._index))
+            scores, handles = self._index.search(qvec, k)
+        else:
+            allowed_handles = self._resolve_allowed_handles(
+                query.filters, query.doc_ids
+            )
+            if not allowed_handles:
+                return VectorStoreQueryResult(nodes=[], similarities=[], ids=[])
+            allowlist = np.asarray(allowed_handles, dtype=np.uint64)
+            scores, handles = self._index.search(
+                qvec, query.similarity_top_k, allowlist=allowlist
+            )
 
         result_nodes: list[TextNode] = []
         similarities: list[float] = []

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -9,17 +9,28 @@ struct TurboQuantIndex {
 
 #[pymethods]
 impl TurboQuantIndex {
+    /// Construct an index. `dim` is optional: when omitted, the
+    /// underlying quantized index is created lazily on the first
+    /// `add` call, picking up the dimensionality from the input
+    /// array's shape.
     #[new]
-    fn new(dim: usize, bit_width: usize) -> Self {
+    #[pyo3(signature = (dim=None, bit_width=4))]
+    fn new(dim: Option<usize>, bit_width: usize) -> Self {
         Self {
-            inner: turbovec_core::TurboQuantIndex::new(dim, bit_width),
+            inner: match dim {
+                Some(d) => turbovec_core::TurboQuantIndex::new(d, bit_width),
+                None => turbovec_core::TurboQuantIndex::new_lazy(bit_width),
+            },
         }
     }
 
     fn add(&mut self, vectors: PyReadonlyArray2<f32>) {
         let arr = vectors.as_array();
+        let dim = arr.ncols();
         let slice = arr.as_slice().expect("vectors must be contiguous");
-        self.inner.add(slice);
+        // `add_2d` handles both eager (dim must match) and lazy (locks
+        // dim on first call) cases.
+        self.inner.add_2d(slice, dim);
     }
 
     /// Run a top-`k` search against the index.
@@ -102,9 +113,12 @@ impl TurboQuantIndex {
         self.inner.len()
     }
 
+    /// Vector dimensionality. Returns ``None`` when the index was
+    /// constructed lazily (no ``dim=``) and hasn't seen an add yet;
+    /// otherwise an ``int``.
     #[getter]
-    fn dim(&self) -> usize {
-        self.inner.dim()
+    fn dim(&self) -> Option<usize> {
+        self.inner.dim_opt()
     }
 
     #[getter]
@@ -120,10 +134,17 @@ struct IdMapIndex {
 
 #[pymethods]
 impl IdMapIndex {
+    /// Construct an id-mapped index. `dim` is optional: when omitted,
+    /// the underlying quantized index is created lazily on the first
+    /// `add_with_ids` call, picking up dim from the input array shape.
     #[new]
-    fn new(dim: usize, bit_width: usize) -> Self {
+    #[pyo3(signature = (dim=None, bit_width=4))]
+    fn new(dim: Option<usize>, bit_width: usize) -> Self {
         Self {
-            inner: turbovec_core::IdMapIndex::new(dim, bit_width),
+            inner: match dim {
+                Some(d) => turbovec_core::IdMapIndex::new(d, bit_width),
+                None => turbovec_core::IdMapIndex::new_lazy(bit_width),
+            },
         }
     }
 
@@ -131,17 +152,19 @@ impl IdMapIndex {
     ///
     /// `ids` must be a 1-D array of `uint64` with length equal to
     /// `vectors.shape[0]`. Raises if any id is already present or if the
-    /// lengths don't match.
+    /// lengths don't match. On a lazy index, this call commits the
+    /// dimensionality from `vectors.shape[1]`.
     fn add_with_ids(
         &mut self,
         vectors: PyReadonlyArray2<f32>,
         ids: PyReadonlyArray1<u64>,
     ) {
         let v = vectors.as_array();
+        let dim = v.ncols();
         let v_slice = v.as_slice().expect("vectors must be contiguous");
         let i = ids.as_array();
         let i_slice = i.as_slice().expect("ids must be contiguous");
-        self.inner.add_with_ids(v_slice, i_slice);
+        self.inner.add_with_ids_2d(v_slice, dim, i_slice);
     }
 
     /// Remove the vector with external id `id`. Returns `True` if it was
@@ -250,9 +273,11 @@ impl IdMapIndex {
         self.inner.contains(id)
     }
 
+    /// Vector dimensionality. Returns ``None`` when the index was
+    /// constructed lazily and hasn't seen an add yet; otherwise ``int``.
     #[getter]
-    fn dim(&self) -> usize {
-        self.inner.dim()
+    fn dim(&self) -> Option<usize> {
+        self.inner.dim_opt()
     }
 
     #[getter]

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -1,4 +1,4 @@
-use numpy::{IntoPyArray, PyArray1, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
+use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::prelude::*;
 use pyo3::types::PyType;
 
@@ -22,25 +22,50 @@ impl TurboQuantIndex {
         self.inner.add(slice);
     }
 
+    /// Run a top-`k` search against the index.
+    ///
+    /// `mask`, when given, is a bool array of length `len(self)`. Only slots
+    /// with `mask[i] == True` contribute to the returned top-`k`. The
+    /// returned result count per query is `min(k, mask.sum())`.
+    #[pyo3(signature = (queries, k, *, mask=None))]
     fn search<'py>(
         &self,
         py: Python<'py>,
         queries: PyReadonlyArray2<f32>,
         k: usize,
-    ) -> (Bound<'py, PyArray2<f32>>, Bound<'py, PyArray2<i64>>) {
+        mask: Option<PyReadonlyArray1<bool>>,
+    ) -> PyResult<(Bound<'py, PyArray2<f32>>, Bound<'py, PyArray2<i64>>)> {
         let arr = queries.as_array();
         let nq = arr.nrows();
-        let slice = arr.as_slice().expect("queries must be contiguous");
-        let results = self.inner.search(slice, k);
+        let q_slice = arr.as_slice().expect("queries must be contiguous");
 
-        let scores = numpy::ndarray::Array2::from_shape_vec((nq, results.k), results.scores)
+        let mask_arr = mask.as_ref().map(|m| m.as_array());
+        let mask_slice: Option<&[bool]> = match mask_arr.as_ref() {
+            Some(m_arr) => {
+                let expected = self.inner.len();
+                if m_arr.len() != expected {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "mask length {} does not match index size {}",
+                        m_arr.len(),
+                        expected,
+                    )));
+                }
+                Some(m_arr.as_slice().expect("mask must be contiguous"))
+            }
+            None => None,
+        };
+
+        let results = self.inner.search_with_mask(q_slice, k, mask_slice);
+        let effective_k = results.k;
+
+        let scores = numpy::ndarray::Array2::from_shape_vec((nq, effective_k), results.scores)
             .unwrap()
             .into_pyarray(py);
-        let indices = numpy::ndarray::Array2::from_shape_vec((nq, results.k), results.indices)
+        let indices = numpy::ndarray::Array2::from_shape_vec((nq, effective_k), results.indices)
             .unwrap()
             .into_pyarray(py);
 
-        (scores, indices)
+        Ok((scores, indices))
     }
 
     fn write(&self, path: &str) -> PyResult<()> {
@@ -127,17 +152,60 @@ impl IdMapIndex {
 
     /// Search for the top-`k` nearest external ids for each query.
     ///
-    /// Returns `(scores, ids)` as `(nq, k)` arrays, `ids` typed `uint64`.
+    /// `allowlist`, when given, is a `uint64` array of external ids; the
+    /// returned top-`k` is restricted to ids in this list. The returned
+    /// result count per query is `min(k, len(allowlist))` (after
+    /// de-duplication).
+    ///
+    /// Returns `(scores, ids)` as `(nq, effective_k)` arrays, `ids` typed
+    /// `uint64`. Raises `ValueError` for an empty allowlist and `KeyError`
+    /// if any allowlist id is not present in the index.
+    #[pyo3(signature = (queries, k, *, allowlist=None))]
     fn search<'py>(
         &self,
         py: Python<'py>,
         queries: PyReadonlyArray2<f32>,
         k: usize,
-    ) -> (Bound<'py, PyArray2<f32>>, Bound<'py, PyArray2<u64>>) {
+        allowlist: Option<PyReadonlyArray1<u64>>,
+    ) -> PyResult<(Bound<'py, PyArray2<f32>>, Bound<'py, PyArray2<u64>>)> {
         let arr = queries.as_array();
         let nq = arr.nrows();
-        let slice = arr.as_slice().expect("queries must be contiguous");
-        let (scores, ids) = self.inner.search(slice, k);
+        let q_slice = arr.as_slice().expect("queries must be contiguous");
+
+        let allow_arr = allowlist.as_ref().map(|a| a.as_array());
+        let allow_slice: Option<&[u64]> = match allow_arr.as_ref() {
+            Some(a_arr) => {
+                if a_arr.is_empty() {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "allowlist is empty",
+                    ));
+                }
+                let slice = a_arr.as_slice().expect("allowlist must be contiguous");
+                let mut unknown: Vec<u64> = Vec::new();
+                for &id in slice {
+                    if !self.inner.contains(id) {
+                        if unknown.len() < 5 {
+                            unknown.push(id);
+                        } else {
+                            unknown.push(id);
+                            break;
+                        }
+                    }
+                }
+                if !unknown.is_empty() {
+                    let preview: Vec<u64> = unknown.iter().take(5).copied().collect();
+                    return Err(pyo3::exceptions::PyKeyError::new_err(format!(
+                        "allowlist contains id(s) not present in index: {:?}{}",
+                        preview,
+                        if unknown.len() > 5 { ", ..." } else { "" },
+                    )));
+                }
+                Some(slice)
+            }
+            None => None,
+        };
+
+        let (scores, ids) = self.inner.search_with_allowlist(q_slice, k, allow_slice);
         let effective_k = if nq == 0 { k } else { scores.len() / nq };
 
         let scores_arr = numpy::ndarray::Array2::from_shape_vec((nq, effective_k), scores)
@@ -146,7 +214,7 @@ impl IdMapIndex {
         let ids_arr = numpy::ndarray::Array2::from_shape_vec((nq, effective_k), ids)
             .unwrap()
             .into_pyarray(py);
-        (scores_arr, ids_arr)
+        Ok((scores_arr, ids_arr))
     }
 
     fn contains(&self, id: u64) -> bool {

--- a/turbovec-python/tests/test_filtering.py
+++ b/turbovec-python/tests/test_filtering.py
@@ -1,0 +1,205 @@
+"""Tests for the `mask=` and `allowlist=` filtering kwargs."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from turbovec import IdMapIndex, TurboQuantIndex
+
+
+DIM = 128
+
+
+def unit_vectors(n: int, dim: int = DIM, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    v = rng.standard_normal((n, dim)).astype(np.float32)
+    v /= np.linalg.norm(v, axis=1, keepdims=True) + 1e-9
+    return v
+
+
+# ------------------- TurboQuantIndex.search(mask=...) -------------------
+
+def test_mask_none_matches_unmasked():
+    idx = TurboQuantIndex(dim=DIM, bit_width=4)
+    idx.add(unit_vectors(100, seed=1))
+    queries = unit_vectors(3, seed=2)
+
+    s1, i1 = idx.search(queries, 10)
+    s2, i2 = idx.search(queries, 10, mask=None)
+    np.testing.assert_array_equal(s1, s2)
+    np.testing.assert_array_equal(i1, i2)
+
+
+def test_mask_all_true_matches_unmasked():
+    idx = TurboQuantIndex(dim=DIM, bit_width=4)
+    idx.add(unit_vectors(80, seed=3))
+    queries = unit_vectors(2, seed=4)
+
+    s1, i1 = idx.search(queries, 5)
+    mask = np.ones(len(idx), dtype=bool)
+    s2, i2 = idx.search(queries, 5, mask=mask)
+    np.testing.assert_array_equal(s1, s2)
+    np.testing.assert_array_equal(i1, i2)
+
+
+def test_mask_restricts_returned_indices():
+    n = 200
+    idx = TurboQuantIndex(dim=DIM, bit_width=4)
+    idx.add(unit_vectors(n, seed=5))
+    queries = unit_vectors(4, seed=6)
+
+    mask = np.zeros(n, dtype=bool)
+    allowed = [3, 7, 19, 42, 88, 121, 150, 175, 198]
+    mask[allowed] = True
+
+    scores, indices = idx.search(queries, 5, mask=mask)
+    assert scores.shape == (4, 5)
+    assert indices.shape == (4, 5)
+    for row in indices:
+        for slot in row:
+            assert slot in allowed, f"kernel returned disallowed slot {slot}"
+    # Scores descending per row.
+    for row in scores:
+        assert np.all(np.diff(row) <= 1e-6)
+
+
+def test_mask_shrinks_effective_k():
+    n = 100
+    idx = TurboQuantIndex(dim=DIM, bit_width=4)
+    idx.add(unit_vectors(n, seed=7))
+    queries = unit_vectors(2, seed=8)
+
+    mask = np.zeros(n, dtype=bool)
+    mask[[5, 10, 15]] = True
+    scores, indices = idx.search(queries, 10, mask=mask)
+    assert scores.shape == (2, 3), "effective_k should be popcount(mask) = 3"
+    assert indices.shape == (2, 3)
+
+
+def test_mask_all_false_returns_empty_columns():
+    n = 50
+    idx = TurboQuantIndex(dim=DIM, bit_width=4)
+    idx.add(unit_vectors(n, seed=9))
+    queries = unit_vectors(2, seed=10)
+
+    mask = np.zeros(n, dtype=bool)
+    scores, indices = idx.search(queries, 5, mask=mask)
+    assert scores.shape == (2, 0)
+    assert indices.shape == (2, 0)
+
+
+def test_mask_wrong_length_raises():
+    idx = TurboQuantIndex(dim=DIM, bit_width=4)
+    idx.add(unit_vectors(50, seed=11))
+    queries = unit_vectors(1, seed=12)
+
+    with pytest.raises(ValueError, match="mask length"):
+        idx.search(queries, 5, mask=np.ones(10, dtype=bool))
+
+
+def test_mask_must_be_bool_dtype():
+    idx = TurboQuantIndex(dim=DIM, bit_width=4)
+    idx.add(unit_vectors(50, seed=13))
+    queries = unit_vectors(1, seed=14)
+
+    with pytest.raises((TypeError, ValueError)):
+        idx.search(queries, 5, mask=np.ones(50, dtype=np.uint8))
+
+
+def test_mask_matches_post_hoc_filter():
+    n = 256
+    idx = TurboQuantIndex(dim=DIM, bit_width=4)
+    idx.add(unit_vectors(n, seed=15))
+    queries = unit_vectors(5, seed=16)
+
+    mask = np.zeros(n, dtype=bool)
+    mask[::3] = True
+    k = 7
+
+    unfiltered_scores, unfiltered_idx = idx.search(queries, n)
+    expected_indices = []
+    expected_scores = []
+    for qi in range(queries.shape[0]):
+        row_idx = unfiltered_idx[qi]
+        row_s = unfiltered_scores[qi]
+        keep = mask[row_idx]
+        expected_indices.append(row_idx[keep][:k])
+        expected_scores.append(row_s[keep][:k])
+
+    masked_scores, masked_idx = idx.search(queries, k, mask=mask)
+    assert masked_idx.shape == (queries.shape[0], k)
+    for qi in range(queries.shape[0]):
+        np.testing.assert_array_equal(masked_idx[qi], expected_indices[qi])
+        # Score parity is exact when both calls go through the same code
+        # path (single batched call on both sides).
+        np.testing.assert_allclose(masked_scores[qi], expected_scores[qi], rtol=1e-4, atol=1e-5)
+
+
+# ------------------- IdMapIndex.search(allowlist=...) -------------------
+
+def test_allowlist_none_matches_unfiltered():
+    idx = IdMapIndex(dim=DIM, bit_width=4)
+    ids = np.arange(7000, 7100, dtype=np.uint64)
+    idx.add_with_ids(unit_vectors(100, seed=20), ids)
+    queries = unit_vectors(2, seed=21)
+
+    s1, i1 = idx.search(queries, 10)
+    s2, i2 = idx.search(queries, 10, allowlist=None)
+    np.testing.assert_array_equal(s1, s2)
+    np.testing.assert_array_equal(i1, i2)
+
+
+def test_allowlist_restricts_returned_ids():
+    idx = IdMapIndex(dim=DIM, bit_width=4)
+    ids = np.arange(1000, 1100, dtype=np.uint64)
+    idx.add_with_ids(unit_vectors(100, seed=22), ids)
+    queries = unit_vectors(3, seed=23)
+
+    allowed = np.array([1003, 1010, 1042, 1077, 1099], dtype=np.uint64)
+    scores, returned = idx.search(queries, 10, allowlist=allowed)
+    assert scores.shape == (3, len(allowed))
+    assert returned.shape == (3, len(allowed))
+    for row in returned:
+        for rid in row:
+            assert rid in allowed
+
+
+def test_allowlist_empty_raises_value_error():
+    idx = IdMapIndex(dim=DIM, bit_width=4)
+    idx.add_with_ids(
+        unit_vectors(5, seed=24),
+        np.array([1, 2, 3, 4, 5], dtype=np.uint64),
+    )
+    queries = unit_vectors(1, seed=25)
+    with pytest.raises(ValueError, match="allowlist is empty"):
+        idx.search(queries, 3, allowlist=np.array([], dtype=np.uint64))
+
+
+def test_allowlist_unknown_id_raises_key_error():
+    idx = IdMapIndex(dim=DIM, bit_width=4)
+    idx.add_with_ids(
+        unit_vectors(5, seed=26),
+        np.array([1, 2, 3, 4, 5], dtype=np.uint64),
+    )
+    queries = unit_vectors(1, seed=27)
+    with pytest.raises(KeyError, match="not present"):
+        idx.search(queries, 3, allowlist=np.array([2, 999], dtype=np.uint64))
+
+
+def test_allowlist_kwarg_is_keyword_only():
+    idx = IdMapIndex(dim=DIM, bit_width=4)
+    ids = np.arange(100, 110, dtype=np.uint64)
+    idx.add_with_ids(unit_vectors(10, seed=28), ids)
+    queries = unit_vectors(1, seed=29)
+    # Positional third arg should be rejected by PyO3 signature.
+    with pytest.raises(TypeError):
+        idx.search(queries, 3, ids)
+
+
+def test_mask_kwarg_is_keyword_only():
+    idx = TurboQuantIndex(dim=DIM, bit_width=4)
+    idx.add(unit_vectors(10, seed=30))
+    queries = unit_vectors(1, seed=31)
+    mask = np.ones(10, dtype=bool)
+    with pytest.raises(TypeError):
+        idx.search(queries, 3, mask)

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -221,9 +221,7 @@ def test_save_and_load_roundtrip(tmp_path):
 
     store.save_to_disk(tmp_path)
 
-    restored = TurboQuantDocumentStore.load_from_disk(
-        tmp_path, allow_dangerous_deserialization=True
-    )
+    restored = TurboQuantDocumentStore.load_from_disk(tmp_path)
     assert restored.count_documents() == 4
     # Every surviving id self-retrieves correctly.
     for doc in docs:
@@ -235,11 +233,34 @@ def test_save_and_load_roundtrip(tmp_path):
         assert results[0].id == doc.id
 
 
-def test_load_refuses_without_flag(tmp_path):
+def test_save_writes_json_sidecar(tmp_path):
+    # Side-car is plain JSON now, not pickle. A reviewer auditing a
+    # turbovec-saved store should be able to read it with a text editor.
+    import json
+
     store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
     store.write_documents(make_docs(2))
     store.save_to_disk(tmp_path)
-    with pytest.raises(ValueError, match="allow_dangerous_deserialization"):
+    assert (tmp_path / "docstore.json").exists()
+    assert not (tmp_path / "docstore.pkl").exists()
+    with open(tmp_path / "docstore.json") as f:
+        data = json.load(f)
+    assert data["schema_version"] >= 1
+
+
+def test_load_rejects_unknown_schema_version(tmp_path):
+    import json
+
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(1))
+    store.save_to_disk(tmp_path)
+    # Hand-bump the schema version to something unknown.
+    with open(tmp_path / "docstore.json") as f:
+        data = json.load(f)
+    data["schema_version"] = 99
+    with open(tmp_path / "docstore.json", "w") as f:
+        json.dump(data, f)
+    with pytest.raises(ValueError, match="schema version"):
         TurboQuantDocumentStore.load_from_disk(tmp_path)
 
 
@@ -497,9 +518,7 @@ def test_dump_and_load_empty_lazy_store(tmp_path):
     # store whose index is still in its lazy uncommitted state.
     store = TurboQuantDocumentStore(bit_width=2)
     store.save_to_disk(tmp_path)
-    loaded = TurboQuantDocumentStore.load_from_disk(
-        tmp_path, allow_dangerous_deserialization=True
-    )
+    loaded = TurboQuantDocumentStore.load_from_disk(tmp_path)
     assert loaded._index.dim is None
     assert loaded._bit_width == 2
     # Subsequent retrieval is empty; subsequent write commits the dim.

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -508,6 +508,116 @@ def test_dump_and_load_empty_lazy_store(tmp_path):
     assert loaded._index.dim == DIM
 
 
+# ---- End-to-end smoke tests: framework wiring ---------------------------
+
+def test_pipeline_end_to_end_retrieval():
+    # Smoke test: wire our store into a Haystack Pipeline via a custom
+    # retriever component and run a query end-to-end. The custom
+    # retriever is a tiny component that just delegates to
+    # store.embedding_retrieval — its job is to exercise the Pipeline
+    # plumbing on top of our store, not to be a real retriever.
+    from haystack import Pipeline, component
+    from haystack.components.embedders import SentenceTransformersTextEmbedder  # noqa: F401 (just an import check)
+
+    @component
+    class _ProbeRetriever:
+        """Minimal Haystack component: calls embedding_retrieval on its store."""
+
+        def __init__(self, document_store):
+            self.document_store = document_store
+
+        @component.output_types(documents=list)
+        def run(self, query_embedding, top_k=3, filters=None):
+            return {
+                "documents": self.document_store.embedding_retrieval(
+                    query_embedding=query_embedding,
+                    top_k=top_k,
+                    filters=filters,
+                )
+            }
+
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    docs = make_docs(8)
+    store.write_documents(docs)
+
+    pipeline = Pipeline()
+    pipeline.add_component("retriever", _ProbeRetriever(document_store=store))
+
+    # Use the query doc's own embedding to make the top-k deterministic.
+    result = pipeline.run(
+        {"retriever": {"query_embedding": docs[0].embedding, "top_k": 3}}
+    )
+    out_docs = result["retriever"]["documents"]
+    assert len(out_docs) == 3
+    assert out_docs[0].id == "doc-0"  # self-match
+
+
+def test_pipeline_filter_passthrough_via_retriever():
+    # Same as above, but exercises the filter path through the pipeline's
+    # parameter routing.
+    from haystack import Pipeline, component
+
+    @component
+    class _ProbeRetriever:
+        def __init__(self, document_store):
+            self.document_store = document_store
+
+        @component.output_types(documents=list)
+        def run(self, query_embedding, top_k=3, filters=None):
+            return {
+                "documents": self.document_store.embedding_retrieval(
+                    query_embedding=query_embedding,
+                    top_k=top_k,
+                    filters=filters,
+                )
+            }
+
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(10))
+
+    pipeline = Pipeline()
+    pipeline.add_component("retriever", _ProbeRetriever(document_store=store))
+
+    # group=="a" matches 5 of 10 docs.
+    result = pipeline.run({
+        "retriever": {
+            "query_embedding": make_docs(1)[0].embedding,
+            "top_k": 10,
+            "filters": {"field": "meta.group", "operator": "==", "value": "a"},
+        }
+    })
+    out_docs = result["retriever"]["documents"]
+    assert len(out_docs) == 5
+    assert all(d.meta["group"] == "a" for d in out_docs)
+
+
+def test_pipeline_to_dict_from_dict_roundtrip():
+    # Pipelines serialize/deserialize their components. Our store must
+    # round-trip through Haystack's component serialization machinery.
+    from haystack import Pipeline, component
+
+    @component
+    class _ProbeRetriever:
+        def __init__(self, document_store):
+            self.document_store = document_store
+
+        @component.output_types(documents=list)
+        def run(self, query_embedding):
+            return {
+                "documents": self.document_store.embedding_retrieval(
+                    query_embedding=query_embedding, top_k=1
+                )
+            }
+
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    pipeline = Pipeline()
+    pipeline.add_component("retriever", _ProbeRetriever(document_store=store))
+    # Serialize-then-load via Haystack's own dict round-trip — exercises
+    # our store's to_dict / from_dict from inside the framework.
+    serialized = pipeline.to_dict()
+    assert "components" in serialized
+
+
 def test_async_embedding_retrieval():
     import asyncio
 

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -219,9 +219,9 @@ def test_save_and_load_roundtrip(tmp_path):
     # Delete one so we exercise a non-identity slot_to_id mapping.
     store.delete_documents(["doc-2"])
 
-    store.save(tmp_path)
+    store.save_to_disk(tmp_path)
 
-    restored = TurboQuantDocumentStore.load(
+    restored = TurboQuantDocumentStore.load_from_disk(
         tmp_path, allow_dangerous_deserialization=True
     )
     assert restored.count_documents() == 4
@@ -238,9 +238,247 @@ def test_save_and_load_roundtrip(tmp_path):
 def test_load_refuses_without_flag(tmp_path):
     store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
     store.write_documents(make_docs(2))
-    store.save(tmp_path)
+    store.save_to_disk(tmp_path)
     with pytest.raises(ValueError, match="allow_dangerous_deserialization"):
-        TurboQuantDocumentStore.load(tmp_path)
+        TurboQuantDocumentStore.load_from_disk(tmp_path)
+
+
+# ---- Tier 1: input validation -------------------------------------------------
+
+def test_write_documents_rejects_non_list():
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    with pytest.raises(ValueError, match="list of Documents"):
+        store.write_documents("not a list of docs")  # type: ignore[arg-type]
+
+
+def test_write_documents_rejects_non_document_elements():
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    with pytest.raises(ValueError, match="list of Documents"):
+        store.write_documents([{"id": "x"}])  # type: ignore[list-item]
+
+
+# ---- Tier 2: utility methods ----------------------------------------------
+
+def test_delete_all_documents():
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(5))
+    assert store.count_documents() == 5
+    store.delete_all_documents()
+    assert store.count_documents() == 0
+
+
+def test_delete_by_filter_returns_count():
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(6))
+    filt = {"field": "meta.group", "operator": "==", "value": "a"}
+    deleted = store.delete_by_filter(filt)
+    assert deleted == 3
+    assert store.count_documents() == 3
+    assert all(
+        doc.meta["group"] == "b" for doc in store.filter_documents()
+    )
+
+
+def test_update_by_filter_merges_metadata():
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(4))
+    filt = {"field": "meta.group", "operator": "==", "value": "a"}
+    updated = store.update_by_filter(filt, {"tier": "premium"})
+    assert updated == 2
+    pros = [
+        doc
+        for doc in store.filter_documents()
+        if doc.meta.get("tier") == "premium"
+    ]
+    assert {doc.id for doc in pros} == {"doc-0", "doc-2"}
+    # Non-matching docs untouched.
+    others = [doc for doc in store.filter_documents() if "tier" not in doc.meta]
+    assert {doc.id for doc in others} == {"doc-1", "doc-3"}
+
+
+def test_count_documents_by_filter():
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(6))
+    filt = {"field": "meta.group", "operator": "==", "value": "a"}
+    assert store.count_documents_by_filter(filt) == 3
+    # Empty/falsy filter falls through to full count.
+    assert store.count_documents_by_filter({}) == 6
+
+
+def test_count_unique_metadata_by_filter():
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(6))
+    # Two unique "group" values across all docs.
+    result = store.count_unique_metadata_by_filter({}, ["meta.group"])
+    assert result == {"group": 2}
+    # Filtered subset: only group "a" → 1 unique.
+    filt = {"field": "meta.group", "operator": "==", "value": "a"}
+    result = store.count_unique_metadata_by_filter(filt, ["group"])
+    assert result == {"group": 1}
+
+
+def test_get_metadata_fields_info_infers_types():
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    docs = make_docs(2)
+    # make_docs gives idx (int) and group (str/keyword); add a bool + float.
+    docs[0].meta["active"] = True
+    docs[0].meta["weight"] = 1.5
+    store.write_documents(docs)
+    info = store.get_metadata_fields_info()
+    assert info["idx"] == {"type": "int"}
+    assert info["group"] == {"type": "keyword"}
+    assert info["active"] == {"type": "boolean"}
+    assert info["weight"] == {"type": "float"}
+
+
+def test_get_metadata_field_min_max():
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(5))  # idx in {0,1,2,3,4}
+    assert store.get_metadata_field_min_max("idx") == {"min": 0, "max": 4}
+    # Missing field returns the empty sentinel.
+    assert store.get_metadata_field_min_max("missing") == {
+        "min": None,
+        "max": None,
+    }
+
+
+def test_get_metadata_field_unique_values():
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(4))
+    values, n = store.get_metadata_field_unique_values("group")
+    assert sorted(values) == ["a", "b"]
+    assert n == 2
+    # search_term narrows to docs whose content contains the term.
+    values, n = store.get_metadata_field_unique_values("group", search_term="text 0")
+    assert values == ["a"]
+    assert n == 1
+
+
+def test_storage_property_returns_documents_by_id():
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(3))
+    storage = store.storage
+    assert set(storage.keys()) == {"doc-0", "doc-1", "doc-2"}
+    assert storage["doc-1"].meta["idx"] == 1
+    # Embeddings always None — turbovec doesn't keep them.
+    assert all(doc.embedding is None for doc in storage.values())
+
+
+def test_shutdown_is_idempotent():
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.shutdown()
+    store.shutdown()  # second call should not raise
+
+
+def test_filter_documents_invalid_filter_raises():
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(2))
+    with pytest.raises(ValueError, match="Invalid filter syntax"):
+        store.filter_documents(filters={"some_random_key": "value"})
+
+
+# ---- Tier 3: scale_score formula per similarity function ------------------
+
+def test_scale_score_cosine_formula():
+    store = TurboQuantDocumentStore(
+        dim=DIM, bit_width=4, embedding_similarity_function="cosine"
+    )
+    store.write_documents(make_docs(3))
+    results = store.embedding_retrieval(
+        query_embedding=make_docs(3)[0].embedding, top_k=3, scale_score=True
+    )
+    # Cosine scores live in [-1, 1]; after (s+1)/2 they're in [0, 1].
+    for doc in results:
+        assert 0.0 <= doc.score <= 1.0
+
+
+def test_scale_score_dot_product_formula():
+    store = TurboQuantDocumentStore(
+        dim=DIM, bit_width=4, embedding_similarity_function="dot_product"
+    )
+    store.write_documents(make_docs(3))
+    results = store.embedding_retrieval(
+        query_embedding=make_docs(3)[0].embedding, top_k=3, scale_score=True
+    )
+    # expit(s/100) sigmoid is monotonically increasing on (-inf, inf) → (0, 1).
+    for doc in results:
+        assert 0.0 < doc.score < 1.0
+
+
+def test_constructor_default_similarity_is_cosine():
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    assert store.embedding_similarity_function == "cosine"
+
+
+def test_to_dict_includes_new_init_params():
+    store = TurboQuantDocumentStore(
+        dim=DIM, bit_width=2, embedding_similarity_function="dot_product", return_embedding=True
+    )
+    serialized = store.to_dict()
+    ip = serialized["init_parameters"]
+    assert ip["embedding_similarity_function"] == "dot_product"
+    assert ip["return_embedding"] is True
+    restored = TurboQuantDocumentStore.from_dict(serialized)
+    assert restored.embedding_similarity_function == "dot_product"
+    assert restored.return_embedding is True
+
+
+# ---- Async methods ------------------------------------------------------
+
+def test_async_count_filter_write_delete():
+    import asyncio
+
+    async def runner():
+        store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+        n = await store.write_documents_async(make_docs(4))
+        assert n == 4
+        assert await store.count_documents_async() == 4
+        docs = await store.filter_documents_async()
+        assert len(docs) == 4
+        await store.delete_documents_async(["doc-0", "doc-1"])
+        assert await store.count_documents_async() == 2
+        await store.delete_all_documents_async()
+        assert await store.count_documents_async() == 0
+
+    asyncio.run(runner())
+
+
+def test_async_filter_helpers():
+    import asyncio
+
+    async def runner():
+        store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+        await store.write_documents_async(make_docs(6))
+        filt = {"field": "meta.group", "operator": "==", "value": "a"}
+        assert await store.count_documents_by_filter_async(filt) == 3
+        n = await store.update_by_filter_async(filt, {"tier": "free"})
+        assert n == 3
+        unique = await store.count_unique_metadata_by_filter_async({}, ["tier"])
+        assert unique == {"tier": 1}
+        info = await store.get_metadata_fields_info_async()
+        assert "group" in info
+        mm = await store.get_metadata_field_min_max_async("idx")
+        assert mm == {"min": 0, "max": 5}
+        uniq, n = await store.get_metadata_field_unique_values_async("group")
+        assert sorted(uniq) == ["a", "b"]
+
+    asyncio.run(runner())
+
+
+def test_async_embedding_retrieval():
+    import asyncio
+
+    async def runner():
+        store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+        docs = make_docs(5)
+        await store.write_documents_async(docs)
+        results = await store.embedding_retrieval_async(
+            query_embedding=docs[0].embedding, top_k=3
+        )
+        assert len(results) == 3
+        assert results[0].id == "doc-0"
+
+    asyncio.run(runner())
 
 
 def test_to_dict_from_dict_round_trip():

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -468,10 +468,10 @@ def test_async_filter_helpers():
 # ---- Tier 4: lazy dim construction ---------------------------------------
 
 def test_constructor_no_dim_is_lazy():
-    # `dim` is optional; the IdMapIndex isn't built until the first write.
+    # `dim` is optional; the underlying IdMapIndex starts in its lazy
+    # uncommitted state and locks dim on the first write.
     store = TurboQuantDocumentStore()
-    assert store._dim is None
-    assert store._index is None
+    assert store._index.dim is None
     # Retrieval before any write returns [].
     assert store.embedding_retrieval(query_embedding=[0.0] * DIM, top_k=3) == []
 
@@ -479,8 +479,7 @@ def test_constructor_no_dim_is_lazy():
 def test_lazy_dim_inferred_on_first_write():
     store = TurboQuantDocumentStore(bit_width=2)
     store.write_documents(make_docs(2))
-    assert store._dim == DIM
-    assert store._index is not None
+    assert store._index.dim == DIM
     assert store._index.bit_width == 2
 
 
@@ -495,19 +494,18 @@ def test_dim_mismatch_after_lazy_creation_raises():
 
 def test_dump_and_load_empty_lazy_store(tmp_path):
     # Saving before any write must not crash, and loading must restore a
-    # store that's also lazy (no phantom index).
+    # store whose index is still in its lazy uncommitted state.
     store = TurboQuantDocumentStore(bit_width=2)
     store.save_to_disk(tmp_path)
     loaded = TurboQuantDocumentStore.load_from_disk(
         tmp_path, allow_dangerous_deserialization=True
     )
-    assert loaded._dim is None
-    assert loaded._index is None
+    assert loaded._index.dim is None
     assert loaded._bit_width == 2
-    # Subsequent retrieval is empty; subsequent write creates the index.
+    # Subsequent retrieval is empty; subsequent write commits the dim.
     assert loaded.embedding_retrieval(query_embedding=[0.0] * DIM, top_k=1) == []
     loaded.write_documents(make_docs(1))
-    assert loaded._index is not None
+    assert loaded._index.dim == DIM
 
 
 def test_async_embedding_retrieval():

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -465,6 +465,51 @@ def test_async_filter_helpers():
     asyncio.run(runner())
 
 
+# ---- Tier 4: lazy dim construction ---------------------------------------
+
+def test_constructor_no_dim_is_lazy():
+    # `dim` is optional; the IdMapIndex isn't built until the first write.
+    store = TurboQuantDocumentStore()
+    assert store._dim is None
+    assert store._index is None
+    # Retrieval before any write returns [].
+    assert store.embedding_retrieval(query_embedding=[0.0] * DIM, top_k=3) == []
+
+
+def test_lazy_dim_inferred_on_first_write():
+    store = TurboQuantDocumentStore(bit_width=2)
+    store.write_documents(make_docs(2))
+    assert store._dim == DIM
+    assert store._index is not None
+    assert store._index.bit_width == 2
+
+
+def test_dim_mismatch_after_lazy_creation_raises():
+    store = TurboQuantDocumentStore()
+    store.write_documents(make_docs(1))  # locks dim to DIM
+    # Build a doc whose embedding has a different shape.
+    bad = Document(id="bad", content="x", embedding=[0.0] * (DIM + 1))
+    with pytest.raises(ValueError, match="does not match store dim"):
+        store.write_documents([bad])
+
+
+def test_dump_and_load_empty_lazy_store(tmp_path):
+    # Saving before any write must not crash, and loading must restore a
+    # store that's also lazy (no phantom index).
+    store = TurboQuantDocumentStore(bit_width=2)
+    store.save_to_disk(tmp_path)
+    loaded = TurboQuantDocumentStore.load_from_disk(
+        tmp_path, allow_dangerous_deserialization=True
+    )
+    assert loaded._dim is None
+    assert loaded._index is None
+    assert loaded._bit_width == 2
+    # Subsequent retrieval is empty; subsequent write creates the index.
+    assert loaded.embedding_retrieval(query_embedding=[0.0] * DIM, top_k=1) == []
+    loaded.write_documents(make_docs(1))
+    assert loaded._index is not None
+
+
 def test_async_embedding_retrieval():
     import asyncio
 

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -138,6 +138,55 @@ def test_embedding_retrieval_with_filter():
     assert all(doc.meta["group"] == "b" for doc in results)
 
 
+def test_embedding_retrieval_selective_filter_returns_top_k():
+    # Regression test for the over-fetch / post-filter recall hit: with a
+    # filter that matches only 3 docs out of 50, top_k=3 must return all 3.
+    # The old implementation could return fewer when the matching docs
+    # weren't in the over-fetched top_k * 10 by raw score.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    docs = make_docs(50)
+    store.write_documents(docs)
+    target_ids = {"doc-7", "doc-23", "doc-41"}
+    for doc in docs:
+        if doc.id in target_ids:
+            doc.meta["tag"] = "needle"
+    # Rewrite to refresh stored metadata (the store snapshotted it on write).
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(docs)
+    filt = {"field": "meta.tag", "operator": "==", "value": "needle"}
+    results = store.embedding_retrieval(
+        query_embedding=docs[0].embedding, top_k=3, filters=filt
+    )
+    assert len(results) == 3
+    assert {doc.id for doc in results} == target_ids
+
+
+def test_embedding_retrieval_no_matches_returns_empty():
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    docs = make_docs(10)
+    store.write_documents(docs)
+    filt = {"field": "meta.group", "operator": "==", "value": "no-such-group"}
+    results = store.embedding_retrieval(
+        query_embedding=docs[0].embedding, top_k=5, filters=filt
+    )
+    assert results == []
+
+
+def test_embedding_retrieval_top_k_larger_than_matches():
+    # When the filter has fewer matches than top_k, the result count
+    # should equal the number of matches (no padding, no error).
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    docs = make_docs(20)
+    store.write_documents(docs)
+    # group=="a" matches 10 of 20.
+    filt = {"field": "meta.group", "operator": "==", "value": "a"}
+    results = store.embedding_retrieval(
+        query_embedding=docs[0].embedding, top_k=100, filters=filt
+    )
+    assert len(results) == 10
+    assert all(doc.meta["group"] == "a" for doc in results)
+
+
 def test_k_larger_than_ntotal_is_clamped():
     store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
     docs = make_docs(3)

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -75,6 +75,8 @@ def test_similarity_search_with_dict_filter():
 
 
 def test_similarity_search_with_callable_filter():
+    # Predicate receives a langchain_core Document (matching the in-tree
+    # InMemoryVectorStore convention), not a bare metadata dict.
     emb = StubEmbeddings(dim=64)
     store = TurboQuantVectorStore.from_texts(
         ["a", "b", "c", "d"],
@@ -83,9 +85,22 @@ def test_similarity_search_with_callable_filter():
         bit_width=4,
     )
     results = store.similarity_search(
-        "a", k=10, filter=lambda meta: meta.get("n", 0) > 2
+        "a", k=10, filter=lambda doc: doc.metadata.get("n", 0) > 2
     )
     assert {r.metadata["n"] for r in results} == {3, 4}
+
+
+def test_similarity_search_callable_filter_can_use_page_content():
+    # Document is passed to the predicate, so page_content is reachable.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["alpha", "beta", "alphabet"], emb, bit_width=4,
+    )
+    results = store.similarity_search(
+        "alpha", k=10, filter=lambda doc: doc.page_content.startswith("alpha")
+    )
+    contents = {r.page_content for r in results}
+    assert contents == {"alpha", "alphabet"}
 
 
 def test_similarity_search_filter_with_scores():

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -416,6 +416,64 @@ def test_async_mmr_raises():
 
 # ---- Empty-store persistence round-trip (lazy index) ---------------------
 
+# ---- End-to-end smoke tests: framework wiring ---------------------------
+
+def test_as_retriever_invoke_returns_documents():
+    # Smoke test: wire the store into LangChain's VectorStoreRetriever via
+    # `as_retriever()` and run a query through the .invoke() interface.
+    # This is the canonical way users plug a VectorStore into a Chain,
+    # so it exercises the base-class wiring that calls similarity_search
+    # on our store from the framework side.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["alpha", "beta", "gamma", "delta"],
+        emb,
+        metadatas=[{"tag": "a"}, {"tag": "b"}, {"tag": "a"}, {"tag": "b"}],
+        bit_width=4,
+    )
+    retriever = store.as_retriever(search_kwargs={"k": 2})
+    docs = retriever.invoke("alpha")
+    assert len(docs) == 2
+    assert all(isinstance(d, Document) for d in docs)
+
+
+def test_as_retriever_with_filter_kwarg():
+    # The retriever passes search_kwargs (including `filter`) through to
+    # similarity_search. This verifies the keyword reaches our store
+    # without being dropped by the base class.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["alpha", "beta", "gamma"],
+        emb,
+        metadatas=[{"tag": "keep"}, {"tag": "drop"}, {"tag": "keep"}],
+        bit_width=4,
+    )
+    retriever = store.as_retriever(
+        search_kwargs={"k": 5, "filter": {"tag": "keep"}}
+    )
+    docs = retriever.invoke("alpha")
+    assert len(docs) == 2
+    assert all(d.metadata["tag"] == "keep" for d in docs)
+
+
+def test_as_retriever_similarity_score_threshold():
+    # `similarity_score_threshold` is the search_type that uses
+    # similarity_search_with_relevance_scores under the hood, which
+    # depends on our _select_relevance_score_fn override. If that's
+    # missing or broken, this test fails with NotImplementedError.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["alpha", "beta", "gamma"], emb, bit_width=4
+    )
+    retriever = store.as_retriever(
+        search_type="similarity_score_threshold",
+        search_kwargs={"k": 3, "score_threshold": 0.0},
+    )
+    docs = retriever.invoke("alpha")
+    # All scores should be >= threshold (relevance in [0, 1] >= 0).
+    assert len(docs) >= 1
+
+
 def test_dump_and_load_empty_store(tmp_path):
     # When no documents have been added the underlying IdMapIndex is in
     # its lazy-uncommitted state (dim=None). dump/load must round-trip

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -178,19 +178,39 @@ def test_dump_and_load_roundtrip(tmp_path):
     )
     store.dump(tmp_path)
 
-    loaded = TurboQuantVectorStore.load(
-        tmp_path, emb, allow_dangerous_deserialization=True
-    )
+    loaded = TurboQuantVectorStore.load(tmp_path, emb)
     assert len(loaded._docs) == 3
     results = loaded.similarity_search("one", k=3)
     assert {doc.page_content for doc in results} == {"one", "two", "three"}
 
 
-def test_load_refuses_without_flag(tmp_path):
+def test_dump_writes_json_sidecar(tmp_path):
+    # Side-car is plain JSON. A reviewer auditing a turbovec-saved store
+    # should be able to read it with a text editor.
+    import json
+
     emb = StubEmbeddings(dim=64)
     store = TurboQuantVectorStore.from_texts(["x"], emb, bit_width=4)
     store.dump(tmp_path)
-    with pytest.raises(ValueError, match="allow_dangerous_deserialization"):
+    assert (tmp_path / "docstore.json").exists()
+    assert not (tmp_path / "docstore.pkl").exists()
+    with open(tmp_path / "docstore.json") as f:
+        data = json.load(f)
+    assert data["schema_version"] >= 1
+
+
+def test_load_rejects_unknown_schema_version(tmp_path):
+    import json
+
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(["x"], emb, bit_width=4)
+    store.dump(tmp_path)
+    with open(tmp_path / "docstore.json") as f:
+        data = json.load(f)
+    data["schema_version"] = 99
+    with open(tmp_path / "docstore.json", "w") as f:
+        json.dump(data, f)
+    with pytest.raises(ValueError, match="schema version"):
         TurboQuantVectorStore.load(tmp_path, emb)
 
 
@@ -481,9 +501,7 @@ def test_dump_and_load_empty_store(tmp_path):
     emb = StubEmbeddings(dim=64)
     store = TurboQuantVectorStore(emb, bit_width=2)
     store.dump(tmp_path)
-    loaded = TurboQuantVectorStore.load(
-        tmp_path, emb, allow_dangerous_deserialization=True
-    )
+    loaded = TurboQuantVectorStore.load(tmp_path, emb)
     assert loaded._index.dim is None
     assert loaded._index.bit_width == 2
     # Subsequent search returns empty; subsequent add commits the dim.

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -149,7 +149,7 @@ def test_metadata_roundtrip():
 
 def test_add_texts_uses_provided_ids():
     emb = StubEmbeddings(dim=64)
-    store = TurboQuantVectorStore.from_texts([], emb, dim=64, bit_width=4)
+    store = TurboQuantVectorStore.from_texts([], emb, bit_width=4)
     returned = store.add_texts(["x", "y"], ids=["id-x", "id-y"])
     assert returned == ["id-x", "id-y"]
     assert set(store._docs.keys()) == {"id-x", "id-y"}
@@ -164,11 +164,11 @@ def test_k_larger_than_ntotal_is_clamped():
 
 def test_empty_store_search_returns_empty():
     emb = StubEmbeddings(dim=64)
-    store = TurboQuantVectorStore.from_texts([], emb, dim=64, bit_width=4)
+    store = TurboQuantVectorStore.from_texts([], emb, bit_width=4)
     assert store.similarity_search("anything", k=5) == []
 
 
-def test_save_and_load_roundtrip(tmp_path):
+def test_dump_and_load_roundtrip(tmp_path):
     emb = StubEmbeddings(dim=64)
     store = TurboQuantVectorStore.from_texts(
         ["one", "two", "three"],
@@ -176,9 +176,9 @@ def test_save_and_load_roundtrip(tmp_path):
         metadatas=[{"n": 1}, {"n": 2}, {"n": 3}],
         bit_width=4,
     )
-    store.save_local(tmp_path)
+    store.dump(tmp_path)
 
-    loaded = TurboQuantVectorStore.load_local(
+    loaded = TurboQuantVectorStore.load(
         tmp_path, emb, allow_dangerous_deserialization=True
     )
     assert len(loaded._docs) == 3
@@ -186,15 +186,16 @@ def test_save_and_load_roundtrip(tmp_path):
     assert {doc.page_content for doc in results} == {"one", "two", "three"}
 
 
-def test_load_local_refuses_without_flag(tmp_path):
+def test_load_refuses_without_flag(tmp_path):
     emb = StubEmbeddings(dim=64)
     store = TurboQuantVectorStore.from_texts(["x"], emb, bit_width=4)
-    store.save_local(tmp_path)
+    store.dump(tmp_path)
     with pytest.raises(ValueError, match="allow_dangerous_deserialization"):
-        TurboQuantVectorStore.load_local(tmp_path, emb)
+        TurboQuantVectorStore.load(tmp_path, emb)
 
 
-def test_delete_removes_documents_and_returns_true():
+def test_delete_removes_documents_returns_none():
+    # Match InMemoryVectorStore convention: delete returns None.
     emb = StubEmbeddings(dim=64)
     store = TurboQuantVectorStore.from_texts(
         ["apple", "banana", "cherry"],
@@ -202,26 +203,32 @@ def test_delete_removes_documents_and_returns_true():
         ids=["a", "b", "c"],
         bit_width=4,
     )
-    assert store.delete(["b"]) is True
+    result = store.delete(["b"])
+    assert result is None
     assert set(store._docs.keys()) == {"a", "c"}
     assert len(store._index) == 2
 
 
-def test_delete_returns_false_when_any_id_missing():
+def test_delete_missing_ids_silently_skips():
+    # Match InMemoryVectorStore convention: missing ids are silently
+    # skipped, no error.
     emb = StubEmbeddings(dim=64)
     store = TurboQuantVectorStore.from_texts(
         ["a", "b"], emb, ids=["id-a", "id-b"], bit_width=4
     )
-    assert store.delete(["id-a", "ghost"]) is False
-    # The existing id was still removed.
+    assert store.delete(["id-a", "ghost"]) is None
     assert "id-a" not in store._docs
+    assert "id-b" in store._docs
 
 
-def test_delete_none_ids_raises():
+def test_delete_none_ids_is_noop():
+    # InMemoryVectorStore treats `delete(None)` as a no-op rather than
+    # raising. Match that.
     emb = StubEmbeddings(dim=64)
     store = TurboQuantVectorStore.from_texts(["x"], emb, bit_width=4)
-    with pytest.raises(ValueError, match="explicit list of ids"):
-        store.delete(None)
+    assert store.delete(None) is None
+    assert "x" not in store._docs  # uuid-based ids, but the store has 1 doc
+    assert len(store._docs) == 1
 
 
 def test_add_texts_upsert_replaces_existing_id():
@@ -240,3 +247,189 @@ def test_mismatched_dim_raises():
     store = TurboQuantVectorStore(emb, index=IdMapIndex(32, 4))
     with pytest.raises(ValueError, match="embedding dimension"):
         store.add_texts(["hi"])
+
+
+# ---- Lazy index construction (Tier 4) -------------------------------------
+
+def test_constructor_no_index_is_lazy():
+    # Without an `index`, the store can be constructed; the underlying
+    # IdMapIndex is created on the first add.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore(emb)
+    assert store._index is None
+    # Search before any add returns empty rather than raising.
+    assert store.similarity_search("anything", k=3) == []
+
+
+def test_lazy_index_created_on_first_add():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore(emb, bit_width=2)
+    store.add_texts(["hello"])
+    assert store._index is not None
+    assert store._index.dim == 64
+    assert store._index.bit_width == 2
+
+
+def test_from_texts_no_dim_arg_required():
+    # Tier 4: dim is inferred from the embedding model, no explicit param.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["one", "two"], emb, bit_width=4
+    )
+    assert store._index.dim == 64
+
+
+# ---- get_by_ids -----------------------------------------------------------
+
+def test_get_by_ids_returns_documents():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["a", "b", "c"], emb,
+        metadatas=[{"n": 1}, {"n": 2}, {"n": 3}],
+        ids=["id-a", "id-b", "id-c"],
+        bit_width=4,
+    )
+    docs = store.get_by_ids(["id-a", "id-c"])
+    assert {d.id for d in docs} == {"id-a", "id-c"}
+    assert {d.metadata["n"] for d in docs} == {1, 3}
+
+
+def test_get_by_ids_silently_skips_missing():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["a"], emb, ids=["id-a"], bit_width=4
+    )
+    docs = store.get_by_ids(["id-a", "id-missing"])
+    assert len(docs) == 1
+    assert docs[0].id == "id-a"
+
+
+# ---- Relevance score normalization ----------------------------------------
+
+def test_select_relevance_score_fn_maps_to_unit_interval():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(["hello"], emb, bit_width=4)
+    fn = store._select_relevance_score_fn()
+    # Cosine similarity in [-1, 1] → relevance in [0, 1].
+    assert fn(-1.0) == 0.0
+    assert fn(0.0) == 0.5
+    assert fn(1.0) == 1.0
+
+
+def test_similarity_search_with_relevance_scores_in_zero_one():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["one", "two", "three"], emb, bit_width=4
+    )
+    results = store.similarity_search_with_relevance_scores("one", k=3)
+    assert len(results) == 3
+    for _doc, score in results:
+        assert 0.0 <= score <= 1.0
+
+
+# ---- MMR raises with explanation ------------------------------------------
+
+def test_max_marginal_relevance_search_raises_with_message():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(["a", "b"], emb, bit_width=4)
+    with pytest.raises(NotImplementedError, match="full-precision"):
+        store.max_marginal_relevance_search("a", k=2)
+
+
+def test_max_marginal_relevance_search_by_vector_raises():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(["a", "b"], emb, bit_width=4)
+    with pytest.raises(NotImplementedError, match="full-precision"):
+        store.max_marginal_relevance_search_by_vector(emb._embed("a"), k=2)
+
+
+# ---- add_documents partial-id support ------------------------------------
+
+def test_add_documents_honors_partial_ids():
+    # Tier 3: per-Document fallback — Documents with .id set keep their
+    # id, others get a UUID. Base-class default (without override) would
+    # drop all ids if any Document had .id=None.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore(emb)
+    docs = [
+        Document(id="explicit-1", page_content="a"),
+        Document(page_content="b"),  # no id → UUID
+        Document(id="explicit-2", page_content="c"),
+    ]
+    returned_ids = store.add_documents(docs)
+    assert "explicit-1" in returned_ids
+    assert "explicit-2" in returned_ids
+    # The UUID-generated id is some non-explicit string.
+    uuid_id = [i for i in returned_ids if i not in ("explicit-1", "explicit-2")]
+    assert len(uuid_id) == 1
+
+
+# ---- Async surfaces -------------------------------------------------------
+
+def test_async_add_search_delete():
+    import asyncio
+
+    async def runner():
+        emb = StubEmbeddings(dim=64)
+        store = TurboQuantVectorStore(emb)
+        ids = await store.aadd_texts(["alpha", "beta", "gamma"])
+        assert len(ids) == 3
+        results = await store.asimilarity_search("alpha", k=2)
+        assert len(results) == 2
+        scored = await store.asimilarity_search_with_score("alpha", k=2)
+        assert len(scored) == 2 and isinstance(scored[0][1], float)
+        by_vec = await store.asimilarity_search_by_vector(emb._embed("alpha"), k=1)
+        assert len(by_vec) == 1
+        got = await store.aget_by_ids(ids)
+        assert len(got) == 3
+        await store.adelete([ids[0]])
+        assert ids[0] not in store._docs
+
+    asyncio.run(runner())
+
+
+def test_async_add_documents_and_afrom_texts():
+    import asyncio
+
+    async def runner():
+        emb = StubEmbeddings(dim=64)
+        store = await TurboQuantVectorStore.afrom_texts(
+            ["x", "y"], emb, bit_width=4
+        )
+        assert len(store._docs) == 2
+        await store.aadd_documents([Document(page_content="z")])
+        assert len(store._docs) == 3
+
+    asyncio.run(runner())
+
+
+def test_async_mmr_raises():
+    import asyncio
+
+    async def runner():
+        emb = StubEmbeddings(dim=64)
+        store = await TurboQuantVectorStore.afrom_texts(["x"], emb, bit_width=4)
+        with pytest.raises(NotImplementedError, match="full-precision"):
+            await store.amax_marginal_relevance_search("x", k=1)
+
+    asyncio.run(runner())
+
+
+# ---- Empty-store persistence round-trip (lazy index) ---------------------
+
+def test_dump_and_load_empty_store(tmp_path):
+    # When no documents have been added the underlying IdMapIndex doesn't
+    # exist yet. dump/load must handle that without writing a phantom
+    # index file or crashing on load.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore(emb, bit_width=2)
+    store.dump(tmp_path)
+    loaded = TurboQuantVectorStore.load(
+        tmp_path, emb, allow_dangerous_deserialization=True
+    )
+    assert loaded._index is None
+    assert loaded._bit_width == 2
+    # Subsequent search returns empty; subsequent add creates the index.
+    assert loaded.similarity_search("anything", k=1) == []
+    loaded.add_texts(["new"])
+    assert loaded._index is not None

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -55,6 +55,69 @@ def test_similarity_search_returns_documents():
     assert all(isinstance(r, Document) for r in results)
 
 
+def test_similarity_search_with_dict_filter():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["alpha", "beta", "gamma", "delta", "epsilon"],
+        emb,
+        metadatas=[
+            {"tier": "free"},
+            {"tier": "pro"},
+            {"tier": "free"},
+            {"tier": "pro"},
+            {"tier": "pro"},
+        ],
+        bit_width=4,
+    )
+    results = store.similarity_search("alpha", k=10, filter={"tier": "pro"})
+    assert len(results) == 3
+    assert all(r.metadata["tier"] == "pro" for r in results)
+
+
+def test_similarity_search_with_callable_filter():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["a", "b", "c", "d"],
+        emb,
+        metadatas=[{"n": 1}, {"n": 2}, {"n": 3}, {"n": 4}],
+        bit_width=4,
+    )
+    results = store.similarity_search(
+        "a", k=10, filter=lambda meta: meta.get("n", 0) > 2
+    )
+    assert {r.metadata["n"] for r in results} == {3, 4}
+
+
+def test_similarity_search_filter_with_scores():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["a", "b", "c"],
+        emb,
+        metadatas=[{"k": 1}, {"k": 2}, {"k": 1}],
+        bit_width=4,
+    )
+    results = store.similarity_search_with_score("a", k=10, filter={"k": 1})
+    assert len(results) == 2
+    for doc, score in results:
+        assert doc.metadata["k"] == 1
+        assert isinstance(score, float)
+
+
+def test_similarity_search_filter_no_matches_returns_empty():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["a", "b"], emb, metadatas=[{"k": 1}, {"k": 2}], bit_width=4
+    )
+    assert store.similarity_search("a", k=5, filter={"k": 999}) == []
+
+
+def test_similarity_search_filter_invalid_type_raises():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(["a"], emb, bit_width=4)
+    with pytest.raises(TypeError):
+        store.similarity_search("a", k=1, filter=42)
+
+
 def test_metadata_roundtrip():
     emb = StubEmbeddings(dim=64)
     store = TurboQuantVectorStore.from_texts(

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -252,20 +252,19 @@ def test_mismatched_dim_raises():
 # ---- Lazy index construction (Tier 4) -------------------------------------
 
 def test_constructor_no_index_is_lazy():
-    # Without an `index`, the store can be constructed; the underlying
-    # IdMapIndex is created on the first add.
+    # Without an `index`, the underlying IdMapIndex is constructed in its
+    # lazy-uncommitted state — `dim` is None until the first add.
     emb = StubEmbeddings(dim=64)
     store = TurboQuantVectorStore(emb)
-    assert store._index is None
+    assert store._index.dim is None
     # Search before any add returns empty rather than raising.
     assert store.similarity_search("anything", k=3) == []
 
 
-def test_lazy_index_created_on_first_add():
+def test_lazy_index_dim_locked_on_first_add():
     emb = StubEmbeddings(dim=64)
     store = TurboQuantVectorStore(emb, bit_width=2)
     store.add_texts(["hello"])
-    assert store._index is not None
     assert store._index.dim == 64
     assert store._index.bit_width == 2
 
@@ -418,18 +417,18 @@ def test_async_mmr_raises():
 # ---- Empty-store persistence round-trip (lazy index) ---------------------
 
 def test_dump_and_load_empty_store(tmp_path):
-    # When no documents have been added the underlying IdMapIndex doesn't
-    # exist yet. dump/load must handle that without writing a phantom
-    # index file or crashing on load.
+    # When no documents have been added the underlying IdMapIndex is in
+    # its lazy-uncommitted state (dim=None). dump/load must round-trip
+    # that without losing the bit_width or accidentally committing a dim.
     emb = StubEmbeddings(dim=64)
     store = TurboQuantVectorStore(emb, bit_width=2)
     store.dump(tmp_path)
     loaded = TurboQuantVectorStore.load(
         tmp_path, emb, allow_dangerous_deserialization=True
     )
-    assert loaded._index is None
-    assert loaded._bit_width == 2
-    # Subsequent search returns empty; subsequent add creates the index.
+    assert loaded._index.dim is None
+    assert loaded._index.bit_width == 2
+    # Subsequent search returns empty; subsequent add commits the dim.
     assert loaded.similarity_search("anything", k=1) == []
     loaded.add_texts(["new"])
-    assert loaded._index is not None
+    assert loaded._index.dim == 64

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -625,3 +625,76 @@ def test_async_adelete_by_ref_doc_id():
         assert len(store._nodes) == 1
 
     asyncio.run(runner())
+
+
+# ------------------- End-to-end smoke tests: framework wiring -----------
+
+def test_vector_store_index_from_vector_store_retrieve():
+    # Smoke test: build a full VectorStoreIndex on top of our store and
+    # retrieve through it. This is the canonical way users plug a vector
+    # store into a LlamaIndex pipeline (RAG, query engine, etc.), so it
+    # exercises the index/retriever glue that calls query() on us from
+    # the framework side.
+    from llama_index.core import VectorStoreIndex, StorageContext
+    from llama_index.core.embeddings import MockEmbedding
+    from llama_index.core.schema import TextNode as LITextNode
+
+    embed_model = MockEmbedding(embed_dim=64)
+    store = TurboQuantVectorStore.from_params(bit_width=4)
+
+    # Build nodes with embeddings (MockEmbedding is deterministic).
+    nodes = []
+    for i, text in enumerate(["alpha doc", "beta doc", "gamma doc"]):
+        node = LITextNode(text=text, id_=f"n-{i}")
+        node.embedding = embed_model.get_text_embedding(text)
+        nodes.append(node)
+    store.add(nodes)
+
+    storage_context = StorageContext.from_defaults(vector_store=store)
+    index = VectorStoreIndex(nodes=[], storage_context=storage_context, embed_model=embed_model)
+    retriever = index.as_retriever(similarity_top_k=2)
+    results = retriever.retrieve("alpha")
+    assert len(results) == 2
+    # Returned NodeWithScore objects wrap our TextNodes.
+    assert all(r.score is not None for r in results)
+    contents = {r.node.get_content() for r in results}
+    assert contents.issubset({"alpha doc", "beta doc", "gamma doc"})
+
+
+def test_storage_context_persist_and_load_roundtrip(tmp_path):
+    # Smoke test: persist via StorageContext, reload via StorageContext.
+    # This is the path real LlamaIndex users follow, and it depends on
+    # our from_persist_dir + persist signature matching the framework's
+    # expectations.
+    from llama_index.core import VectorStoreIndex, StorageContext
+    from llama_index.core.embeddings import MockEmbedding
+    from llama_index.core.schema import TextNode as LITextNode
+
+    embed_model = MockEmbedding(embed_dim=64)
+    persist_dir = tmp_path / "storage"
+
+    # Build, persist.
+    store = TurboQuantVectorStore.from_params(bit_width=4)
+    nodes = []
+    for i, text in enumerate(["one", "two", "three"]):
+        node = LITextNode(text=text, id_=f"n-{i}")
+        node.embedding = embed_model.get_text_embedding(text)
+        nodes.append(node)
+    store.add(nodes)
+
+    storage_context = StorageContext.from_defaults(vector_store=store)
+    storage_context.persist(persist_dir=str(persist_dir))
+
+    # Reload via the from_persist_dir path.
+    reloaded_store = TurboQuantVectorStore.from_persist_dir(str(persist_dir))
+    assert len(reloaded_store._nodes) == 3
+    # Original query still works after reload.
+    storage_context2 = StorageContext.from_defaults(
+        vector_store=reloaded_store, persist_dir=str(persist_dir),
+    )
+    index = VectorStoreIndex(
+        nodes=[], storage_context=storage_context2, embed_model=embed_model,
+    )
+    retriever = index.as_retriever(similarity_top_k=2)
+    results = retriever.retrieve("one")
+    assert len(results) == 2

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -296,18 +296,109 @@ def test_query_filter_selective_returns_top_k_from_matches():
     assert all(n.metadata["tag"] == "needle" for n in result.nodes)
 
 
-def test_query_with_doc_ids_filter():
+def test_query_with_node_ids_filter():
+    # `node_ids` restricts to specific node_ids — matches SimpleVectorStore's
+    # canonical behaviour.
     store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
     nodes = [_make_node(f"doc {i}", seed=i) for i in range(5)]
     store.add(nodes)
-    # doc_ids restricts to specific node_ids.
     keep = [nodes[1].node_id, nodes[3].node_id]
     q = VectorStoreQuery(
-        query_embedding=_unit_vec(0, 64), similarity_top_k=5, doc_ids=keep
+        query_embedding=_unit_vec(0, 64), similarity_top_k=5, node_ids=keep
     )
     result = store.query(q)
     assert len(result.nodes) == 2
     assert {n.node_id for n in result.nodes} == set(keep)
+
+
+def test_query_with_doc_ids_filter_matches_ref_doc_id_only():
+    # `doc_ids` filters by `ref_doc_id` (source document), not node_id.
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [
+        _make_node(f"chunk {i}", seed=i, ref_doc_id=f"src-{i // 2}")
+        for i in range(6)
+    ]
+    store.add(nodes)
+    # Two source docs: src-0 (chunks 0, 1) and src-1 (chunks 2, 3).
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64),
+        similarity_top_k=10,
+        doc_ids=["src-0", "src-1"],
+    )
+    result = store.query(q)
+    assert len(result.nodes) == 4
+    # A bare node_id passed via doc_ids does NOT match; that's what node_ids
+    # is for.
+    q2 = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64),
+        similarity_top_k=10,
+        doc_ids=[nodes[0].node_id],
+    )
+    assert store.query(q2).nodes == []
+
+
+def test_query_with_node_ids_and_filters_intersect():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [
+        _make_node(f"doc {i}", seed=i, metadata={"tier": "pro" if i % 2 else "free"})
+        for i in range(6)
+    ]
+    store.add(nodes)
+    keep = [nodes[i].node_id for i in (0, 1, 2, 3)]  # narrow to first four
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="tier", value="pro", operator=FilterOperator.EQ)]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64),
+        similarity_top_k=10,
+        node_ids=keep,
+        filters=filters,
+    )
+    result = store.query(q)
+    # tier=="pro" → odd indices (1, 3, 5). Intersect with {0,1,2,3} → {1,3}.
+    assert {n.node_id for n in result.nodes} == {nodes[1].node_id, nodes[3].node_id}
+
+
+def test_query_ne_filter_treats_missing_key_as_no_match():
+    # Matches SimpleVectorStore reference: NE on a missing key returns False.
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [
+        _make_node("with", seed=0, metadata={"tier": "free"}),
+        _make_node("without", seed=1, metadata={}),  # no `tier` key
+    ]
+    store.add(nodes)
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="tier", value="pro", operator=FilterOperator.NE)]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    result = store.query(q)
+    # Only the doc with `tier=="free"` matches (free != pro). The doc with
+    # no `tier` key is NOT a match — its key is missing.
+    assert len(result.nodes) == 1
+    assert result.nodes[0].metadata.get("tier") == "free"
+
+
+def test_query_text_match_is_case_insensitive():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [
+        _make_node("a", seed=0, metadata={"title": "The Lord of the Rings"}),
+        _make_node("b", seed=1, metadata={"title": "Lord of Light"}),
+        _make_node("c", seed=2, metadata={"title": "The Hobbit"}),
+    ]
+    store.add(nodes)
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="title", value="LORD", operator=FilterOperator.TEXT_MATCH)
+        ]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    result = store.query(q)
+    titles = {n.metadata["title"] for n in result.nodes}
+    assert titles == {"The Lord of the Rings", "Lord of Light"}
 
 
 def test_query_unsupported_filter_operator_raises():

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -72,11 +72,9 @@ def test_persist_and_load_lazy_uncommitted_store(tmp_path):
     # A store that's never seen an add must round-trip through persist
     # without committing a dim or losing its bit_width.
     store = TurboQuantVectorStore(bit_width=2)
-    persist_dir = tmp_path / "lazy_store"
-    store.persist(str(persist_dir))
-    loaded = TurboQuantVectorStore.from_persist_path(
-        str(persist_dir), allow_dangerous_deserialization=True
-    )
+    persist_path = tmp_path / "lazy_store.json"
+    store.persist(str(persist_path))
+    loaded = TurboQuantVectorStore.from_persist_path(str(persist_path))
     assert loaded._index.dim is None
     assert loaded._index.bit_width == 2
     loaded.add([_make_node("post-load", seed=0)])
@@ -159,21 +157,40 @@ def test_persist_and_from_persist_path_roundtrip(tmp_path):
         _make_node("three", seed=3, metadata={"n": 3}),
     ]
     store.add(nodes)
-    store.persist(str(tmp_path))
+    persist_path = tmp_path / "store.json"
+    store.persist(str(persist_path))
 
-    loaded = TurboQuantVectorStore.from_persist_path(
-        str(tmp_path), allow_dangerous_deserialization=True
-    )
+    loaded = TurboQuantVectorStore.from_persist_path(str(persist_path))
     result = loaded.query(VectorStoreQuery(query_embedding=_unit_vec(1, 64), similarity_top_k=3))
     assert {n.get_content() for n in result.nodes} == {"one", "two", "three"}
 
 
-def test_from_persist_path_refuses_without_flag(tmp_path):
+def test_from_persist_dir_loads_default_namespace(tmp_path):
+    # StorageContext-style: a directory containing a namespaced filename.
     store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
-    store.add([_make_node("x", seed=1)])
-    store.persist(str(tmp_path))
-    with pytest.raises(ValueError, match="allow_dangerous_deserialization"):
-        TurboQuantVectorStore.from_persist_path(str(tmp_path))
+    nodes = [_make_node(f"doc {i}", seed=i) for i in range(3)]
+    store.add(nodes)
+    # Mimic StorageContext.persist's filename layout.
+    persist_path = tmp_path / "default__vector_store.json"
+    store.persist(str(persist_path))
+
+    loaded = TurboQuantVectorStore.from_persist_dir(str(tmp_path))
+    result = loaded.query(
+        VectorStoreQuery(query_embedding=_unit_vec(0, 64), similarity_top_k=3)
+    )
+    assert len(result.nodes) == 3
+
+
+def test_from_persist_dir_with_custom_namespace(tmp_path):
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([_make_node("ns-doc", seed=0)])
+    persist_path = tmp_path / "custom-ns__vector_store.json"
+    store.persist(str(persist_path))
+
+    loaded = TurboQuantVectorStore.from_persist_dir(
+        str(tmp_path), namespace="custom-ns"
+    )
+    assert len(loaded._nodes) == 1
 
 
 def test_delete_by_ref_doc_id_removes_every_matching_node():
@@ -454,3 +471,157 @@ def test_query_unsupported_filter_operator_raises():
     )
     with pytest.raises(NotImplementedError):
         store.query(q)
+
+
+# ------------------- Tier 1: protocol completeness -----------------------
+
+def test_get_raises_with_explanation():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [_make_node("a", seed=1)]
+    ids = store.add(nodes)
+    with pytest.raises(NotImplementedError, match="quantiz"):
+        store.get(ids[0])
+
+
+def test_get_nodes_by_node_ids():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [_make_node(f"doc {i}", seed=i) for i in range(3)]
+    ids = store.add(nodes)
+    fetched = store.get_nodes(node_ids=[ids[0], ids[2]])
+    assert {n.node_id for n in fetched} == {ids[0], ids[2]}
+    # Missing ids are silently skipped, matching SimpleVectorStore-ish convention.
+    fetched = store.get_nodes(node_ids=[ids[0], "nonexistent"])
+    assert {n.node_id for n in fetched} == {ids[0]}
+
+
+def test_get_nodes_by_filters():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [
+        _make_node(f"doc {i}", seed=i, metadata={"tier": "pro" if i % 2 else "free"})
+        for i in range(4)
+    ]
+    store.add(nodes)
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="tier", value="pro", operator=FilterOperator.EQ)]
+    )
+    fetched = store.get_nodes(filters=filters)
+    assert len(fetched) == 2
+    assert all(n.metadata["tier"] == "pro" for n in fetched)
+
+
+def test_get_nodes_intersects_node_ids_and_filters():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [
+        _make_node(f"doc {i}", seed=i, metadata={"tier": "pro" if i % 2 else "free"})
+        for i in range(4)
+    ]
+    ids = store.add(nodes)
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="tier", value="pro", operator=FilterOperator.EQ)]
+    )
+    fetched = store.get_nodes(node_ids=[ids[0], ids[1]], filters=filters)
+    # tier==pro is odd indices → {ids[1], ids[3]}. Intersect with {ids[0], ids[1]} → {ids[1]}.
+    assert [n.node_id for n in fetched] == [ids[1]]
+
+
+def test_get_nodes_empty_filter_returns_all():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [_make_node(f"doc {i}", seed=i) for i in range(3)]
+    store.add(nodes)
+    fetched = store.get_nodes()
+    assert len(fetched) == 3
+
+
+def test_clear_resets_store():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=2)
+    store.add([_make_node(f"doc {i}", seed=i) for i in range(3)])
+    assert len(store._nodes) == 3
+    store.clear()
+    assert len(store._nodes) == 0
+    assert len(store._index) == 0
+    # bit_width is preserved across clear; dim resets to lazy.
+    assert store._index.bit_width == 2
+    assert store._index.dim is None
+    # The cleared store is still usable.
+    store.add([_make_node("post-clear", seed=0)])
+    assert len(store._nodes) == 1
+
+
+def test_delete_nodes_with_filters():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [
+        _make_node(f"doc {i}", seed=i, metadata={"tier": "pro" if i % 2 else "free"})
+        for i in range(4)
+    ]
+    store.add(nodes)
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="tier", value="pro", operator=FilterOperator.EQ)]
+    )
+    store.delete_nodes(filters=filters)
+    assert len(store._nodes) == 2
+    assert all(data["metadata"]["tier"] == "free" for data in store._nodes.values())
+
+
+def test_delete_nodes_no_args_is_noop():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([_make_node("a", seed=1)])
+    store.delete_nodes()
+    assert len(store._nodes) == 1
+
+
+def test_to_dict_from_dict_roundtrip():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=2)
+    cfg = store.to_dict()
+    assert cfg["bit_width"] == 2
+    assert cfg["dim"] == 64
+    restored = TurboQuantVectorStore.from_dict(cfg)
+    assert restored._index.dim == 64
+    assert restored._index.bit_width == 2
+
+
+def test_to_dict_from_dict_lazy_store():
+    store = TurboQuantVectorStore(bit_width=2)
+    cfg = store.to_dict()
+    assert cfg["dim"] is None
+    restored = TurboQuantVectorStore.from_dict(cfg)
+    assert restored._index.dim is None
+    assert restored._index.bit_width == 2
+
+
+# ------------------- Tier 2: async overrides -----------------------------
+
+def test_async_add_query_delete_clear_get():
+    import asyncio
+
+    async def runner():
+        store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+        nodes = [_make_node(f"doc {i}", seed=i) for i in range(3)]
+        await store.async_add(nodes)
+        result = await store.aquery(
+            VectorStoreQuery(query_embedding=_unit_vec(0, 64), similarity_top_k=3)
+        )
+        assert len(result.nodes) == 3
+        fetched = await store.aget_nodes(node_ids=[n.node_id for n in nodes[:2]])
+        assert len(fetched) == 2
+        await store.adelete_nodes(node_ids=[nodes[0].node_id])
+        assert len(store._nodes) == 2
+        await store.aclear()
+        assert len(store._nodes) == 0
+
+    asyncio.run(runner())
+
+
+def test_async_adelete_by_ref_doc_id():
+    import asyncio
+
+    async def runner():
+        store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+        store.add([
+            _make_node("a", seed=1, ref_doc_id="parent"),
+            _make_node("b", seed=2, ref_doc_id="parent"),
+            _make_node("c", seed=3, ref_doc_id="other"),
+        ])
+        await store.adelete("parent")
+        assert len(store._nodes) == 1
+
+    asyncio.run(runner())

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -6,7 +6,13 @@ import pytest
 pytest.importorskip("llama_index.core")
 
 from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
-from llama_index.core.vector_stores.types import VectorStoreQuery
+from llama_index.core.vector_stores.types import (
+    FilterCondition,
+    FilterOperator,
+    MetadataFilter,
+    MetadataFilters,
+    VectorStoreQuery,
+)
 
 from turbovec import IdMapIndex
 from turbovec.llama_index import TurboQuantVectorStore
@@ -175,3 +181,143 @@ def test_add_upsert_replaces_same_node_id():
     assert len(store._index) == 1
     result = store.query(VectorStoreQuery(query_embedding=_unit_vec(2, 64), similarity_top_k=1))
     assert result.nodes[0].get_content() == "v2"
+
+
+# ------------------- Filtered query -------------------
+
+def _store_with_tiered_nodes() -> TurboQuantVectorStore:
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [
+        _make_node(f"doc {i}", seed=i, metadata={"tier": tier, "idx": i})
+        for i, tier in enumerate(["free", "pro", "free", "pro", "enterprise"])
+    ]
+    store.add(nodes)
+    return store
+
+
+def test_query_with_eq_filter():
+    store = _store_with_tiered_nodes()
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="tier", value="pro", operator=FilterOperator.EQ)]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    result = store.query(q)
+    assert len(result.nodes) == 2
+    assert all(n.metadata["tier"] == "pro" for n in result.nodes)
+
+
+def test_query_with_in_filter():
+    store = _store_with_tiered_nodes()
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(
+                key="tier", value=["pro", "enterprise"], operator=FilterOperator.IN
+            )
+        ]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    result = store.query(q)
+    assert len(result.nodes) == 3
+    assert all(n.metadata["tier"] in {"pro", "enterprise"} for n in result.nodes)
+
+
+def test_query_with_and_filter():
+    store = _store_with_tiered_nodes()
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="tier", value="pro", operator=FilterOperator.EQ),
+            MetadataFilter(key="idx", value=2, operator=FilterOperator.GT),
+        ],
+        condition=FilterCondition.AND,
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    result = store.query(q)
+    # tier=="pro" matches idx 1, 3; combined with idx > 2 leaves only idx=3.
+    assert len(result.nodes) == 1
+    assert result.nodes[0].metadata["idx"] == 3
+
+
+def test_query_with_or_filter():
+    store = _store_with_tiered_nodes()
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="tier", value="enterprise", operator=FilterOperator.EQ),
+            MetadataFilter(key="idx", value=0, operator=FilterOperator.EQ),
+        ],
+        condition=FilterCondition.OR,
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    result = store.query(q)
+    # enterprise = idx 4, OR idx==0 → 2 nodes total.
+    assert len(result.nodes) == 2
+    idxs = {n.metadata["idx"] for n in result.nodes}
+    assert idxs == {0, 4}
+
+
+def test_query_filter_no_matches_returns_empty():
+    store = _store_with_tiered_nodes()
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="tier", value="nonexistent", operator=FilterOperator.EQ)]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=5, filters=filters
+    )
+    result = store.query(q)
+    assert result.nodes == []
+    assert result.similarities == []
+    assert result.ids == []
+
+
+def test_query_filter_selective_returns_top_k_from_matches():
+    # 50 nodes, filter selects 3 — we must return all 3 even when top_k=3
+    # and the matching nodes wouldn't be in the unfiltered top-3.
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [
+        _make_node(f"doc {i}", seed=i, metadata={"tag": "needle" if i in (7, 23, 41) else "hay"})
+        for i in range(50)
+    ]
+    store.add(nodes)
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="tag", value="needle", operator=FilterOperator.EQ)]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=3, filters=filters
+    )
+    result = store.query(q)
+    assert len(result.nodes) == 3
+    assert all(n.metadata["tag"] == "needle" for n in result.nodes)
+
+
+def test_query_with_doc_ids_filter():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [_make_node(f"doc {i}", seed=i) for i in range(5)]
+    store.add(nodes)
+    # doc_ids restricts to specific node_ids.
+    keep = [nodes[1].node_id, nodes[3].node_id]
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=5, doc_ids=keep
+    )
+    result = store.query(q)
+    assert len(result.nodes) == 2
+    assert {n.node_id for n in result.nodes} == set(keep)
+
+
+def test_query_unsupported_filter_operator_raises():
+    store = _store_with_tiered_nodes()
+    # ANY is intentionally not in our supported list.
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="tier", value=["pro"], operator=FilterOperator.ANY)]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=3, filters=filters
+    )
+    with pytest.raises(NotImplementedError):
+        store.query(q)

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -41,6 +41,48 @@ def test_from_params_creates_index():
     assert store.is_embedding_query is True
 
 
+# ---- Lazy index construction --------------------------------------------
+
+def test_constructor_no_index_is_lazy():
+    # No-arg construction yields a lazy-uncommitted IdMapIndex.
+    store = TurboQuantVectorStore()
+    assert store._index.dim is None
+    # Query before any add returns an empty result.
+    result = store.query(
+        VectorStoreQuery(query_embedding=_unit_vec(0, 64), similarity_top_k=3)
+    )
+    assert result.nodes == []
+    assert result.similarities == []
+    assert result.ids == []
+
+
+def test_lazy_dim_locked_on_first_add():
+    store = TurboQuantVectorStore(bit_width=2)
+    store.add([_make_node("x", seed=0)])
+    assert store._index.dim == 64
+    assert store._index.bit_width == 2
+
+
+def test_from_params_without_dim_is_lazy():
+    store = TurboQuantVectorStore.from_params(bit_width=4)
+    assert store._index.dim is None
+
+
+def test_persist_and_load_lazy_uncommitted_store(tmp_path):
+    # A store that's never seen an add must round-trip through persist
+    # without committing a dim or losing its bit_width.
+    store = TurboQuantVectorStore(bit_width=2)
+    persist_dir = tmp_path / "lazy_store"
+    store.persist(str(persist_dir))
+    loaded = TurboQuantVectorStore.from_persist_path(
+        str(persist_dir), allow_dangerous_deserialization=True
+    )
+    assert loaded._index.dim is None
+    assert loaded._index.bit_width == 2
+    loaded.add([_make_node("post-load", seed=0)])
+    assert loaded._index.dim == 64
+
+
 def test_add_and_query_returns_nodes():
     store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
     nodes = [_make_node(f"doc {i}", seed=i) for i in range(5)]

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -52,6 +52,8 @@ pub struct IdMapIndex {
 }
 
 impl IdMapIndex {
+    /// Construct an id-map index with a known dim. The dim is locked at
+    /// construction.
     pub fn new(dim: usize, bit_width: usize) -> Self {
         Self {
             inner: TurboQuantIndex::new(dim, bit_width),
@@ -60,12 +62,40 @@ impl IdMapIndex {
         }
     }
 
+    /// Construct an empty id-map index without committing to a dim. The
+    /// dim is inferred and locked on the first [`Self::add_with_ids_2d`]
+    /// call.
+    pub fn new_lazy(bit_width: usize) -> Self {
+        Self {
+            inner: TurboQuantIndex::new_lazy(bit_width),
+            slot_to_id: Vec::new(),
+            id_to_slot: HashMap::new(),
+        }
+    }
+
     /// Add `n = vectors.len() / dim` vectors with the given external ids.
+    /// Requires the inner index's dim to already be set (eager constructor
+    /// or a previous lazy add).
     ///
     /// Panics if `ids.len() != n`, if any id is already present in the
-    /// index, or if `ids` contains duplicates within this call.
+    /// index, if `ids` contains duplicates within this call, or if the
+    /// inner index is still in lazy/uninitialized state.
     pub fn add_with_ids(&mut self, vectors: &[f32], ids: &[u64]) {
-        let dim = self.inner.dim();
+        let dim = self.inner.dim_opt().expect(
+            "IdMapIndex dim is not set; use add_with_ids_2d(vectors, dim, ids) \
+             on the first add or construct with IdMapIndex::new(dim, bit_width)",
+        );
+        self.add_with_ids_2d(vectors, dim, ids);
+    }
+
+    /// Add `vectors` of dimensionality `dim` with the given external ids.
+    /// On a lazy index this locks the dim; on an already-dim'd index
+    /// `dim` must match.
+    ///
+    /// This is the form bindings with shape information (e.g. the Python
+    /// binding receiving a 2D ndarray) should use, since a flat
+    /// `&[f32]` alone is ambiguous about shape.
+    pub fn add_with_ids_2d(&mut self, vectors: &[f32], dim: usize, ids: &[u64]) {
         let n = vectors.len() / dim;
         assert_eq!(
             vectors.len(),
@@ -94,7 +124,7 @@ impl IdMapIndex {
         }
         self.slot_to_id.extend_from_slice(ids);
 
-        self.inner.add(vectors);
+        self.inner.add_2d(vectors, dim);
     }
 
     /// Remove the vector with the given external id.
@@ -192,8 +222,16 @@ impl IdMapIndex {
         self.slot_to_id.is_empty()
     }
 
+    /// Vector dimensionality, or `0` if the index is lazy and hasn't
+    /// seen an add yet (matches [`TurboQuantIndex::dim`] semantics).
     pub fn dim(&self) -> usize {
         self.inner.dim()
+    }
+
+    /// Vector dimensionality as an [`Option`], where `None` means the
+    /// index is lazy and uncommitted.
+    pub fn dim_opt(&self) -> Option<usize> {
+        self.inner.dim_opt()
     }
 
     pub fn bit_width(&self) -> usize {
@@ -209,10 +247,11 @@ impl IdMapIndex {
     /// Serialize to a `.tvim` file — the inner quantized index plus the
     /// id-map side-tables. Round-trips exactly through [`Self::load`].
     pub fn write(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
+        // Mirror TurboQuantIndex::write: dim=0 means lazy-uninitialized.
         io::write_id_map(
             path,
             self.inner.bit_width(),
-            self.inner.dim(),
+            self.inner.dim_opt().unwrap_or(0),
             self.inner.len(),
             self.inner.packed_codes(),
             self.inner.norms(),
@@ -224,7 +263,8 @@ impl IdMapIndex {
     pub fn load(path: impl AsRef<Path>) -> std::io::Result<Self> {
         let (bit_width, dim, n_vectors, packed_codes, norms, slot_to_id) =
             io::load_id_map(path)?;
-        let inner = TurboQuantIndex::from_parts(dim, bit_width, n_vectors, packed_codes, norms);
+        let dim_opt = if dim == 0 { None } else { Some(dim) };
+        let inner = TurboQuantIndex::from_parts(dim_opt, bit_width, n_vectors, packed_codes, norms);
         let id_to_slot: HashMap<u64, usize> = slot_to_id
             .iter()
             .enumerate()

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -128,10 +128,43 @@ impl IdMapIndex {
     /// indices `qi * k .. (qi + 1) * k` in both arrays. Number of rows
     /// is `queries.len() / dim`.
     pub fn search(&self, queries: &[f32], k: usize) -> (Vec<f32>, Vec<u64>) {
-        let res = self.inner.search(queries, k);
-        // `res.k` may be smaller than the requested `k` if the index
-        // has fewer than `k` vectors.
-        let effective_k = res.k;
+        self.search_with_allowlist(queries, k, None)
+    }
+
+    /// Search restricted to the given `allowlist` of external ids.
+    ///
+    /// `allowlist`, when `Some`, restricts the returned top-`k` to ids in the
+    /// allowlist. The effective result count per query is
+    /// `min(k, allowlist.len())` (after de-duplication).
+    ///
+    /// Panics if `allowlist` is empty or contains an id not currently
+    /// present in the index. Duplicate ids in the allowlist are accepted
+    /// and deduplicated.
+    ///
+    /// Passing `allowlist = None` is equivalent to [`Self::search`].
+    pub fn search_with_allowlist(
+        &self,
+        queries: &[f32],
+        k: usize,
+        allowlist: Option<&[u64]>,
+    ) -> (Vec<f32>, Vec<u64>) {
+        let mask_buf: Option<Vec<bool>> = allowlist.map(|ids| {
+            assert!(!ids.is_empty(), "allowlist is empty");
+            let mut mask = vec![false; self.inner.len()];
+            for &id in ids {
+                let slot = match self.id_to_slot.get(&id) {
+                    Some(&s) => s,
+                    None => panic!("id {id} in allowlist is not present in index"),
+                };
+                mask[slot] = true;
+            }
+            mask
+        });
+
+        let res = self
+            .inner
+            .search_with_mask(queries, k, mask_buf.as_deref());
+
         let mut ids = Vec::with_capacity(res.indices.len());
         for &slot in &res.indices {
             // Inner returns i64 slot indices. Convert via slot_to_id.
@@ -143,7 +176,6 @@ impl IdMapIndex {
             let id = self.slot_to_id[slot as usize];
             ids.push(id);
         }
-        let _ = effective_k; // keep `k` in the returned vec length
         (res.scores, ids)
     }
 

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -62,7 +62,11 @@ struct BlockedCache {
 }
 
 pub struct TurboQuantIndex {
-    dim: usize,
+    /// Vector dimensionality. `None` means the index was constructed
+    /// without a known dim (lazy mode) and hasn't seen its first add yet.
+    /// Once set — either eagerly in [`Self::new`] or implicitly on the
+    /// first [`Self::add_2d`] call — it never changes.
+    dim: Option<usize>,
     bit_width: usize,
     n_vectors: usize,
     packed_codes: Vec<u8>,
@@ -101,12 +105,15 @@ impl SearchResults {
 }
 
 impl TurboQuantIndex {
+    /// Construct an index with a known dimensionality. The dim is locked
+    /// at construction; subsequent [`Self::add`] / [`Self::add_2d`] calls
+    /// must match.
     pub fn new(dim: usize, bit_width: usize) -> Self {
         assert!((2..=4).contains(&bit_width), "bit_width must be 2, 3, or 4");
         assert!(dim % 8 == 0, "dim must be a multiple of 8");
 
         Self {
-            dim,
+            dim: Some(dim),
             bit_width,
             n_vectors: 0,
             packed_codes: Vec::new(),
@@ -117,20 +124,43 @@ impl TurboQuantIndex {
         }
     }
 
+    /// Construct an empty index without committing to a dimensionality.
+    /// The dim is inferred and locked on the first [`Self::add_2d`] call
+    /// (or [`Self::add`] if the caller wires dim in separately).
+    pub fn new_lazy(bit_width: usize) -> Self {
+        assert!((2..=4).contains(&bit_width), "bit_width must be 2, 3, or 4");
+        Self {
+            dim: None,
+            bit_width,
+            n_vectors: 0,
+            packed_codes: Vec::new(),
+            norms: Vec::new(),
+            rotation: OnceLock::new(),
+            centroids: OnceLock::new(),
+            blocked: OnceLock::new(),
+        }
+    }
+
+    /// Add a flat batch of vectors. `dim` must be set (either eagerly at
+    /// construction or by a prior [`Self::add_2d`] call). Panics otherwise.
     pub fn add(&mut self, vectors: &[f32]) {
-        let n = vectors.len() / self.dim;
+        let dim = self.dim.expect(
+            "TurboQuantIndex dim is not set; use add_2d(vectors, dim) on the \
+             first add or construct via TurboQuantIndex::new(dim, bit_width)",
+        );
+        let n = vectors.len() / dim;
         assert_eq!(
             vectors.len(),
-            n * self.dim,
+            n * dim,
             "vectors length must be a multiple of dim"
         );
 
         let rotation = self
             .rotation
-            .get_or_init(|| rotation::make_rotation_matrix(self.dim));
-        let (boundaries, _) = codebook::codebook(self.bit_width, self.dim);
+            .get_or_init(|| rotation::make_rotation_matrix(dim));
+        let (boundaries, _) = codebook::codebook(self.bit_width, dim);
         let (packed, norms) =
-            encode::encode(vectors, n, self.dim, rotation, &boundaries, self.bit_width);
+            encode::encode(vectors, n, dim, rotation, &boundaries, self.bit_width);
 
         if self.n_vectors == 0 {
             self.packed_codes = packed;
@@ -146,6 +176,27 @@ impl TurboQuantIndex {
         // Rotation and centroids remain valid (they only depend on
         // `(dim, ROTATION_SEED)` and `(bit_width, dim)`).
         self.blocked = OnceLock::new();
+    }
+
+    /// Add `vectors` of dimension `dim`. On a lazy index this locks the
+    /// index dim; on an already-dim'd index `dim` must match the index's
+    /// existing dim.
+    ///
+    /// This is the form that bindings with shape information (e.g. the
+    /// Python binding receiving a 2D numpy array) should use, since a
+    /// flat `&[f32]` alone is ambiguous about its shape.
+    pub fn add_2d(&mut self, vectors: &[f32], dim: usize) {
+        match self.dim {
+            Some(existing) => assert_eq!(
+                existing, dim,
+                "dim mismatch: index dim={existing}, batch dim={dim}"
+            ),
+            None => {
+                assert!(dim % 8 == 0, "dim must be a multiple of 8");
+                self.dim = Some(dim);
+            }
+        }
+        self.add(vectors);
     }
 
     /// Run a top-`k` search against the index.
@@ -177,19 +228,31 @@ impl TurboQuantIndex {
         k: usize,
         mask: Option<&[bool]>,
     ) -> SearchResults {
-        let nq = queries.len() / self.dim;
-        assert_eq!(queries.len(), nq * self.dim);
+        // A lazy index that's never seen an add returns an empty result
+        // shaped according to the caller's query count (best effort: we
+        // don't know dim, so nq is 0). Matches Python users' expectation
+        // that `search` on an empty store is a no-op rather than an error.
+        let Some(dim) = self.dim else {
+            return SearchResults {
+                scores: Vec::new(),
+                indices: Vec::new(),
+                nq: 0,
+                k: 0,
+            };
+        };
+        let nq = queries.len() / dim;
+        assert_eq!(queries.len(), nq * dim);
 
         let rotation = self
             .rotation
-            .get_or_init(|| rotation::make_rotation_matrix(self.dim));
+            .get_or_init(|| rotation::make_rotation_matrix(dim));
         let centroids = self.centroids.get_or_init(|| {
-            let (_, c) = codebook::codebook(self.bit_width, self.dim);
+            let (_, c) = codebook::codebook(self.bit_width, dim);
             c
         });
         let blocked = self.blocked.get_or_init(|| {
             let (data, n_blocks) =
-                pack::repack(&self.packed_codes, self.n_vectors, self.bit_width, self.dim);
+                pack::repack(&self.packed_codes, self.n_vectors, self.bit_width, dim);
             BlockedCache { data, n_blocks }
         });
 
@@ -224,7 +287,7 @@ impl TurboQuantIndex {
             centroids,
             &self.norms,
             self.bit_width,
-            self.dim,
+            dim,
             self.n_vectors,
             blocked.n_blocks,
             k,
@@ -249,24 +312,32 @@ impl TurboQuantIndex {
     ///
     /// Safe to call multiple times and from multiple threads.
     pub fn prepare(&self) {
+        // On a lazy index that's seen no add, there's nothing to prepare
+        // — dim is unknown and the caches depend on it.
+        let Some(dim) = self.dim else { return };
         self.rotation
-            .get_or_init(|| rotation::make_rotation_matrix(self.dim));
+            .get_or_init(|| rotation::make_rotation_matrix(dim));
         self.centroids.get_or_init(|| {
-            let (_, c) = codebook::codebook(self.bit_width, self.dim);
+            let (_, c) = codebook::codebook(self.bit_width, dim);
             c
         });
         self.blocked.get_or_init(|| {
             let (data, n_blocks) =
-                pack::repack(&self.packed_codes, self.n_vectors, self.bit_width, self.dim);
+                pack::repack(&self.packed_codes, self.n_vectors, self.bit_width, dim);
             BlockedCache { data, n_blocks }
         });
     }
 
     pub fn write(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
+        // Sentinel: dim=0 in the file header means "lazy index, dim never
+        // committed". The loader interprets dim=0 + n_vectors=0 as a
+        // freshly-constructed lazy state. dim=0 is otherwise meaningless
+        // (the constructor asserts dim % 8 == 0 with dim >= 8), so this
+        // doesn't collide with any valid eager index.
         io::write(
             path,
             self.bit_width,
-            self.dim,
+            self.dim.unwrap_or(0),
             self.n_vectors,
             &self.packed_codes,
             &self.norms,
@@ -275,11 +346,12 @@ impl TurboQuantIndex {
 
     pub fn load(path: impl AsRef<Path>) -> std::io::Result<Self> {
         let (bit_width, dim, n_vectors, packed_codes, norms) = io::load(path)?;
-        Ok(Self::from_parts(dim, bit_width, n_vectors, packed_codes, norms))
+        let dim_opt = if dim == 0 { None } else { Some(dim) };
+        Ok(Self::from_parts(dim_opt, bit_width, n_vectors, packed_codes, norms))
     }
 
     pub(crate) fn from_parts(
-        dim: usize,
+        dim: Option<usize>,
         bit_width: usize,
         n_vectors: usize,
         packed_codes: Vec<u8>,
@@ -323,7 +395,10 @@ impl TurboQuantIndex {
             self.n_vectors
         );
 
-        let bytes_per_vec = self.dim * self.bit_width / 8;
+        // n_vectors > 0 (asserted above) implies a successful add, which
+        // implies self.dim was committed at that point. Unwrap is safe.
+        let dim = self.dim.expect("n_vectors > 0 but dim is None");
+        let bytes_per_vec = dim * self.bit_width / 8;
         let last = self.n_vectors - 1;
 
         if idx != last {
@@ -355,7 +430,18 @@ impl TurboQuantIndex {
         self.n_vectors == 0
     }
 
+    /// Vector dimensionality, or `0` if this index was constructed lazily
+    /// and hasn't seen an add yet. `0` is a safe sentinel because the
+    /// eager constructor asserts `dim >= 8` (multiple of 8). Use
+    /// [`Self::dim_opt`] when you need to distinguish "not set" from a
+    /// (nonsensical) zero.
     pub fn dim(&self) -> usize {
+        self.dim.unwrap_or(0)
+    }
+
+    /// Vector dimensionality as an [`Option`], where `None` means the
+    /// index is lazy and hasn't been committed to a dim yet.
+    pub fn dim_opt(&self) -> Option<usize> {
         self.dim
     }
 

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -160,6 +160,23 @@ impl TurboQuantIndex {
     /// pay that cost up front if you want deterministic first-query
     /// latency.
     pub fn search(&self, queries: &[f32], k: usize) -> SearchResults {
+        self.search_with_mask(queries, k, None)
+    }
+
+    /// Run a top-`k` search restricted to slots whose `mask` entry is `true`.
+    ///
+    /// `mask`, when `Some`, must have length equal to [`Self::len`]. Only
+    /// slots with `mask[i] == true` contribute to the returned top-`k`. The
+    /// effective result count per query is `min(k, n_allowed)` where
+    /// `n_allowed` is the number of `true` entries in `mask`.
+    ///
+    /// Passing `mask = None` is equivalent to [`Self::search`].
+    pub fn search_with_mask(
+        &self,
+        queries: &[f32],
+        k: usize,
+        mask: Option<&[bool]>,
+    ) -> SearchResults {
         let nq = queries.len() / self.dim;
         assert_eq!(queries.len(), nq * self.dim);
 
@@ -176,7 +193,28 @@ impl TurboQuantIndex {
             BlockedCache { data, n_blocks }
         });
 
-        let k = k.min(self.n_vectors);
+        let packed_mask = mask.map(|m| {
+            assert_eq!(
+                m.len(),
+                self.n_vectors,
+                "mask length {} does not match index size {}",
+                m.len(),
+                self.n_vectors,
+            );
+            let n_words = (self.n_vectors + 63) / 64;
+            let mut buf = vec![0u64; n_words];
+            for (i, &b) in m.iter().enumerate() {
+                if b {
+                    buf[i >> 6] |= 1u64 << (i & 63);
+                }
+            }
+            buf
+        });
+
+        let n_allowed = packed_mask.as_ref().map_or(self.n_vectors, |p| {
+            p.iter().map(|w| w.count_ones() as usize).sum::<usize>()
+        });
+        let effective_k = k.min(self.n_vectors).min(n_allowed);
 
         let (scores, indices) = search::search(
             queries,
@@ -190,13 +228,14 @@ impl TurboQuantIndex {
             self.n_vectors,
             blocked.n_blocks,
             k,
+            packed_mask.as_deref(),
         );
 
         SearchResults {
             scores,
             indices,
             nq,
-            k,
+            k: effective_k,
         }
     }
 

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -142,6 +142,7 @@ unsafe fn search_multi_query_avx2(
     n_vectors: usize,
     nq: usize,
     k: usize,
+    mask: Option<&[u64]>,
     heap_scores: &mut [Vec<f32>],
     heap_indices: &mut [Vec<u32>],
     heap_sizes: &mut [usize],
@@ -227,6 +228,9 @@ unsafe fn search_multi_query_avx2(
 
             if *sz < k {
                 for lane in 0..(end - base_vec) {
+                    if let Some(m) = mask {
+                        if !mask_allows(m, base_vec + lane) { continue; }
+                    }
                     let score = block_out[lane];
                     if *sz < k {
                         hs[*sz] = score;
@@ -258,6 +262,9 @@ unsafe fn search_multi_query_avx2(
 
                     let chunk_end = (chunk_start + 8).min(end - base_vec);
                     for lane in chunk_start..chunk_end {
+                        if let Some(m) = mask {
+                            if !mask_allows(m, base_vec + lane) { continue; }
+                        }
                         let score = block_out[lane];
                         if score > *hmin {
                             hs[*hmi] = score;
@@ -308,6 +315,7 @@ unsafe fn search_multi_query_avx512bw(
     n_vectors: usize,
     nq: usize,
     k: usize,
+    mask: Option<&[u64]>,
     heap_scores: &mut [Vec<f32>],
     heap_indices: &mut [Vec<u32>],
     heap_sizes: &mut [usize],
@@ -458,6 +466,7 @@ unsafe fn search_multi_query_avx512bw(
                 biases,
                 nq,
                 k,
+                mask,
                 heap_scores,
                 heap_indices,
                 heap_sizes,
@@ -503,6 +512,7 @@ unsafe fn search_multi_query_avx512bw(
             biases,
             nq,
             k,
+            mask,
             heap_scores,
             heap_indices,
             heap_sizes,
@@ -529,6 +539,7 @@ unsafe fn avx2_block_epilogue(
     biases: &[f32],
     nq: usize,
     k: usize,
+    mask: Option<&[u64]>,
     heap_scores: &mut [Vec<f32>],
     heap_indices: &mut [Vec<u32>],
     heap_sizes: &mut [usize],
@@ -613,6 +624,9 @@ unsafe fn avx2_block_epilogue(
                     let bit = m.trailing_zeros() as usize;
                     m &= m - 1;
                     let lane = chunk * 8 + bit;
+                    if let Some(am) = mask {
+                        if !mask_allows(am, base_vec + lane) { continue; }
+                    }
                     let score = block_out[lane];
                     // Re-check: earlier lanes in this block may have raised
                     // *hmin above what the SIMD compare saw.
@@ -651,6 +665,9 @@ unsafe fn avx2_block_epilogue(
 
         if *sz < k {
             for lane in 0..end_lane {
+                if let Some(am) = mask {
+                    if !mask_allows(am, base_vec + lane) { continue; }
+                }
                 let score = block_out[lane];
                 if *sz < k {
                     hs[*sz] = score;
@@ -682,6 +699,9 @@ unsafe fn avx2_block_epilogue(
 
                 let chunk_end = (chunk_start + 8).min(end_lane);
                 for lane in chunk_start..chunk_end {
+                    if let Some(am) = mask {
+                        if !mask_allows(am, base_vec + lane) { continue; }
+                    }
                     let score = block_out[lane];
                     if score > *hmin {
                         hs[*hmi] = score;
@@ -902,8 +922,24 @@ fn build_query_neon_lut_from_slice(
     QueryNeonLut { uint8_luts, scale, bias }
 }
 
+/// Slot-allowlist bitmask: packed little-endian, bit `i` set iff slot `i` is
+/// allowed. Caller guarantees `len * 64 >= n_vectors`. Bits at index `>=
+/// n_vectors` are ignored.
+#[inline(always)]
+pub(crate) fn mask_allows(mask: &[u64], slot: usize) -> bool {
+    // Safety: caller validates mask length against n_vectors before reaching
+    // any kernel; we never query past it in scoring loops.
+    (mask[slot >> 6] >> (slot & 63)) & 1 != 0
+}
+
 /// Full search: rotation + LUT build + scoring + heap top-k.
-/// Returns (scores_flat, indices_flat) each of length nq * k.
+///
+/// `mask`: optional packed bitset over slots (one bit per vector,
+/// little-endian within each u64). When `Some`, only slots with their bit set
+/// contribute to the top-k. The returned per-query result count is
+/// `min(k, popcount(mask))`.
+///
+/// Returns (scores_flat, indices_flat) each of length nq * effective_k.
 pub fn search(
     queries: &[f32],    // (nq, dim) row-major
     nq: usize,
@@ -916,8 +952,16 @@ pub fn search(
     n_vectors: usize,
     n_blocks: usize,
     k: usize,
+    mask: Option<&[u64]>,
 ) -> (Vec<f32>, Vec<i64>) {
-    let k = k.min(n_vectors);
+    let n_allowed = match mask {
+        Some(m) => m.iter().map(|w| w.count_ones() as usize).sum::<usize>(),
+        None => n_vectors,
+    };
+    let k = k.min(n_allowed);
+    if k == 0 {
+        return (Vec::new(), Vec::new());
+    }
     let n_byte_groups = dim / (8 / bits);
 
     // Batched rotation: q_rot = queries @ rotation^T via a single GEMM.
@@ -1033,6 +1077,9 @@ pub fn search(
                         let mut heap_min = f32::NEG_INFINITY;
                         let mut heap_mi = 0usize;
                         for (i, &s) in row.iter().enumerate() {
+                            if let Some(m) = mask {
+                                if !mask_allows(m, i) { continue; }
+                            }
                             if heap_sz < k {
                                 heap_s[heap_sz] = s;
                                 heap_i[heap_sz] = i as u32;
@@ -1114,7 +1161,7 @@ pub fn search(
                         search_multi_query_avx512bw(
                             blocked_codes, &lut_refs, &scale_vals, &bias_vals,
                             n_byte_groups, norms, n_vectors,
-                            batch_nq, k,
+                            batch_nq, k, mask,
                             &mut heap_scores, &mut heap_indices,
                             &mut heap_sizes, &mut heap_mins, &mut heap_min_idxs,
                         );
@@ -1122,7 +1169,7 @@ pub fn search(
                         search_multi_query_avx2(
                             blocked_codes, &lut_refs, &scale_vals, &bias_vals,
                             n_byte_groups, norms, n_vectors,
-                            batch_nq, k,
+                            batch_nq, k, mask,
                             &mut heap_scores, &mut heap_indices,
                             &mut heap_sizes, &mut heap_mins, &mut heap_min_idxs,
                         );
@@ -1166,6 +1213,9 @@ pub fn search(
                     for lane in 0..BLOCK {
                         let vi = base_vec + lane;
                         if vi >= n_vectors { break; }
+                        if let Some(m) = mask {
+                            if !mask_allows(m, vi) { continue; }
+                        }
                         // Total bias is applied once; per-sub-table zero-points
                         // are already folded into qlut.bias at LUT build time.
                         let mut score = qlut.bias;

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -152,7 +152,10 @@ unsafe fn search_multi_query_avx2(
     use std::arch::x86_64::*;
 
     let n_blocks = (n_vectors + BLOCK - 1) / BLOCK;
-    let mask = _mm256_set1_epi8(0x0F);
+    // SIMD nibble mask; named distinctly from the `mask: Option<&[u64]>`
+    // function parameter (the slot allowlist) to avoid shadowing inside
+    // the loops below where we test the slot mask.
+    let nibble_mask = _mm256_set1_epi8(0x0F);
     let codes_base = blocked_codes.as_ptr();
 
     for b in 0..n_blocks {
@@ -162,8 +165,8 @@ unsafe fn search_multi_query_avx2(
         for g in 0..n_byte_groups {
             let cp = codes_base.add((b * n_byte_groups + g) * BLOCK);
             let codes_v = _mm256_loadu_si256(cp as *const __m256i);
-            let clo = _mm256_and_si256(codes_v, mask);
-            let chi = _mm256_and_si256(_mm256_srli_epi16(codes_v, 4), mask);
+            let clo = _mm256_and_si256(codes_v, nibble_mask);
+            let chi = _mm256_and_si256(_mm256_srli_epi16(codes_v, 4), nibble_mask);
 
             for qi in 0..4 {
                 let lut = _mm256_loadu_si256(luts[qi].as_ptr().add(g * 32) as *const __m256i);

--- a/turbovec/tests/filtering.rs
+++ b/turbovec/tests/filtering.rs
@@ -1,0 +1,325 @@
+//! Correctness tests for slot-mask filtering on `TurboQuantIndex` and the
+//! allowlist wrapper on `IdMapIndex`.
+//!
+//! Invariants exercised:
+//!   - Masked search returns the same top-k as an unmasked search filtered
+//!     post-hoc to the same allowed set (kernel parity).
+//!   - `mask = None` and `mask = Some(all_true)` produce identical results.
+//!   - Effective k shrinks to `n_allowed` when the mask is more selective.
+//!   - Length / emptiness / unknown-id error paths panic.
+//!   - `IdMapIndex.search_with_allowlist` returns only ids in the allowlist
+//!     and never returns slot indices outside it.
+
+extern crate blas_src;
+
+use turbovec::{IdMapIndex, TurboQuantIndex};
+
+fn gaussian_normalized(n: usize, dim: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed | 1;
+    let mut next = || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    let mut uniform = || {
+        let raw = (next() >> 40) as u32 | 1;
+        raw as f32 / (1u32 << 24) as f32
+    };
+    let two_pi = 2.0_f32 * std::f32::consts::PI;
+    let mut data = vec![0.0f32; n * dim];
+    let mut i = 0;
+    while i < data.len() {
+        let u1 = uniform().max(1e-7);
+        let u2 = uniform();
+        let r = (-2.0 * u1.ln()).sqrt();
+        let theta = two_pi * u2;
+        data[i] = r * theta.cos();
+        if i + 1 < data.len() {
+            data[i + 1] = r * theta.sin();
+        }
+        i += 2;
+    }
+    for row_i in 0..n {
+        let row = &mut data[row_i * dim..(row_i + 1) * dim];
+        let norm: f32 = row.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            let inv = 1.0 / norm;
+            for x in row.iter_mut() {
+                *x *= inv;
+            }
+        }
+    }
+    data
+}
+
+fn build_index(n: usize, dim: usize, seed: u64) -> TurboQuantIndex {
+    let data = gaussian_normalized(n, dim, seed);
+    let mut idx = TurboQuantIndex::new(dim, 4);
+    idx.add(&data);
+    idx
+}
+
+/// Reference top-k under a mask: score everything, filter to allowed slots,
+/// take top-k by score.
+fn reference_topk(
+    idx: &TurboQuantIndex,
+    query: &[f32],
+    mask: &[bool],
+    k: usize,
+) -> (Vec<f32>, Vec<i64>) {
+    let n = mask.len();
+    let res = idx.search(query, n);
+    let scores = &res.scores[..res.k];
+    let indices = &res.indices[..res.k];
+    let mut filtered: Vec<(f32, i64)> = scores
+        .iter()
+        .zip(indices.iter())
+        .filter(|(_, &slot)| mask[slot as usize])
+        .map(|(&s, &i)| (s, i))
+        .collect();
+    filtered.truncate(k);
+    (
+        filtered.iter().map(|p| p.0).collect(),
+        filtered.iter().map(|p| p.1).collect(),
+    )
+}
+
+#[test]
+fn mask_matches_post_hoc_filter() {
+    let dim = 128;
+    let n = 256;
+    let idx = build_index(n, dim, 0xF11D_0001);
+    let query = gaussian_normalized(1, dim, 0xF11D_0002);
+
+    // Allow every other slot.
+    let mut mask = vec![false; n];
+    for i in 0..n {
+        if i % 2 == 0 {
+            mask[i] = true;
+        }
+    }
+
+    let masked = idx.search_with_mask(&query, 10, Some(&mask));
+    let (ref_scores, ref_indices) = reference_topk(&idx, &query, &mask, 10);
+
+    assert_eq!(masked.k, 10, "expected 10 results, got {}", masked.k);
+    assert_eq!(&masked.scores[..], &ref_scores[..], "score mismatch");
+    assert_eq!(&masked.indices[..], &ref_indices[..], "index mismatch");
+    for &slot in &masked.indices {
+        assert!(
+            mask[slot as usize],
+            "kernel returned disallowed slot {}",
+            slot
+        );
+    }
+}
+
+#[test]
+fn mask_none_equals_mask_all_true() {
+    let dim = 64;
+    let n = 200;
+    let idx = build_index(n, dim, 0xF11D_0003);
+    let query = gaussian_normalized(1, dim, 0xF11D_0004);
+
+    let unfiltered = idx.search(&query, 20);
+    let all_true = vec![true; n];
+    let filtered = idx.search_with_mask(&query, 20, Some(&all_true));
+
+    assert_eq!(unfiltered.k, filtered.k);
+    assert_eq!(&unfiltered.scores[..], &filtered.scores[..]);
+    assert_eq!(&unfiltered.indices[..], &filtered.indices[..]);
+}
+
+#[test]
+fn effective_k_shrinks_when_allowlist_smaller_than_k() {
+    let dim = 64;
+    let n = 100;
+    let idx = build_index(n, dim, 0xF11D_0005);
+    let query = gaussian_normalized(1, dim, 0xF11D_0006);
+
+    let mut mask = vec![false; n];
+    mask[3] = true;
+    mask[42] = true;
+    mask[77] = true;
+
+    let res = idx.search_with_mask(&query, 10, Some(&mask));
+    assert_eq!(res.k, 3, "effective k should be 3 (popcount of mask)");
+    assert_eq!(res.scores.len(), 3);
+    assert_eq!(res.indices.len(), 3);
+    for &slot in &res.indices {
+        assert!(mask[slot as usize]);
+    }
+}
+
+#[test]
+fn all_false_mask_returns_empty_results() {
+    let dim = 64;
+    let n = 64;
+    let idx = build_index(n, dim, 0xF11D_0007);
+    let query = gaussian_normalized(1, dim, 0xF11D_0008);
+
+    let mask = vec![false; n];
+    let res = idx.search_with_mask(&query, 5, Some(&mask));
+    assert_eq!(res.k, 0);
+    assert!(res.scores.is_empty());
+    assert!(res.indices.is_empty());
+}
+
+#[test]
+#[should_panic(expected = "mask length")]
+fn mask_length_mismatch_panics() {
+    let dim = 64;
+    let n = 50;
+    let idx = build_index(n, dim, 0xF11D_0009);
+    let query = gaussian_normalized(1, dim, 0xF11D_000A);
+
+    let wrong_len_mask = vec![true; 10];
+    let _ = idx.search_with_mask(&query, 5, Some(&wrong_len_mask));
+}
+
+#[test]
+fn multi_query_batch_respects_mask() {
+    // The x86 kernels batch queries in groups of 4. Make sure the mask is
+    // honoured for every query in a multi-query batch, including the
+    // non-power-of-4 tail.
+    let dim = 128;
+    let n = 256;
+    let nq = 7;
+    let idx = build_index(n, dim, 0xF11D_000B);
+    let queries = gaussian_normalized(nq, dim, 0xF11D_000C);
+
+    let mut mask = vec![false; n];
+    for i in 0..n {
+        if i % 3 == 0 {
+            mask[i] = true;
+        }
+    }
+
+    let res = idx.search_with_mask(&queries, 8, Some(&mask));
+    assert_eq!(res.nq, nq);
+    assert_eq!(res.k, 8);
+    assert_eq!(res.indices.len(), nq * 8);
+
+    for qi in 0..nq {
+        let row_start = qi * res.k;
+        let row = &res.indices[row_start..row_start + res.k];
+        let scores_row = &res.scores[row_start..row_start + res.k];
+        // Every returned slot must be in the allowed set.
+        for &slot in row {
+            assert!(
+                mask[slot as usize],
+                "query {qi}: kernel returned disallowed slot {slot}"
+            );
+        }
+        // Scores are returned in descending order.
+        for w in scores_row.windows(2) {
+            assert!(w[0] >= w[1], "query {qi}: scores not descending: {scores_row:?}");
+        }
+        // The fused 4-query NEON kernel and the single-query tail kernel
+        // produce scores that match within float rounding (~1e-4 relative).
+        // The reference uses the single-query path; compare scores within
+        // tolerance and indices exactly (assuming no tie-flips at this dim).
+        let query_row = &queries[qi * dim..(qi + 1) * dim];
+        let (ref_scores, ref_indices) = reference_topk(&idx, query_row, &mask, res.k);
+        assert_eq!(row, &ref_indices[..], "query {qi} index mismatch");
+        for (a, b) in scores_row.iter().zip(ref_scores.iter()) {
+            assert!(
+                (a - b).abs() <= 1e-4 * a.abs().max(b.abs()).max(1.0),
+                "query {qi}: score {a} vs reference {b}",
+            );
+        }
+    }
+}
+
+// ------------------- IdMapIndex allowlist -------------------
+
+#[test]
+fn allowlist_returns_only_listed_ids() {
+    let dim = 128;
+    let n = 100;
+    let data = gaussian_normalized(n, dim, 0xF11D_1001);
+    let ids: Vec<u64> = (0..n as u64).map(|i| 1000 + i).collect();
+    let mut idx = IdMapIndex::new(dim, 4);
+    idx.add_with_ids(&data, &ids);
+
+    let query = gaussian_normalized(1, dim, 0xF11D_1002);
+    let allowed: Vec<u64> = vec![1003, 1010, 1042, 1077, 1099];
+    let (scores, returned_ids) = idx.search_with_allowlist(&query, 10, Some(&allowed));
+
+    assert_eq!(scores.len(), allowed.len(), "effective k = allowlist len");
+    assert_eq!(returned_ids.len(), allowed.len());
+    for id in &returned_ids {
+        assert!(
+            allowed.contains(id),
+            "kernel returned id {} not in allowlist",
+            id
+        );
+    }
+}
+
+#[test]
+fn allowlist_none_equivalent_to_plain_search() {
+    let dim = 64;
+    let n = 80;
+    let data = gaussian_normalized(n, dim, 0xF11D_1003);
+    let ids: Vec<u64> = (0..n as u64).map(|i| 7000 + i * 13).collect();
+    let mut idx = IdMapIndex::new(dim, 4);
+    idx.add_with_ids(&data, &ids);
+
+    let query = gaussian_normalized(1, dim, 0xF11D_1004);
+    let (s1, i1) = idx.search(&query, 5);
+    let (s2, i2) = idx.search_with_allowlist(&query, 5, None);
+    assert_eq!(s1, s2);
+    assert_eq!(i1, i2);
+}
+
+#[test]
+#[should_panic(expected = "allowlist is empty")]
+fn empty_allowlist_panics() {
+    let dim = 64;
+    let data = gaussian_normalized(10, dim, 0xF11D_1005);
+    let ids: Vec<u64> = (0..10).collect();
+    let mut idx = IdMapIndex::new(dim, 4);
+    idx.add_with_ids(&data, &ids);
+
+    let query = gaussian_normalized(1, dim, 0xF11D_1006);
+    let _ = idx.search_with_allowlist(&query, 3, Some(&[]));
+}
+
+#[test]
+#[should_panic(expected = "not present in index")]
+fn unknown_id_in_allowlist_panics() {
+    let dim = 64;
+    let data = gaussian_normalized(10, dim, 0xF11D_1007);
+    let ids: Vec<u64> = (0..10).collect();
+    let mut idx = IdMapIndex::new(dim, 4);
+    idx.add_with_ids(&data, &ids);
+
+    let query = gaussian_normalized(1, dim, 0xF11D_1008);
+    let _ = idx.search_with_allowlist(&query, 3, Some(&[5, 999]));
+}
+
+#[test]
+fn allowlist_survives_swap_remove() {
+    // After remove(), slots shift but external ids are stable. An allowlist
+    // built against ids should keep working without rebuilding.
+    let dim = 64;
+    let n = 30;
+    let data = gaussian_normalized(n, dim, 0xF11D_1009);
+    let ids: Vec<u64> = (0..n as u64).map(|i| 5000 + i).collect();
+    let mut idx = IdMapIndex::new(dim, 4);
+    idx.add_with_ids(&data, &ids);
+
+    let allowed: Vec<u64> = vec![5005, 5015, 5020];
+    let query = gaussian_normalized(1, dim, 0xF11D_100A);
+
+    let _before = idx.search_with_allowlist(&query, 3, Some(&allowed));
+    // Removing an id NOT in the allowlist; the allowlist should remain valid.
+    assert!(idx.remove(5025));
+    let after = idx.search_with_allowlist(&query, 3, Some(&allowed));
+    assert_eq!(after.1.len(), 3);
+    for id in &after.1 {
+        assert!(allowed.contains(id));
+    }
+}

--- a/turbovec/tests/lazy_init.rs
+++ b/turbovec/tests/lazy_init.rs
@@ -1,0 +1,238 @@
+//! Tests for lazy index construction on `TurboQuantIndex` and `IdMapIndex`.
+//!
+//! Invariants exercised:
+//!   - `new_lazy(bit_width)` constructs an index with no committed dim.
+//!   - `dim_opt()` returns `None` before the first add and `Some(d)` after.
+//!   - `dim()` returns `0` as a sentinel before the first add.
+//!   - `add_2d` / `add_with_ids_2d` lock the dim on first call and require
+//!     a matching dim on subsequent calls.
+//!   - `search` on a lazy uncommitted index returns empty results (no panic).
+//!   - `prepare` on a lazy uncommitted index is a no-op.
+//!   - `add` (the dim-implicit form) panics on a lazy uncommitted index.
+//!   - File format: `write` from a lazy uncommitted index produces a file
+//!     that loads back into a lazy uncommitted state; `write` from a
+//!     committed index round-trips exactly.
+
+extern crate blas_src;
+
+use std::fs;
+use turbovec::{IdMapIndex, TurboQuantIndex};
+
+const DIM: usize = 64;
+
+fn unit_vectors(n: usize, dim: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed | 1;
+    let mut next = || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    let mut uniform = || {
+        let raw = (next() >> 40) as u32 | 1;
+        raw as f32 / (1u32 << 24) as f32
+    };
+    let two_pi = 2.0_f32 * std::f32::consts::PI;
+    let mut data = vec![0.0f32; n * dim];
+    let mut i = 0;
+    while i < data.len() {
+        let u1 = uniform().max(1e-7);
+        let u2 = uniform();
+        let r = (-2.0 * u1.ln()).sqrt();
+        let theta = two_pi * u2;
+        data[i] = r * theta.cos();
+        if i + 1 < data.len() {
+            data[i + 1] = r * theta.sin();
+        }
+        i += 2;
+    }
+    for row in 0..n {
+        let row_slice = &mut data[row * dim..(row + 1) * dim];
+        let norm: f32 = row_slice.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            let inv = 1.0 / norm;
+            for x in row_slice.iter_mut() {
+                *x *= inv;
+            }
+        }
+    }
+    data
+}
+
+// ---- TurboQuantIndex ----
+
+#[test]
+fn new_lazy_starts_with_no_dim() {
+    let idx = TurboQuantIndex::new_lazy(4);
+    assert_eq!(idx.dim_opt(), None);
+    assert_eq!(idx.dim(), 0, "dim() returns 0 as sentinel");
+    assert_eq!(idx.len(), 0);
+    assert_eq!(idx.bit_width(), 4);
+}
+
+#[test]
+fn add_2d_locks_dim_on_first_call() {
+    let mut idx = TurboQuantIndex::new_lazy(4);
+    let data = unit_vectors(3, DIM, 0xA00D_0001);
+    idx.add_2d(&data, DIM);
+    assert_eq!(idx.dim_opt(), Some(DIM));
+    assert_eq!(idx.len(), 3);
+}
+
+#[test]
+fn add_2d_subsequent_calls_must_match_dim() {
+    let mut idx = TurboQuantIndex::new_lazy(4);
+    let data1 = unit_vectors(2, DIM, 0xA00D_0002);
+    idx.add_2d(&data1, DIM);
+    let data2 = unit_vectors(2, DIM, 0xA00D_0003);
+    idx.add_2d(&data2, DIM);
+    assert_eq!(idx.len(), 4);
+}
+
+#[test]
+#[should_panic(expected = "dim mismatch")]
+fn add_2d_panics_on_dim_change() {
+    let mut idx = TurboQuantIndex::new_lazy(4);
+    let data = unit_vectors(1, DIM, 0xA00D_0004);
+    idx.add_2d(&data, DIM);
+    let wrong = unit_vectors(1, DIM * 2, 0xA00D_0005);
+    idx.add_2d(&wrong, DIM * 2);
+}
+
+#[test]
+#[should_panic(expected = "dim is not set")]
+fn plain_add_panics_on_lazy_uncommitted() {
+    let mut idx = TurboQuantIndex::new_lazy(4);
+    let data = unit_vectors(1, DIM, 0xA00D_0006);
+    idx.add(&data);
+}
+
+#[test]
+fn search_on_lazy_uncommitted_returns_empty() {
+    let idx = TurboQuantIndex::new_lazy(4);
+    let queries = unit_vectors(2, DIM, 0xA00D_0007);
+    let res = idx.search(&queries, 5);
+    assert_eq!(res.scores.len(), 0);
+    assert_eq!(res.indices.len(), 0);
+    assert_eq!(res.k, 0);
+}
+
+#[test]
+fn prepare_on_lazy_uncommitted_is_noop() {
+    let idx = TurboQuantIndex::new_lazy(4);
+    idx.prepare(); // should not panic
+}
+
+#[test]
+fn write_load_round_trip_lazy_uncommitted() {
+    let tmp = std::env::temp_dir().join("turbovec_lazy_uncommitted.tv");
+    {
+        let idx = TurboQuantIndex::new_lazy(4);
+        idx.write(&tmp).unwrap();
+    }
+    let loaded = TurboQuantIndex::load(&tmp).unwrap();
+    assert_eq!(loaded.dim_opt(), None);
+    assert_eq!(loaded.len(), 0);
+    assert_eq!(loaded.bit_width(), 4);
+    fs::remove_file(&tmp).ok();
+}
+
+#[test]
+fn write_load_round_trip_eager_index_still_works() {
+    // Regression: the dim=0 sentinel logic must not affect normal indexes.
+    let tmp = std::env::temp_dir().join("turbovec_lazy_eager.tv");
+    {
+        let mut idx = TurboQuantIndex::new(DIM, 4);
+        idx.add(&unit_vectors(4, DIM, 0xA00D_0008));
+        idx.write(&tmp).unwrap();
+    }
+    let loaded = TurboQuantIndex::load(&tmp).unwrap();
+    assert_eq!(loaded.dim_opt(), Some(DIM));
+    assert_eq!(loaded.len(), 4);
+    fs::remove_file(&tmp).ok();
+}
+
+#[test]
+fn write_load_round_trip_lazy_after_committed_add() {
+    let tmp = std::env::temp_dir().join("turbovec_lazy_committed.tv");
+    {
+        let mut idx = TurboQuantIndex::new_lazy(2);
+        idx.add_2d(&unit_vectors(3, DIM, 0xA00D_0009), DIM);
+        idx.write(&tmp).unwrap();
+    }
+    let loaded = TurboQuantIndex::load(&tmp).unwrap();
+    assert_eq!(loaded.dim_opt(), Some(DIM));
+    assert_eq!(loaded.len(), 3);
+    assert_eq!(loaded.bit_width(), 2);
+    fs::remove_file(&tmp).ok();
+}
+
+// ---- IdMapIndex ----
+
+#[test]
+fn id_map_new_lazy_starts_with_no_dim() {
+    let idx = IdMapIndex::new_lazy(4);
+    assert_eq!(idx.dim_opt(), None);
+    assert_eq!(idx.dim(), 0);
+    assert_eq!(idx.len(), 0);
+}
+
+#[test]
+fn id_map_add_with_ids_2d_locks_dim() {
+    let mut idx = IdMapIndex::new_lazy(4);
+    let data = unit_vectors(3, DIM, 0xA00D_0010);
+    let ids: Vec<u64> = vec![10, 20, 30];
+    idx.add_with_ids_2d(&data, DIM, &ids);
+    assert_eq!(idx.dim_opt(), Some(DIM));
+    assert_eq!(idx.len(), 3);
+    assert!(idx.contains(20));
+}
+
+#[test]
+#[should_panic(expected = "dim is not set")]
+fn id_map_plain_add_with_ids_panics_on_lazy_uncommitted() {
+    let mut idx = IdMapIndex::new_lazy(4);
+    let data = unit_vectors(1, DIM, 0xA00D_0011);
+    idx.add_with_ids(&data, &[42]);
+}
+
+#[test]
+fn id_map_search_on_lazy_uncommitted_returns_empty() {
+    let idx = IdMapIndex::new_lazy(4);
+    let queries = unit_vectors(1, DIM, 0xA00D_0012);
+    let (scores, ids) = idx.search(&queries, 5);
+    assert!(scores.is_empty());
+    assert!(ids.is_empty());
+}
+
+#[test]
+fn id_map_write_load_round_trip_lazy_uncommitted() {
+    let tmp = std::env::temp_dir().join("turbovec_idmap_lazy_uncommitted.tvim");
+    {
+        let idx = IdMapIndex::new_lazy(2);
+        idx.write(&tmp).unwrap();
+    }
+    let loaded = IdMapIndex::load(&tmp).unwrap();
+    assert_eq!(loaded.dim_opt(), None);
+    assert_eq!(loaded.len(), 0);
+    assert_eq!(loaded.bit_width(), 2);
+    fs::remove_file(&tmp).ok();
+}
+
+#[test]
+fn id_map_write_load_round_trip_lazy_after_committed_add() {
+    let tmp = std::env::temp_dir().join("turbovec_idmap_lazy_committed.tvim");
+    let ids: Vec<u64> = vec![100, 200, 300];
+    {
+        let mut idx = IdMapIndex::new_lazy(4);
+        idx.add_with_ids_2d(&unit_vectors(3, DIM, 0xA00D_0013), DIM, &ids);
+        idx.write(&tmp).unwrap();
+    }
+    let loaded = IdMapIndex::load(&tmp).unwrap();
+    assert_eq!(loaded.dim_opt(), Some(DIM));
+    assert_eq!(loaded.len(), 3);
+    for &id in &ids {
+        assert!(loaded.contains(id));
+    }
+    fs::remove_file(&tmp).ok();
+}


### PR DESCRIPTION
## Summary

Adds optional `mask=` / `allowlist=` kwargs to `search` on both index
types so callers can restrict the returned top-k to a caller-supplied
subset of vectors. The kernel applies the filter at the heap-update
site rather than via post-filtering, so selective filters return up to
`k` results from the allowed set instead of fewer-than-`k` from an
over-fetch pass.

Closes #21.

## What's in

**Core feature** (`feb645c`)
- `TurboQuantIndex::search_with_mask(queries, k, Option<&[bool]>)` — slot bitmask.
- `IdMapIndex::search_with_allowlist(queries, k, Option<&[u64]>)` — id allowlist; builds the bitmask via `id_to_slot`.
- Python: keyword-only `mask=` / `allowlist=` on the corresponding `search` methods. Pre-validates dtype, shape, emptiness and unknown ids to raise clean `ValueError` / `KeyError` rather than panic.
- Threaded through every scoring path: NEON (aarch64), AVX2 (x86_64), AVX-512BW (x86_64), and the scalar fallback. NEON's check sits in the per-query top-k scan; the x86 paths gate each inline heap update.
- `n_allowed == 0` short-circuits before the kernel so empty-heap update sites stay safe.
- Output shape shrinks to `min(k, n_allowed)` — consistent with the existing `k > len(idx)` contract. No sentinel padding.

**Docs + integrations** (`cf009c0`)
- `docs/api.md`: kwargs documented + new Filtering section.
- `README.md`: feature bullet + hybrid-retrieval example.
- `CHANGELOG.md`: new file under [Unreleased].
- Haystack `embedding_retrieval`: drops the `top_k * 10` over-fetch hack; resolves filters to an allowlist upfront. The "results may be fewer than top_k" caveat in the docstring goes away.
- LangChain `similarity_search*`: accepts `filter: dict | Callable | None` (previously silently ignored via `**_`).
- LlamaIndex `query()`: honours `VectorStoreQuery.filters` (EQ, NE, GT/GTE/LT/LTE, IN/NIN, TEXT_MATCH, CONTAINS, IS_EMPTY; AND/OR; nested) and `VectorStoreQuery.doc_ids`. Unsupported operators raise `NotImplementedError` rather than silently mismatching.

## Tests

- Rust: 11 new tests in `turbovec/tests/filtering.rs` covering correctness vs post-hoc reference, `mask=None` equivalence, effective-k shrinking, multi-query batches across the 4-query NEON kernel and its tail, error paths, and id stability across `swap_remove`.
- Python bindings: 14 tests in `turbovec-python/tests/test_filtering.py` (shape/dtype validation, kwarg-only enforcement, parity with reference filter).
- Integration filter tests added to `test_haystack.py` / `test_langchain.py` / `test_llama_index.py`, including a regression test that a filter matching 3 of 50 docs returns all 3 with `top_k=3`.

Full suite (locally on ARM/macOS): Rust crate + 97 Python tests pass.

## Caveats

The x86 paths (AVX2 + AVX-512BW) compile cleanly but I couldn't run them on this machine. The kernel changes are mechanical — same `if let Some(m) = mask { if !mask_allows(...) { continue; } }` guard at every heap-insert site — but they should get a smoke test on x86 before merge.

## Test plan

- [ ] `cargo test -p turbovec` on the x86 benchmark instance
- [ ] `pytest turbovec-python/tests` on the x86 benchmark instance
- [ ] Spot-check a quick speed bench to confirm `mask=None` doesn't regress unfiltered search

🤖 Generated with [Claude Code](https://claude.com/claude-code)