### PR TITLE
Add Agno framework integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ See [`docs/api.md`](docs/api.md) for the full reference.
 - [LangChain](docs/integrations/langchain.md) — `pip install turbovec[langchain]`
 - [LlamaIndex](docs/integrations/llama_index.md) — `pip install turbovec[llama-index]`
 - [Haystack](docs/integrations/haystack.md) — `pip install turbovec[haystack]`
+- [Agno](docs/integrations/agno.md) — `pip install turbovec[agno]`
 
 ## Rust
 

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -1,0 +1,65 @@
+# Agno integration
+
+`turbovec.agno.TurboQuantVectorDb` implements Agno's `VectorDb` interface backed by an `IdMapIndex`, supporting insert, upsert, search, and delete with O(1) id-based operations.
+
+## Install
+
+```bash
+pip install turbovec[agno]
+```
+
+## Basic usage
+
+```python
+from agno.agent import Agent
+from agno.knowledge import Knowledge
+from agno.knowledge.embedder.openai import OpenAIEmbedder
+from turbovec.agno import TurboQuantVectorDb
+
+vector_db = TurboQuantVectorDb(
+    dim=1536,
+    bit_width=4,
+    embedder=OpenAIEmbedder(),
+)
+
+knowledge = Knowledge(vector_db=vector_db)
+knowledge.load_text("Turbovec compresses vectors to 4 bits per dimension.")
+
+agent = Agent(knowledge=knowledge)
+agent.print_response("What does turbovec do?")
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `dim` | `int` | `1536` | Embedding dimension |
+| `bit_width` | `int` | `4` | Quantization bits (2 or 4) |
+| `embedder` | `Embedder` | `None` | Agno embedder for search queries |
+| `path` | `str` | `None` | Directory for save/load persistence |
+| `similarity_threshold` | `float` | `None` | Minimum score to include in results |
+
+## Save / load
+
+```python
+vector_db = TurboQuantVectorDb(dim=1536, bit_width=4, path="./my-store")
+vector_db.create()  # loads from path if exists, else creates new
+
+# ... add documents ...
+
+vector_db.save()  # persists to path
+```
+
+## Delete
+
+```python
+vector_db.delete_by_id("doc-123")
+vector_db.delete_by_name("my-document.pdf")
+vector_db.delete_by_metadata({"source": "web"})
+```
+
+## Known limitations
+
+- No metadata filtering during search. Post-search filtering can be done at the application layer.
+- Side-car docstore uses pickle. Only load from trusted sources.
+- Search is brute-force over quantized vectors. Suitable for corpora up to ~10M vectors.

--- a/turbovec-python/pyproject.toml
+++ b/turbovec-python/pyproject.toml
@@ -49,6 +49,7 @@ Issues = "https://github.com/RyanCodrai/turbovec/issues"
 langchain = ["langchain-core>=0.3"]
 llama-index = ["llama-index-core>=0.11"]
 haystack = ["haystack-ai>=2.0"]
+agno = ["agno"]
 
 [tool.maturin]
 manifest-path = "Cargo.toml"

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -1,0 +1,282 @@
+"""Agno VectorDb backed by turbovec's quantized index.
+
+Install with: ``pip install turbovec[agno]``.
+"""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from ._turbovec import IdMapIndex
+
+try:
+    from agno.knowledge.document import Document
+    from agno.knowledge.embedder import Embedder
+    from agno.vectordb.base import VectorDb
+    from agno.vectordb.distance import Distance
+except ImportError as exc:
+    raise ImportError(
+        "agno is required to use turbovec.agno. "
+        "Install with: pip install turbovec[agno]"
+    ) from exc
+
+
+_INDEX_FILENAME = "index.tvim"
+_STORE_FILENAME = "docstore.pkl"
+
+
+class TurboQuantVectorDb(VectorDb):
+    """Agno VectorDb backed by a :class:`IdMapIndex`.
+
+    Vectors are quantized to 2-4 bits per dimension using TurboQuant.
+    Supports insert, upsert, search, and delete operations.
+    """
+
+    def __init__(
+        self,
+        *,
+        dim: int = 1536,
+        bit_width: int = 4,
+        embedder: Optional[Embedder] = None,
+        path: Optional[str] = None,
+        name: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(name=name or "turbovec", **kwargs)
+        self.dim = dim
+        self.bit_width = bit_width
+        self.embedder = embedder
+        self.path = path
+
+        self._index: Optional[IdMapIndex] = None
+        self._docs: Dict[str, Dict[str, Any]] = {}
+        self._str_to_u64: Dict[str, int] = {}
+        self._u64_to_str: Dict[int, str] = {}
+        self._next_u64: int = 0
+
+    def _issue_handle(self) -> int:
+        self._next_u64 += 1
+        return self._next_u64
+
+    def create(self) -> None:
+        if self._index is None:
+            if self.path and Path(self.path).exists():
+                self._load(self.path)
+            else:
+                self._index = IdMapIndex(self.dim, self.bit_width)
+
+    async def async_create(self) -> None:
+        self.create()
+
+    def name_exists(self, name: str) -> bool:
+        return name in self._docs
+
+    async def async_name_exists(self, name: str) -> bool:
+        return self.name_exists(name)
+
+    def id_exists(self, id: str) -> bool:
+        return id in self._str_to_u64
+
+    def content_hash_exists(self, content_hash: str) -> bool:
+        for doc_meta in self._docs.values():
+            if doc_meta.get("content_hash") == content_hash:
+                return True
+        return False
+
+    def insert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if self._index is None:
+            self.create()
+
+        for doc in documents:
+            if doc.embedding is None:
+                continue
+            vec = np.asarray(doc.embedding, dtype=np.float32)
+            if vec.ndim == 1:
+                vec = vec[None, :]
+            if not vec.flags["C_CONTIGUOUS"]:
+                vec = np.ascontiguousarray(vec)
+
+            handle = self._issue_handle()
+            handle_arr = np.array([handle], dtype=np.uint64)
+            self._index.add_with_ids(vec, handle_arr)
+
+            doc_id = doc.id or str(handle)
+            self._str_to_u64[doc_id] = handle
+            self._u64_to_str[handle] = doc_id
+            self._docs[doc_id] = {
+                "name": doc.name,
+                "content": doc.content,
+                "meta_data": doc.meta_data,
+                "content_hash": content_hash,
+            }
+
+    async def async_insert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.insert(content_hash, documents, filters)
+
+    def upsert_available(self) -> bool:
+        return True
+
+    def upsert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if self._index is None:
+            self.create()
+
+        for doc in documents:
+            doc_id = doc.id
+            if doc_id and doc_id in self._str_to_u64:
+                self.delete_by_id(doc_id)
+        self.insert(content_hash, documents, filters)
+
+    async def async_upsert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.upsert(content_hash, documents, filters)
+
+    def search(self, query: str, limit: int = 5, filters: Optional[Any] = None) -> List[Document]:
+        if self._index is None or len(self._index) == 0:
+            return []
+
+        if self.embedder is None:
+            return []
+
+        query_embedding = self.embedder.get_embedding(query)
+        if query_embedding is None:
+            return []
+
+        qvec = np.asarray(query_embedding, dtype=np.float32)
+        if qvec.ndim == 1:
+            qvec = qvec[None, :]
+        if not qvec.flags["C_CONTIGUOUS"]:
+            qvec = np.ascontiguousarray(qvec)
+
+        k = min(limit, len(self._index))
+        scores, handles = self._index.search(qvec, k)
+
+        results: List[Document] = []
+        for score, handle in zip(scores[0], handles[0]):
+            doc_id = self._u64_to_str.get(int(handle))
+            if doc_id is None:
+                continue
+            doc_data = self._docs.get(doc_id)
+            if doc_data is None:
+                continue
+
+            if self.similarity_threshold and float(score) < self.similarity_threshold:
+                continue
+
+            results.append(
+                Document(
+                    id=doc_id,
+                    name=doc_data.get("name"),
+                    content=doc_data.get("content", ""),
+                    meta_data=doc_data.get("meta_data", {}),
+                )
+            )
+        return results
+
+    async def async_search(self, query: str, limit: int = 5, filters: Optional[Any] = None) -> List[Document]:
+        return self.search(query, limit, filters)
+
+    def drop(self) -> None:
+        self._index = None
+        self._docs.clear()
+        self._str_to_u64.clear()
+        self._u64_to_str.clear()
+        self._next_u64 = 0
+
+    async def async_drop(self) -> None:
+        self.drop()
+
+    def exists(self) -> bool:
+        return self._index is not None and len(self._index) > 0
+
+    async def async_exists(self) -> bool:
+        return self.exists()
+
+    def delete(self) -> bool:
+        self.drop()
+        return True
+
+    def delete_by_id(self, id: str) -> bool:
+        handle = self._str_to_u64.pop(id, None)
+        if handle is None:
+            return False
+        self._u64_to_str.pop(handle, None)
+        self._docs.pop(id, None)
+        self._index.remove(handle)
+        return True
+
+    def delete_by_name(self, name: str) -> bool:
+        to_delete = [did for did, meta in self._docs.items() if meta.get("name") == name]
+        for did in to_delete:
+            self.delete_by_id(did)
+        return len(to_delete) > 0
+
+    def delete_by_metadata(self, metadata: Dict[str, Any]) -> bool:
+        to_delete = []
+        for did, meta in self._docs.items():
+            doc_meta = meta.get("meta_data", {})
+            if all(doc_meta.get(k) == v for k, v in metadata.items()):
+                to_delete.append(did)
+        for did in to_delete:
+            self.delete_by_id(did)
+        return len(to_delete) > 0
+
+    def delete_by_content_id(self, content_id: str) -> bool:
+        return self.delete_by_id(content_id)
+
+    def get_supported_search_types(self) -> List[str]:
+        return ["similarity"]
+
+    def save(self, folder_path: Optional[str] = None) -> None:
+        path = folder_path or self.path
+        if path is None:
+            return
+        folder = Path(path)
+        folder.mkdir(parents=True, exist_ok=True)
+        self._index.write(str(folder / _INDEX_FILENAME))
+        with open(folder / _STORE_FILENAME, "wb") as f:
+            pickle.dump(
+                {
+                    "docs": self._docs,
+                    "str_to_u64": self._str_to_u64,
+                    "next_u64": self._next_u64,
+                },
+                f,
+            )
+
+    def _load(self, folder_path: str) -> None:
+        folder = Path(folder_path)
+        self._index = IdMapIndex.load(str(folder / _INDEX_FILENAME))
+        store_path = folder / _STORE_FILENAME
+        if store_path.exists():
+            with open(store_path, "rb") as f:
+                state = pickle.load(f)
+            self._docs = state["docs"]
+            self._str_to_u64 = state["str_to_u64"]
+            self._next_u64 = state["next_u64"]
+            self._u64_to_str = {h: s for s, h in self._str_to_u64.items()}
+
+
+__all__ = ["TurboQuantVectorDb"]

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("agno")
+
+from agno.knowledge.document import Document
+
+from turbovec import IdMapIndex
+from turbovec.agno import TurboQuantVectorDb
+
+
+class StubEmbedder:
+    """Deterministic embedder for tests."""
+
+    def __init__(self, dim: int = 64) -> None:
+        self.dim = dim
+
+    def get_embedding(self, text: str) -> list[float]:
+        rng = np.random.default_rng(abs(hash(text)) % (2**32))
+        v = rng.standard_normal(self.dim).astype(np.float32)
+        v /= np.linalg.norm(v) + 1e-9
+        return v.tolist()
+
+
+def _make_doc(content: str, doc_id: str, embedding_dim: int = 64) -> Document:
+    rng = np.random.default_rng(abs(hash(content)) % (2**32))
+    v = rng.standard_normal(embedding_dim).astype(np.float32)
+    v /= np.linalg.norm(v) + 1e-9
+    return Document(id=doc_id, name=doc_id, content=content, embedding=v.tolist())
+
+
+def test_create_initializes_index():
+    db = TurboQuantVectorDb(dim=64, bit_width=4)
+    db.create()
+    assert db.exists() is False  # empty index
+    assert db._index is not None
+
+
+def test_insert_and_search():
+    embedder = StubEmbedder(dim=64)
+    db = TurboQuantVectorDb(dim=64, bit_width=4, embedder=embedder)
+    db.create()
+
+    docs = [_make_doc("apple", "d1"), _make_doc("banana", "d2"), _make_doc("cherry", "d3")]
+    db.insert("hash1", docs)
+
+    assert db.exists() is True
+    assert len(db._index) == 3
+
+    results = db.search("apple", limit=2)
+    assert len(results) == 2
+    assert all(isinstance(r, Document) for r in results)
+
+
+def test_upsert_replaces_existing():
+    embedder = StubEmbedder(dim=64)
+    db = TurboQuantVectorDb(dim=64, bit_width=4, embedder=embedder)
+    db.create()
+
+    doc1 = _make_doc("version1", "same-id")
+    db.insert("h1", [doc1])
+    assert db._docs["same-id"]["content"] == "version1"
+
+    doc2 = _make_doc("version2", "same-id")
+    db.upsert("h2", [doc2])
+    assert db._docs["same-id"]["content"] == "version2"
+    assert len(db._index) == 1
+
+
+def test_delete_by_id():
+    embedder = StubEmbedder(dim=64)
+    db = TurboQuantVectorDb(dim=64, bit_width=4, embedder=embedder)
+    db.create()
+
+    docs = [_make_doc("a", "d1"), _make_doc("b", "d2")]
+    db.insert("h1", docs)
+
+    assert db.delete_by_id("d1") is True
+    assert db.delete_by_id("ghost") is False
+    assert len(db._index) == 1
+    assert "d1" not in db._docs
+
+
+def test_delete_by_name():
+    embedder = StubEmbedder(dim=64)
+    db = TurboQuantVectorDb(dim=64, bit_width=4, embedder=embedder)
+    db.create()
+
+    doc = _make_doc("content", "d1")
+    doc.name = "my-file.pdf"
+    db.insert("h1", [doc])
+
+    assert db.delete_by_name("my-file.pdf") is True
+    assert db.delete_by_name("nonexistent") is False
+
+
+def test_delete_by_metadata():
+    embedder = StubEmbedder(dim=64)
+    db = TurboQuantVectorDb(dim=64, bit_width=4, embedder=embedder)
+    db.create()
+
+    doc = _make_doc("content", "d1")
+    doc.meta_data = {"source": "web"}
+    db.insert("h1", [doc])
+
+    assert db.delete_by_metadata({"source": "web"}) is True
+    assert len(db._docs) == 0
+
+
+def test_content_hash_exists():
+    db = TurboQuantVectorDb(dim=64, bit_width=4)
+    db.create()
+
+    doc = _make_doc("content", "d1")
+    db.insert("unique-hash", [doc])
+
+    assert db.content_hash_exists("unique-hash") is True
+    assert db.content_hash_exists("other-hash") is False
+
+
+def test_drop_clears_everything():
+    embedder = StubEmbedder(dim=64)
+    db = TurboQuantVectorDb(dim=64, bit_width=4, embedder=embedder)
+    db.create()
+
+    db.insert("h1", [_make_doc("x", "d1")])
+    db.drop()
+
+    assert db._index is None
+    assert len(db._docs) == 0
+
+
+def test_save_and_load(tmp_path):
+    embedder = StubEmbedder(dim=64)
+    db = TurboQuantVectorDb(dim=64, bit_width=4, embedder=embedder, path=str(tmp_path))
+    db.create()
+
+    db.insert("h1", [_make_doc("hello", "d1"), _make_doc("world", "d2")])
+    db.save()
+
+    db2 = TurboQuantVectorDb(dim=64, bit_width=4, embedder=embedder, path=str(tmp_path))
+    db2.create()  # should load from path
+
+    assert len(db2._index) == 2
+    assert "d1" in db2._docs
+
+
+def test_empty_search_returns_empty():
+    embedder = StubEmbedder(dim=64)
+    db = TurboQuantVectorDb(dim=64, bit_width=4, embedder=embedder)
+    db.create()
+
+    results = db.search("anything", limit=5)
+    assert results == []
+
+
+def test_search_without_embedder_returns_empty():
+    db = TurboQuantVectorDb(dim=64, bit_width=4, embedder=None)
+    db.create()
+    db.insert("h1", [_make_doc("x", "d1")])
+
+    results = db.search("query", limit=5)
+    assert results == []
+
+
+def test_id_exists():
+    db = TurboQuantVectorDb(dim=64, bit_width=4)
+    db.create()
+    db.insert("h1", [_make_doc("x", "d1")])
+
+    assert db.id_exists("d1") is True
+    assert db.id_exists("d2") is False
+
+
+def test_get_supported_search_types():
+    db = TurboQuantVectorDb(dim=64, bit_width=4)
+    assert db.get_supported_search_types() == ["similarity"]


### PR DESCRIPTION
Fixes #23

Add turbovec integration for the Agno agent framework (https://github.com/agno-agi/agno), implementing the VectorDb interface backed by IdMapIndex.

Follows the same pattern as existing LangChain/LlamaIndex/Haystack integrations.

## Changes

- turbovec-python/python/turbovec/agno.py - TurboQuantVectorDb class
- turbovec-python/tests/test_agno.py - 14 unit tests
- docs/integrations/agno.md - usage documentation
- turbovec-python/pyproject.toml - added agno optional dependency
- README.md - added Agno to framework integrations list

## Usage

    pip install turbovec[agno]

    from turbovec.agno import TurboQuantVectorDb

    vector_db = TurboQuantVectorDb(dim=1536, bit_width=4, embedder=my_embedder)
    vector_db.create()

## Operations supported

- insert / upsert with content hash deduplication
- similarity search via embedder
- delete by id, name, or metadata
- save/load persistence to disk