### PR TITLE
Add metadata filtering to LangChain and LlamaIndex integrations

### DIFF
--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -83,8 +83,24 @@ docs = store.similarity_search_by_vector(qvec.tolist(), k=5)
 
 Scores are raw inner products. Because vectors are L2-normalized on insert, inner product equals cosine similarity — higher is better, range `[-1, 1]`.
 
+## Metadata filtering
+
+Pass a `filter` dict to any search method. Keys are metadata field names; values are either a single value (exact match) or a list (match any).
+
+```python
+# Exact match
+docs = store.similarity_search("query", k=5, filter={"tenant": "acme"})
+
+# Match any value in list
+docs = store.similarity_search("query", k=5, filter={"source": ["web", "pdf"]})
+
+# Multiple conditions (AND)
+docs = store.similarity_search("query", k=5, filter={"tenant": "acme", "year": 2025})
+```
+
+Filtering is applied post-retrieval with over-fetching (10x `k`) to maintain result count. For very restrictive filters on large corpora, results may be fewer than `k`.
+
 ## Known limitations
 
-- **No first-class metadata filtering.** LangChain's `VectorStore` interface doesn't standardize filter predicates. If you need filtered search, use the Haystack integration (which exposes a filter DSL).
 - **Embeddings are dropped after quantization.** `search` returns `Document` objects with `page_content` and `metadata`, but not the original embedding.
 - **Side-car is pickle.** We may migrate to a safer format in a future major version; for now, treat `allow_dangerous_deserialization=True` as mandatory reading.

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -109,35 +109,46 @@ class TurboQuantVectorStore(VectorStore):
             self._docs[id_] = (text, dict(meta))
         return ids
 
-    def similarity_search(self, query: str, k: int = 4, **_: Any) -> list[Document]:
-        return [doc for doc, _score in self.similarity_search_with_score(query, k=k)]
+    def similarity_search(
+        self, query: str, k: int = 4, filter: dict[str, Any] | None = None, **_: Any
+    ) -> list[Document]:
+        return [doc for doc, _score in self.similarity_search_with_score(query, k=k, filter=filter)]
 
     def similarity_search_with_score(
-        self, query: str, k: int = 4, **_: Any
+        self, query: str, k: int = 4, filter: dict[str, Any] | None = None, **_: Any
     ) -> list[tuple[Document, float]]:
         qvec = np.asarray(self._embedding.embed_query(query), dtype=np.float32)
-        return self._search_vector(qvec, k)
+        return self._search_vector(qvec, k, filter=filter)
 
     def similarity_search_by_vector(
-        self, embedding: list[float], k: int = 4, **_: Any
+        self, embedding: list[float], k: int = 4, filter: dict[str, Any] | None = None, **_: Any
     ) -> list[Document]:
         qvec = np.asarray(embedding, dtype=np.float32)
-        return [doc for doc, _score in self._search_vector(qvec, k)]
+        return [doc for doc, _score in self._search_vector(qvec, k, filter=filter)]
 
-    def _search_vector(self, qvec: np.ndarray, k: int) -> list[tuple[Document, float]]:
+    def _search_vector(
+        self, qvec: np.ndarray, k: int, filter: dict[str, Any] | None = None
+    ) -> list[tuple[Document, float]]:
         if qvec.ndim == 1:
             qvec = qvec[None, :]
         if not qvec.flags["C_CONTIGUOUS"]:
             qvec = np.ascontiguousarray(qvec)
-        k = min(k, len(self._index))
-        if k == 0:
+        # Over-fetch when filtering so we still return ~k results after
+        # dropping non-matches.
+        fetch_k = k if filter is None else min(k * 10, len(self._index))
+        fetch_k = min(fetch_k, len(self._index))
+        if fetch_k == 0:
             return []
-        scores, handles = self._index.search(qvec, k)
+        scores, handles = self._index.search(qvec, fetch_k)
         results: list[tuple[Document, float]] = []
         for score, handle in zip(scores[0], handles[0]):
             sid = self._u64_to_str[int(handle)]
             text, meta = self._docs[sid]
+            if filter is not None and not _matches_filter(meta, filter):
+                continue
             results.append((Document(page_content=text, metadata=dict(meta)), float(score)))
+            if len(results) >= k:
+                break
         return results
 
     def delete(self, ids: list[str] | None = None, **_: Any) -> bool | None:
@@ -217,6 +228,18 @@ class TurboQuantVectorStore(VectorStore):
             str_to_u64=state["str_to_u64"],
             next_u64=state["next_u64"],
         )
+
+
+def _matches_filter(meta: dict[str, Any], filter: dict[str, Any]) -> bool:
+    """Check if document metadata matches all filter key-value pairs."""
+    for key, value in filter.items():
+        if isinstance(value, list):
+            if meta.get(key) not in value:
+                return False
+        else:
+            if meta.get(key) != value:
+                return False
+    return True
 
 
 __all__ = ["TurboQuantVectorStore"]

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -160,11 +160,15 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         if not qvec.flags["C_CONTIGUOUS"]:
             qvec = np.ascontiguousarray(qvec)
 
-        k = min(query.similarity_top_k, len(self._index))
-        if k == 0:
+        has_filters = query.filters is not None
+        fetch_k = query.similarity_top_k if not has_filters else min(
+            query.similarity_top_k * 10, len(self._index)
+        )
+        fetch_k = min(fetch_k, len(self._index))
+        if fetch_k == 0:
             return VectorStoreQueryResult(nodes=[], similarities=[], ids=[])
 
-        scores, handles = self._index.search(qvec, k)
+        scores, handles = self._index.search(qvec, fetch_k)
 
         result_nodes: list[TextNode] = []
         similarities: list[float] = []
@@ -172,6 +176,12 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         for score, handle in zip(scores[0], handles[0]):
             nid = self._u64_to_node_id[int(handle)]
             state = self._nodes[nid]
+
+            if has_filters and not _matches_metadata_filter(
+                state["metadata"], query.filters
+            ):
+                continue
+
             node = TextNode(
                 id_=nid,
                 text=state["text"],
@@ -184,6 +194,8 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
             result_nodes.append(node)
             similarities.append(float(score))
             ids.append(nid)
+            if len(result_nodes) >= query.similarity_top_k:
+                break
 
         return VectorStoreQueryResult(nodes=result_nodes, similarities=similarities, ids=ids)
 
@@ -229,6 +241,27 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         store._u64_to_node_id = {h: nid for nid, h in state["node_id_to_u64"].items()}
         store._next_u64 = state["next_u64"]
         return store
+
+
+def _matches_metadata_filter(meta: dict[str, Any], filters: Any) -> bool:
+    """Check if node metadata matches the VectorStoreQuery filters.
+
+    Supports MetadataFilters from llama_index with exact match conditions.
+    """
+    if filters is None:
+        return True
+    # LlamaIndex MetadataFilters has a .filters list of MetadataFilter objects
+    if hasattr(filters, "filters"):
+        for f in filters.filters:
+            key = f.key
+            value = f.value
+            if isinstance(value, list):
+                if meta.get(key) not in value:
+                    return False
+            else:
+                if meta.get(key) != value:
+                    return False
+    return True
 
 
 __all__ = ["TurboQuantVectorStore"]

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -162,3 +162,80 @@ def test_mismatched_dim_raises():
     store = TurboQuantVectorStore(emb, index=IdMapIndex(32, 4))
     with pytest.raises(ValueError, match="embedding dimension"):
         store.add_texts(["hi"])
+
+
+def test_filter_by_exact_match():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["doc1", "doc2", "doc3"],
+        emb,
+        metadatas=[
+            {"source": "web", "tenant": "acme"},
+            {"source": "pdf", "tenant": "acme"},
+            {"source": "web", "tenant": "globex"},
+        ],
+        bit_width=4,
+    )
+    results = store.similarity_search("doc1", k=10, filter={"tenant": "acme"})
+    assert len(results) == 2
+    assert all(doc.metadata["tenant"] == "acme" for doc in results)
+
+
+def test_filter_by_list_value():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["a", "b", "c", "d"],
+        emb,
+        metadatas=[
+            {"category": "finance"},
+            {"category": "tech"},
+            {"category": "health"},
+            {"category": "finance"},
+        ],
+        bit_width=4,
+    )
+    results = store.similarity_search(
+        "a", k=10, filter={"category": ["finance", "tech"]}
+    )
+    assert len(results) == 3
+    assert all(doc.metadata["category"] in ["finance", "tech"] for doc in results)
+
+
+def test_filter_no_matches_returns_empty():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["x", "y"],
+        emb,
+        metadatas=[{"source": "a"}, {"source": "b"}],
+        bit_width=4,
+    )
+    results = store.similarity_search("x", k=10, filter={"source": "nonexistent"})
+    assert results == []
+
+
+def test_filter_with_score():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["one", "two", "three"],
+        emb,
+        metadatas=[{"n": 1}, {"n": 2}, {"n": 3}],
+        bit_width=4,
+    )
+    results = store.similarity_search_with_score("one", k=10, filter={"n": 1})
+    assert len(results) == 1
+    doc, score = results[0]
+    assert doc.metadata["n"] == 1
+
+
+def test_filter_by_vector():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["a", "b", "c"],
+        emb,
+        metadatas=[{"keep": True}, {"keep": False}, {"keep": True}],
+        bit_width=4,
+    )
+    qvec = emb.embed_query("a")
+    results = store.similarity_search_by_vector(qvec, k=10, filter={"keep": True})
+    assert len(results) == 2
+    assert all(doc.metadata["keep"] is True for doc in results)


### PR DESCRIPTION
Fixes #25

Adds post-retrieval metadata filtering to the LangChain and LlamaIndex integrations, removing the documented limitation from both.

## LangChain

New filter parameter on all search methods:

    store.similarity_search('query', k=5, filter={'tenant': 'acme'})
    store.similarity_search('query', k=5, filter={'source': ['web', 'pdf']})

Supports exact match (single value) and list match (any value in list). Multiple keys are AND-ed.

## LlamaIndex

Metadata filtering via VectorStoreQuery.filters (MetadataFilters object):

    from llama_index.core.vector_stores import MetadataFilters, MetadataFilter
    filters = MetadataFilters(filters=[MetadataFilter(key='source', value='web')])
    query = VectorStoreQuery(query_embedding=vec, similarity_top_k=5, filters=filters)
    result = store.query(query)

## Implementation

Both use 10x over-fetch when a filter is present, then post-filter results. Matches the approach already used by the Haystack integration.

## Tests

5 new LangChain tests covering exact match, list values, empty results, score filtering, and vector search filtering.