### PR TITLE
Add Agno framework integration (closes #23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,36 @@ appears under each surface it touches.
 
 ## [Unreleased]
 
-(Nothing in flight — `next` lines below describe published versions.)
+### turbovec — Python package
+
+#### Added
+
+- **Agno integration** (`turbovec.agno`). New `TurboQuantVectorDb` class
+  implementing Agno's `VectorDb` interface, structurally aligned with
+  `agno.vectordb.lancedb.LanceDb` (the closest in-tree single-machine
+  backend). Drop-in for callers that use `LanceDb` as their Agno
+  knowledge backend.
+  - Dim is sourced from `embedder.dimensions` (matches `LanceDb`); no
+    baked-in default.
+  - Filtered search uses the kernel-level `allowlist=` path: filters
+    resolve to a handle allowlist before scoring, so selective filters
+    return up to `limit` results from the filtered set instead of
+    fewer-than-`limit` from a post-filter.
+  - JSON side-car persistence (no pickle, no
+    `allow_dangerous_deserialization` flag).
+  - Constructor restricts `search_type=vector` and `distance=cosine`
+    — turbovec doesn't ship a BM25/lexical index and stores
+    unit-normalized vectors only. Non-vector / non-cosine constructions
+    raise `ValueError` rather than silently misbehaving.
+  - Honours `similarity_threshold` (cosine → relevance clamped to
+    `[0, 1]` via `(s + 1) / 2`), `reranker` (optional rerank pass after
+    vector retrieval), `content_id` / `content_hash` payload fields.
+  - Full async surface: `async_*` variants for create/insert/upsert/
+    search/drop/exists/name_exists, using the embedder's async batch
+    paths when available.
+  - Install: `pip install turbovec[agno]`.
+
+## turbovec 0.3.0 (Rust crate) — 2026-05-17
 
 ## turbovec 0.3.0 (Rust crate) — 2026-05-17
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Drop-in replacements for the in-tree reference vector / document stores in each 
 - [LangChain](docs/integrations/langchain.md) — `pip install turbovec[langchain]` · replaces `langchain_core.vectorstores.InMemoryVectorStore`
 - [LlamaIndex](docs/integrations/llama_index.md) — `pip install turbovec[llama-index]` · replaces `llama_index.core.vector_stores.SimpleVectorStore`
 - [Haystack](docs/integrations/haystack.md) — `pip install turbovec[haystack]` · replaces `haystack.document_stores.in_memory.InMemoryDocumentStore`
+- [Agno](docs/integrations/agno.md) — `pip install turbovec[agno]` · replaces `agno.vectordb.lancedb.LanceDb`
 
 ## Rust
 

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -1,0 +1,141 @@
+# Agno integration
+
+`turbovec.agno.TurboQuantVectorDb` is an [Agno](https://github.com/agno-agi/agno) `VectorDb` backed by an `IdMapIndex`. It implements the same public surface as `agno.vectordb.lancedb.LanceDb` (the closest in-tree single-machine backend) so this can be swapped in wherever LanceDb is used.
+
+## Install
+
+```bash
+pip install turbovec[agno]
+```
+
+## Basic usage
+
+```python
+from agno.agent import Agent
+from agno.knowledge import Knowledge
+from agno.knowledge.embedder.openai import OpenAIEmbedder
+from turbovec.agno import TurboQuantVectorDb
+
+vector_db = TurboQuantVectorDb(embedder=OpenAIEmbedder())
+
+knowledge = Knowledge(vector_db=vector_db)
+knowledge.load_text("Turbovec compresses vectors to 4 bits per dimension.")
+
+agent = Agent(knowledge=knowledge)
+agent.print_response("What does turbovec do?")
+```
+
+## Constructor
+
+```python
+TurboQuantVectorDb(
+    *,
+    id: Optional[str] = None,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    similarity_threshold: Optional[float] = None,
+    embedder: Embedder,                              # required
+    bit_width: int = 4,
+    search_type: SearchType = SearchType.vector,
+    distance: Distance = Distance.cosine,
+    reranker: Optional[Reranker] = None,
+    path: Optional[str] = None,
+)
+```
+
+| Parameter | Notes |
+|---|---|
+| `embedder` | **Required.** Source of truth for the embedding dimension — `embedder.dimensions` sizes the underlying quantized index. |
+| `bit_width` | Quantization width per coordinate; one of `{2, 4}`. |
+| `search_type` | Only `SearchType.vector` is supported. Constructing with `keyword` or `hybrid` raises `ValueError` (keyword/hybrid would require an external BM25/lexical index that turbovec doesn't ship). |
+| `distance` | Only `Distance.cosine` is supported. turbovec stores unit-normalized vectors and the kernel's raw score is cosine similarity directly. |
+| `similarity_threshold` | Optional. Scores are mapped from cosine `[-1, 1]` to relevance `[0, 1]` via `(s + 1) / 2`; results below the threshold are dropped. |
+| `reranker` | Optional Agno reranker applied to the result set after vector retrieval. |
+| `path` | Optional directory for save/load persistence. When given, `create()` loads existing data from this path if present. |
+
+## Insert / upsert
+
+`insert` and `upsert` follow the same `(content_hash, documents, filters)` signature as `LanceDb`. The internal `doc_id` is derived as `md5(f"{base_id}_{content_hash}")` where `base_id` is `doc.id` (or `md5(content)` when missing). The contract: the same `(base_id, content_hash)` pair always produces the same internal id, and the same `base_id` with a *different* `content_hash` is treated as a new entry — letting you keep content versions side-by-side.
+
+```python
+from agno.knowledge.document import Document
+
+docs = [Document(id="doc-1", name="paper.pdf", content="...", meta_data={"source": "arxiv"})]
+vector_db.insert(content_hash="v1", documents=docs)
+
+# Same doc with a new content_hash → new stored entry.
+vector_db.insert(content_hash="v2", documents=docs)
+```
+
+Documents without embeddings are embedded via `self.embedder` before insertion. If embedding fails (`get_embedding` returns `None`) the call raises `ValueError` rather than silently dropping the document.
+
+## Filtered search
+
+Filters are resolved to an allowlist **before** scoring — the kernel only ever inserts allowed candidates into the per-query heap. You always get up to `limit` results from the filtered set; no over-fetching, no recall hit on selective filters.
+
+```python
+results = vector_db.search(
+    "quantum computing applications",
+    limit=5,
+    filters={"source": "arxiv", "year": 2024},      # AND of exact equality
+)
+```
+
+Dict filters use AND-of-exact-equality on `Document.meta_data`. List-style `FilterExpr` filters (Agno's structured filter type) are silently ignored, matching `LanceDb`'s behaviour.
+
+## Existence checks
+
+```python
+vector_db.name_exists("paper.pdf")          # bool — by Document.name
+vector_db.id_exists("derived-md5-id")        # bool — by the internally-derived id
+vector_db.content_hash_exists("v1")          # O(1) — set lookup, not a scan
+```
+
+## Delete
+
+```python
+vector_db.delete_by_id(derived_id)               # by internal id
+vector_db.delete_by_name("paper.pdf")             # by Document.name
+vector_db.delete_by_metadata({"source": "web"})   # AND-of-equality on meta_data
+vector_db.delete_by_content_id("cid-42")          # by Document.content_id
+vector_db.drop()                                  # clear all
+vector_db.delete()                                # alias for drop(), returns True
+```
+
+Each `delete_by_*` returns `True` iff at least one document was removed.
+
+## update_metadata
+
+```python
+vector_db.update_metadata("cid-42", {"reviewed": True})
+```
+
+Merges the given metadata into `meta_data` of every document with the matching `content_id`. Overrides the base class's no-op warning.
+
+## Save / load
+
+```python
+vector_db = TurboQuantVectorDb(embedder=embedder, path="./my-store")
+vector_db.create()                          # loads from path if existing
+
+# ... insert documents ...
+
+vector_db.save()                            # persists to path
+```
+
+Writes two files under the given folder path:
+- `index.tvim` — the `IdMapIndex` payload.
+- `docstore.json` — JSON-encoded document text, metadata, and id maps.
+
+Document metadata must be JSON-serializable — same constraint Agno's `LanceDb` imposes on its payload column. The side-car carries a `schema_version` field; loaders refuse to deserialize unknown versions.
+
+## Async
+
+Every public method has an async counterpart (`async_create`, `async_insert`, `async_upsert`, `async_search`, `async_drop`, `async_exists`, `async_name_exists`). When the embedder exposes `async_get_embedding` / `async_get_embeddings_batch_and_usage`, the async paths use it for genuine async embedding generation.
+
+## Known limitations
+
+- **Vector search only.** `search_type=SearchType.keyword` and `SearchType.hybrid` are not supported (would require an external BM25 / lexical index). Constructor raises `ValueError` on those.
+- **Cosine distance only.** `Distance.cosine` is the only supported metric. turbovec stores unit-normalized vectors; other distances would require non-trivial scoring changes.
+- **Embeddings are not retained after quantization.** Stored vectors are the quantized form; the original full-precision embedding can't be recovered.
+- **JSON-serializable metadata only.** Non-JSON-serializable values fail at `save()` time.

--- a/turbovec-python/pyproject.toml
+++ b/turbovec-python/pyproject.toml
@@ -49,6 +49,7 @@ Issues = "https://github.com/RyanCodrai/turbovec/issues"
 langchain = ["langchain-core>=0.3"]
 llama-index = ["llama-index-core>=0.11"]
 haystack = ["haystack-ai>=2.0"]
+agno = ["agno>=2.0"]
 
 [tool.maturin]
 manifest-path = "Cargo.toml"

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -1,0 +1,634 @@
+"""Agno VectorDb backed by turbovec's quantized index.
+
+Install with: ``pip install turbovec[agno]``.
+
+Implements Agno's ``VectorDb`` interface and matches the public surface
+of ``agno.vectordb.lancedb.LanceDb`` (the closest in-tree single-machine
+backend) so this can be swapped in wherever ``LanceDb`` is used.
+"""
+
+from __future__ import annotations
+
+import json
+from hashlib import md5
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Set, Union
+
+import numpy as np
+
+from ._turbovec import IdMapIndex
+
+try:
+    from agno.knowledge.document import Document
+    from agno.knowledge.embedder import Embedder
+    from agno.knowledge.reranker.base import Reranker
+    from agno.vectordb.base import VectorDb
+    from agno.vectordb.distance import Distance
+    from agno.vectordb.search import SearchType
+except ImportError as exc:
+    raise ImportError(
+        "agno is required to use turbovec.agno. "
+        "Install with: pip install turbovec[agno]"
+    ) from exc
+
+
+_INDEX_FILENAME = "index.tvim"
+_STORE_FILENAME = "docstore.json"
+# Bump when docstore.json shape changes; loader refuses unknown versions.
+_DOCSTORE_SCHEMA_VERSION = 1
+
+
+class TurboQuantVectorDb(VectorDb):
+    """Agno VectorDb backed by a :class:`IdMapIndex`.
+
+    Vectors are quantized to 2-4 bits per dimension. The public surface
+    mirrors ``agno.vectordb.lancedb.LanceDb`` so this is a drop-in
+    replacement wherever a single-machine LanceDb is used. Search-time
+    filtering is resolved to an allowlist *before* scoring (kernel-level)
+    rather than via post-filtering, so selective filters return up to
+    ``limit`` results from the filtered set instead of fewer.
+
+    Example::
+
+        from agno.knowledge.embedder.openai import OpenAIEmbedder
+        from turbovec.agno import TurboQuantVectorDb
+
+        vector_db = TurboQuantVectorDb(embedder=OpenAIEmbedder())
+        vector_db.create()
+        # ... use as a normal Agno VectorDb ...
+    """
+
+    def __init__(
+        self,
+        *,
+        id: Optional[str] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        similarity_threshold: Optional[float] = None,
+        embedder: Optional[Embedder] = None,
+        bit_width: int = 4,
+        search_type: SearchType = SearchType.vector,
+        distance: Distance = Distance.cosine,
+        reranker: Optional[Reranker] = None,
+        path: Optional[str] = None,
+    ) -> None:
+        """
+        :param embedder: Required. Agno embedder used to encode documents
+            and queries. ``embedder.dimensions`` must be set — it's the
+            sole source of truth for the underlying quantized index's
+            dimensionality.
+        :param bit_width: Quantization width (2 or 4).
+        :param search_type: Only :class:`SearchType.vector` is supported;
+            other values raise :class:`ValueError`. (Keyword/hybrid search
+            would require an external BM25/lexical index.)
+        :param distance: Only :class:`Distance.cosine` is supported.
+            turbovec stores unit-normalized vectors, so the kernel's raw
+            score is cosine similarity directly.
+        :param reranker: Optional Agno reranker applied to the result set
+            after vector retrieval.
+        :param path: Optional directory for save/load persistence. When
+            given to the constructor, :meth:`create` loads existing data
+            from this path if present.
+        """
+        super().__init__(
+            id=id,
+            name=name,
+            description=description,
+            similarity_threshold=similarity_threshold,
+        )
+        if embedder is None:
+            raise ValueError(
+                "`embedder` is required; turbovec needs the embedder's "
+                "`dimensions` to size the underlying index."
+            )
+        if embedder.dimensions is None:
+            raise ValueError("Embedder.dimensions must be set.")
+        if bit_width not in (2, 4):
+            raise ValueError(f"bit_width must be 2 or 4, got {bit_width}")
+        if search_type != SearchType.vector:
+            raise ValueError(
+                f"TurboQuantVectorDb only supports search_type=SearchType.vector; "
+                f"got {search_type}. Use LanceDb / Chroma / etc. for keyword "
+                f"or hybrid search."
+            )
+        if distance != Distance.cosine:
+            raise ValueError(
+                f"TurboQuantVectorDb only supports distance=Distance.cosine; "
+                f"got {distance}. turbovec stores unit-normalized vectors."
+            )
+
+        self.embedder: Embedder = embedder
+        self.dimensions: int = embedder.dimensions
+        self.bit_width = bit_width
+        self.search_type = search_type
+        self.distance = distance
+        self.reranker = reranker
+        self.path: Optional[str] = path
+
+        # Eager IdMapIndex — embedder.dimensions is known.
+        self._index: IdMapIndex = IdMapIndex(self.dimensions, bit_width)
+        # str doc_id -> u64 handle
+        self._str_to_u64: Dict[str, int] = {}
+        # u64 handle -> stored payload (mirrors LanceDb's "payload" shape)
+        self._u64_to_doc: Dict[int, Dict[str, Any]] = {}
+        # u64 handle assignment counter
+        self._next_u64: int = 0
+        # Auxiliary indexes for O(1) protocol queries
+        self._content_hashes: Set[str] = set()
+        self._name_to_ids: Dict[str, Set[str]] = {}
+
+    # ---- handle allocation ------------------------------------------------
+
+    def _issue_handle(self) -> int:
+        self._next_u64 += 1
+        return self._next_u64
+
+    # ---- VectorDb protocol: lifecycle ------------------------------------
+
+    def create(self) -> None:
+        """Initialize the store. If ``path`` was given and the directory
+        contains a previous save, load it; otherwise the store is ready
+        as-is."""
+        if self.path is not None and Path(self.path).is_dir():
+            try:
+                self._load_from(Path(self.path))
+            except FileNotFoundError:
+                # Empty directory — nothing to load.
+                pass
+
+    async def async_create(self) -> None:
+        self.create()
+
+    def drop(self) -> None:
+        """Drop all data and reset to an empty store."""
+        self._index = IdMapIndex(self.dimensions, self.bit_width)
+        self._str_to_u64.clear()
+        self._u64_to_doc.clear()
+        self._next_u64 = 0
+        self._content_hashes.clear()
+        self._name_to_ids.clear()
+
+    async def async_drop(self) -> None:
+        self.drop()
+
+    def exists(self) -> bool:
+        return len(self._index) > 0
+
+    async def async_exists(self) -> bool:
+        return self.exists()
+
+    def delete(self) -> bool:
+        self.drop()
+        return True
+
+    # ---- VectorDb protocol: existence checks ------------------------------
+
+    def name_exists(self, name: str) -> bool:
+        return name in self._name_to_ids
+
+    async def async_name_exists(self, name: str) -> bool:
+        return self.name_exists(name)
+
+    def id_exists(self, id: str) -> bool:
+        return id in self._str_to_u64
+
+    def content_hash_exists(self, content_hash: str) -> bool:
+        return content_hash in self._content_hashes
+
+    # ---- VectorDb protocol: insert / upsert -------------------------------
+
+    @staticmethod
+    def _derive_doc_id(doc: Document, content_hash: str, cleaned_content: str) -> str:
+        """Match LanceDb's id-derivation contract so the same doc with the
+        same content_hash produces the same stable doc_id across stores."""
+        base_id = doc.id or md5(cleaned_content.encode()).hexdigest()
+        return md5(f"{base_id}_{content_hash}".encode()).hexdigest()
+
+    def _embed_missing(self, documents: List[Document]) -> None:
+        """Populate embeddings on any documents that don't have one. Uses
+        the embedder's batch path when available."""
+        to_embed = [
+            doc
+            for doc in documents
+            if doc.embedding is None
+            or (isinstance(doc.embedding, list) and len(doc.embedding) == 0)
+        ]
+        if not to_embed:
+            return
+        if (
+            getattr(self.embedder, "enable_batch", False)
+            and hasattr(self.embedder, "get_embeddings_batch_and_usage")
+        ):
+            contents = [doc.content for doc in to_embed]
+            embeddings, usages = self.embedder.get_embeddings_batch_and_usage(contents)
+            for j, doc in enumerate(to_embed):
+                if j < len(embeddings):
+                    doc.embedding = embeddings[j]
+                    doc.usage = usages[j] if j < len(usages) else None
+        else:
+            for doc in to_embed:
+                doc.embed(embedder=self.embedder)
+
+    async def _embed_missing_async(self, documents: List[Document]) -> None:
+        to_embed = [
+            doc
+            for doc in documents
+            if doc.embedding is None
+            or (isinstance(doc.embedding, list) and len(doc.embedding) == 0)
+        ]
+        if not to_embed:
+            return
+        if (
+            getattr(self.embedder, "enable_batch", False)
+            and hasattr(self.embedder, "async_get_embeddings_batch_and_usage")
+        ):
+            contents = [doc.content for doc in to_embed]
+            embeddings, usages = await self.embedder.async_get_embeddings_batch_and_usage(
+                contents
+            )
+            for j, doc in enumerate(to_embed):
+                if j < len(embeddings):
+                    doc.embedding = embeddings[j]
+                    doc.usage = usages[j] if j < len(usages) else None
+        else:
+            # Embedder has no async batch path — fall back to sync.
+            self._embed_missing(to_embed)
+
+    def insert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if not documents:
+            return
+
+        # Merge `filters` into each document's metadata (matches LanceDb).
+        if filters:
+            for doc in documents:
+                meta = dict(doc.meta_data) if doc.meta_data else {}
+                meta.update(filters)
+                doc.meta_data = meta
+
+        self._embed_missing(documents)
+
+        # Raise on any document that still lacks an embedding rather than
+        # silently dropping — silent drops mask data-pipeline bugs.
+        missing = [doc for doc in documents if not doc.embedding]
+        if missing:
+            ids = [doc.id or "<no id>" for doc in missing]
+            raise ValueError(
+                f"failed to embed {len(missing)} document(s): {ids}"
+            )
+
+        # Batch the entire `documents` list into a single add_with_ids call.
+        # Per-document inserts would invalidate the SIMD-blocked cache
+        # between every doc.
+        vectors = np.asarray([doc.embedding for doc in documents], dtype=np.float32)
+        if vectors.ndim != 2:
+            raise ValueError(
+                f"expected 2D embedding batch, got {vectors.ndim}D"
+            )
+        if vectors.shape[1] != self.dimensions:
+            raise ValueError(
+                f"embedding dim {vectors.shape[1]} does not match "
+                f"index dim {self.dimensions}"
+            )
+        if not vectors.flags["C_CONTIGUOUS"]:
+            vectors = np.ascontiguousarray(vectors)
+
+        handles = np.array(
+            [self._issue_handle() for _ in documents], dtype=np.uint64
+        )
+        self._index.add_with_ids(vectors, handles)
+
+        for doc, handle in zip(documents, handles):
+            cleaned = doc.content.replace("\x00", "�") if doc.content else ""
+            doc_id = self._derive_doc_id(doc, content_hash, cleaned)
+            h = int(handle)
+            self._str_to_u64[doc_id] = h
+            self._u64_to_doc[h] = {
+                "id": doc_id,
+                "name": doc.name,
+                "content": cleaned,
+                "meta_data": dict(doc.meta_data) if doc.meta_data else {},
+                "usage": doc.usage,
+                "content_id": doc.content_id,
+                "content_hash": content_hash,
+            }
+            self._content_hashes.add(content_hash)
+            if doc.name:
+                self._name_to_ids.setdefault(doc.name, set()).add(doc_id)
+
+    async def async_insert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if not documents:
+            return
+        await self._embed_missing_async(documents)
+        # Now every doc should have an embedding; insert delegates to sync.
+        self.insert(content_hash, documents, filters)
+
+    def upsert_available(self) -> bool:
+        return True
+
+    def upsert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        # Compute the deterministic doc_id for each input and remove any
+        # existing entry with the same id, then delegate to insert.
+        for doc in documents:
+            cleaned = doc.content.replace("\x00", "�") if doc.content else ""
+            doc_id = self._derive_doc_id(doc, content_hash, cleaned)
+            if doc_id in self._str_to_u64:
+                self.delete_by_id(doc_id)
+        self.insert(content_hash, documents, filters)
+
+    async def async_upsert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        for doc in documents:
+            cleaned = doc.content.replace("\x00", "�") if doc.content else ""
+            doc_id = self._derive_doc_id(doc, content_hash, cleaned)
+            if doc_id in self._str_to_u64:
+                self.delete_by_id(doc_id)
+        await self.async_insert(content_hash, documents, filters)
+
+    # ---- VectorDb protocol: search ----------------------------------------
+
+    def _resolve_filter_to_handles(
+        self, filters: Optional[Union[Dict[str, Any], List[Any]]]
+    ) -> Optional[List[int]]:
+        """Convert a dict filter into the list of internal u64 handles
+        whose document's ``meta_data`` matches every key/value pair (AND).
+        Returns ``None`` when no filter was supplied — caller should run
+        an unfiltered search. Returns ``[]`` to mean "no matches".
+
+        Matches LanceDb's dict-filter semantics (exact equality, AND of
+        keys). ``FilterExpr``-style list filters are not yet supported
+        in LanceDb itself, so we silently ignore them here too with a
+        debug log.
+        """
+        if filters is None:
+            return None
+        if isinstance(filters, list):
+            # LanceDb logs a warning and ignores. Mirror that — the
+            # alternative is to error and break callers that pass an
+            # accidental list.
+            return None
+        if not isinstance(filters, dict) or not filters:
+            return None
+        items = list(filters.items())
+        return [
+            handle
+            for handle, data in self._u64_to_doc.items()
+            if all((data.get("meta_data") or {}).get(k) == v for k, v in items)
+        ]
+
+    def _scaled_similarity(self, raw: float) -> float:
+        """Map cosine similarity in ``[-1, 1]`` to ``[0, 1]``. Clamped to
+        absorb the small overshoot caused by quantization noise."""
+        return max(0.0, min(1.0, (raw + 1.0) / 2.0))
+
+    def _build_results(
+        self, scores: np.ndarray, handles: np.ndarray
+    ) -> List[Document]:
+        results: List[Document] = []
+        threshold = self.similarity_threshold
+        for raw_score, handle in zip(scores[0], handles[0]):
+            doc_data = self._u64_to_doc.get(int(handle))
+            if doc_data is None:
+                continue
+            similarity = self._scaled_similarity(float(raw_score))
+            if threshold is not None and similarity < threshold:
+                continue
+            results.append(
+                Document(
+                    id=doc_data["id"],
+                    name=doc_data.get("name"),
+                    content=doc_data.get("content", ""),
+                    meta_data=dict(doc_data.get("meta_data") or {}),
+                    usage=doc_data.get("usage"),
+                    content_id=doc_data.get("content_id"),
+                )
+            )
+        return results
+
+    def search(
+        self,
+        query: str,
+        limit: int = 5,
+        filters: Optional[Union[Dict[str, Any], List[Any]]] = None,
+    ) -> List[Document]:
+        if len(self._index) == 0:
+            return []
+
+        query_embedding = self.embedder.get_embedding(query)
+        if query_embedding is None:
+            return []
+        qvec = np.asarray(query_embedding, dtype=np.float32)
+        if qvec.ndim == 1:
+            qvec = qvec[None, :]
+        if not qvec.flags["C_CONTIGUOUS"]:
+            qvec = np.ascontiguousarray(qvec)
+
+        allowed_handles = self._resolve_filter_to_handles(filters)
+        if allowed_handles is None:
+            # Unfiltered.
+            k = min(limit, len(self._index))
+            scores, handles = self._index.search(qvec, k)
+        else:
+            if not allowed_handles:
+                return []
+            allowlist = np.asarray(allowed_handles, dtype=np.uint64)
+            scores, handles = self._index.search(qvec, limit, allowlist=allowlist)
+
+        results = self._build_results(scores, handles)
+        if self.reranker is not None and results:
+            results = self.reranker.rerank(query=query, documents=results)
+        return results
+
+    async def async_search(
+        self,
+        query: str,
+        limit: int = 5,
+        filters: Optional[Union[Dict[str, Any], List[Any]]] = None,
+    ) -> List[Document]:
+        if len(self._index) == 0:
+            return []
+
+        if hasattr(self.embedder, "async_get_embedding"):
+            query_embedding = await self.embedder.async_get_embedding(query)
+        else:
+            query_embedding = self.embedder.get_embedding(query)
+        if query_embedding is None:
+            return []
+        qvec = np.asarray(query_embedding, dtype=np.float32)
+        if qvec.ndim == 1:
+            qvec = qvec[None, :]
+        if not qvec.flags["C_CONTIGUOUS"]:
+            qvec = np.ascontiguousarray(qvec)
+
+        allowed_handles = self._resolve_filter_to_handles(filters)
+        if allowed_handles is None:
+            k = min(limit, len(self._index))
+            scores, handles = self._index.search(qvec, k)
+        else:
+            if not allowed_handles:
+                return []
+            allowlist = np.asarray(allowed_handles, dtype=np.uint64)
+            scores, handles = self._index.search(qvec, limit, allowlist=allowlist)
+
+        results = self._build_results(scores, handles)
+        if self.reranker is not None and results:
+            results = self.reranker.rerank(query=query, documents=results)
+        return results
+
+    def get_supported_search_types(self) -> List[str]:
+        # Only vector. Keyword and hybrid would require an external BM25
+        # / lexical index that turbovec doesn't ship.
+        return [SearchType.vector.value]
+
+    # ---- VectorDb protocol: delete ----------------------------------------
+
+    def delete_by_id(self, id: str) -> bool:
+        handle = self._str_to_u64.pop(id, None)
+        if handle is None:
+            return False
+        doc_data = self._u64_to_doc.pop(handle, None)
+        if doc_data is not None:
+            name = doc_data.get("name")
+            if name and name in self._name_to_ids:
+                self._name_to_ids[name].discard(id)
+                if not self._name_to_ids[name]:
+                    del self._name_to_ids[name]
+        self._index.remove(handle)
+        # Lazily drop content_hash from the set if no surviving doc has it.
+        if doc_data is not None:
+            ch = doc_data.get("content_hash")
+            if ch and not any(
+                d.get("content_hash") == ch for d in self._u64_to_doc.values()
+            ):
+                self._content_hashes.discard(ch)
+        return True
+
+    def delete_by_name(self, name: str) -> bool:
+        ids = list(self._name_to_ids.get(name, set()))
+        for doc_id in ids:
+            self.delete_by_id(doc_id)
+        return bool(ids)
+
+    def delete_by_metadata(self, metadata: Dict[str, Any]) -> bool:
+        items = list(metadata.items())
+        to_delete = [
+            data["id"]
+            for data in self._u64_to_doc.values()
+            if all((data.get("meta_data") or {}).get(k) == v for k, v in items)
+        ]
+        for doc_id in to_delete:
+            self.delete_by_id(doc_id)
+        return bool(to_delete)
+
+    def delete_by_content_id(self, content_id: str) -> bool:
+        to_delete = [
+            data["id"]
+            for data in self._u64_to_doc.values()
+            if data.get("content_id") == content_id
+        ]
+        for doc_id in to_delete:
+            self.delete_by_id(doc_id)
+        return bool(to_delete)
+
+    def update_metadata(self, content_id: str, metadata: Dict[str, Any]) -> None:
+        """Merge ``metadata`` into ``meta_data`` of every document whose
+        ``content_id`` matches. Overrides the base-class no-op log."""
+        for data in self._u64_to_doc.values():
+            if data.get("content_id") == content_id:
+                meta = dict(data.get("meta_data") or {})
+                meta.update(metadata)
+                data["meta_data"] = meta
+
+    # ---- Persistence (JSON side-car) --------------------------------------
+
+    def save(self, folder_path: Optional[str] = None) -> None:
+        """Persist the quantized index plus a JSON side-car to disk. Pass
+        ``folder_path`` to override the constructor's ``path=``.
+
+        Writes two files under ``folder_path``:
+          - ``index.tvim`` — the :class:`IdMapIndex` payload.
+          - ``docstore.json`` — JSON-encoded document text, metadata, and
+            id maps. Side-car carries a ``schema_version`` field; loaders
+            reject unknown versions rather than silently misinterpreting
+            bytes.
+        """
+        path = folder_path if folder_path is not None else self.path
+        if path is None:
+            raise ValueError(
+                "No path to save to. Pass `folder_path=` here or set "
+                "`path=` on the constructor."
+            )
+        folder = Path(path)
+        folder.mkdir(parents=True, exist_ok=True)
+        self._index.write(str(folder / _INDEX_FILENAME))
+        payload = {
+            "schema_version": _DOCSTORE_SCHEMA_VERSION,
+            # Round-trip int handles via list-of-pairs (JSON keys must be
+            # strings, but our handles are ints).
+            "u64_to_doc": [[h, d] for h, d in self._u64_to_doc.items()],
+            "next_u64": self._next_u64,
+            "bit_width": self.bit_width,
+            "dimensions": self.dimensions,
+        }
+        with open(folder / _STORE_FILENAME, "w") as f:
+            json.dump(payload, f)
+
+    def _load_from(self, folder: Path) -> None:
+        side_car = folder / _STORE_FILENAME
+        index_file = folder / _INDEX_FILENAME
+        if not side_car.exists() or not index_file.exists():
+            raise FileNotFoundError(
+                f"missing one of {_STORE_FILENAME}/{_INDEX_FILENAME} under {folder}"
+            )
+        with open(side_car) as f:
+            state = json.load(f)
+        version = state.get("schema_version", 0)
+        if version != _DOCSTORE_SCHEMA_VERSION:
+            raise ValueError(
+                f"{_STORE_FILENAME} has schema_version {version}; this "
+                f"turbovec expects {_DOCSTORE_SCHEMA_VERSION}"
+            )
+        if state.get("dimensions") != self.dimensions:
+            raise ValueError(
+                f"persisted dimensions={state.get('dimensions')} does not "
+                f"match this store's embedder dimensions={self.dimensions}"
+            )
+
+        self._index = IdMapIndex.load(str(index_file))
+        self._u64_to_doc = {int(h): d for h, d in state["u64_to_doc"]}
+        self._next_u64 = int(state["next_u64"])
+
+        # Rebuild reverse indexes from the loaded payload.
+        self._str_to_u64 = {
+            data["id"]: handle for handle, data in self._u64_to_doc.items()
+        }
+        self._content_hashes = set()
+        self._name_to_ids = {}
+        for data in self._u64_to_doc.values():
+            ch = data.get("content_hash")
+            if ch:
+                self._content_hashes.add(ch)
+            name = data.get("name")
+            if name:
+                self._name_to_ids.setdefault(name, set()).add(data["id"])
+
+
+__all__ = ["TurboQuantVectorDb"]

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -125,8 +125,11 @@ class TurboQuantVectorDb(VectorDb):
         self.reranker = reranker
         self.path: Optional[str] = path
 
-        # Eager IdMapIndex — embedder.dimensions is known.
-        self._index: IdMapIndex = IdMapIndex(self.dimensions, bit_width)
+        # Lazy: the underlying IdMapIndex is created by `create()`, not
+        # in __init__. This matches LanceDb's `exists()` contract: a
+        # freshly-constructed store doesn't "exist" until `create()` is
+        # called, and `drop()` returns it to that state.
+        self._index: Optional[IdMapIndex] = None
         # str doc_id -> u64 handle
         self._str_to_u64: Dict[str, int] = {}
         # u64 handle -> stored payload (mirrors LanceDb's "payload" shape)
@@ -146,22 +149,33 @@ class TurboQuantVectorDb(VectorDb):
     # ---- VectorDb protocol: lifecycle ------------------------------------
 
     def create(self) -> None:
-        """Initialize the store. If ``path`` was given and the directory
-        contains a previous save, load it; otherwise the store is ready
-        as-is."""
+        """Create the underlying index if it doesn't already exist.
+        Idempotent — calling on an already-created store is a no-op.
+
+        If ``path`` was set on the constructor and a previous save exists
+        under it, ``create()`` loads that save; otherwise it instantiates
+        a fresh empty index sized to ``embedder.dimensions``.
+        """
+        if self._index is not None:
+            return
+        # Try loading from path first if one was set; fall through to a
+        # fresh index if the path doesn't contain a previous save.
         if self.path is not None and Path(self.path).is_dir():
             try:
                 self._load_from(Path(self.path))
+                return
             except FileNotFoundError:
-                # Empty directory — nothing to load.
                 pass
+        self._index = IdMapIndex(self.dimensions, self.bit_width)
 
     async def async_create(self) -> None:
         self.create()
 
     def drop(self) -> None:
-        """Drop all data and reset to an empty store."""
-        self._index = IdMapIndex(self.dimensions, self.bit_width)
+        """Drop the underlying index. After this call ``exists()`` returns
+        ``False`` until ``create()`` is called again — matches LanceDb's
+        contract where ``drop()`` removes the table entirely."""
+        self._index = None
         self._str_to_u64.clear()
         self._u64_to_doc.clear()
         self._next_u64 = 0
@@ -172,27 +186,56 @@ class TurboQuantVectorDb(VectorDb):
         self.drop()
 
     def exists(self) -> bool:
-        return len(self._index) > 0
+        """True iff the underlying index has been created via ``create()``
+        and not subsequently dropped. Matches LanceDb's
+        "table-exists-in-connection" semantic; *does not* mean
+        "has any documents" — call ``get_count()`` for that."""
+        return self._index is not None
 
     async def async_exists(self) -> bool:
         return self.exists()
 
     def delete(self) -> bool:
-        self.drop()
-        return True
+        """Returns ``False``. The Agno protocol declares this abstract
+        method but LanceDb (the drop-in reference) unconditionally
+        returns False — actual destruction goes through ``drop()``."""
+        return False
+
+    def optimize(self) -> None:
+        """No-op. The underlying quantized index doesn't have a
+        post-write optimization step. Matches LanceDb's ``optimize()``
+        which is also a no-op."""
+        return None
+
+    def get_count(self) -> int:
+        """Number of documents currently stored."""
+        if self._index is None:
+            return 0
+        return len(self._index)
+
+    async def async_get_count(self) -> int:
+        return self.get_count()
 
     # ---- VectorDb protocol: existence checks ------------------------------
 
     def name_exists(self, name: str) -> bool:
+        if self._index is None:
+            return False
         return name in self._name_to_ids
 
     async def async_name_exists(self, name: str) -> bool:
+        # LanceDb raises NotImplementedError here; we have a trivial sync
+        # backing call, so we return the real answer. Intentional deviation.
         return self.name_exists(name)
 
     def id_exists(self, id: str) -> bool:
+        if self._index is None:
+            return False
         return id in self._str_to_u64
 
     def content_hash_exists(self, content_hash: str) -> bool:
+        if self._index is None:
+            return False
         return content_hash in self._content_hashes
 
     # ---- VectorDb protocol: insert / upsert -------------------------------
@@ -262,6 +305,12 @@ class TurboQuantVectorDb(VectorDb):
     ) -> None:
         if not documents:
             return
+        if self._index is None:
+            # Match LanceDb's "table not initialized" handling: do not
+            # silently auto-create. Callers must invoke create() first.
+            raise RuntimeError(
+                "TurboQuantVectorDb not initialized — call create() before insert()."
+            )
 
         # Merge `filters` into each document's metadata (matches LanceDb).
         if filters:
@@ -341,13 +390,11 @@ class TurboQuantVectorDb(VectorDb):
         documents: List[Document],
         filters: Optional[Dict[str, Any]] = None,
     ) -> None:
-        # Compute the deterministic doc_id for each input and remove any
-        # existing entry with the same id, then delegate to insert.
-        for doc in documents:
-            cleaned = doc.content.replace("\x00", "�") if doc.content else ""
-            doc_id = self._derive_doc_id(doc, content_hash, cleaned)
-            if doc_id in self._str_to_u64:
-                self.delete_by_id(doc_id)
+        # Match LanceDb's semantic: replace all documents previously
+        # stored under this content_hash with the incoming batch. Not
+        # "replace by derived doc_id" — that's a different contract.
+        if self.content_hash_exists(content_hash):
+            self._delete_by_content_hash(content_hash)
         self.insert(content_hash, documents, filters)
 
     async def async_upsert(
@@ -356,12 +403,24 @@ class TurboQuantVectorDb(VectorDb):
         documents: List[Document],
         filters: Optional[Dict[str, Any]] = None,
     ) -> None:
-        for doc in documents:
-            cleaned = doc.content.replace("\x00", "�") if doc.content else ""
-            doc_id = self._derive_doc_id(doc, content_hash, cleaned)
-            if doc_id in self._str_to_u64:
-                self.delete_by_id(doc_id)
+        if self.content_hash_exists(content_hash):
+            self._delete_by_content_hash(content_hash)
         await self.async_insert(content_hash, documents, filters)
+
+    def _delete_by_content_hash(self, content_hash: str) -> bool:
+        """Internal helper matching LanceDb's same-named method: delete
+        every document whose ``content_hash`` matches. Returns True if at
+        least one document was deleted."""
+        if self._index is None:
+            return False
+        to_delete = [
+            data["id"]
+            for data in self._u64_to_doc.values()
+            if data.get("content_hash") == content_hash
+        ]
+        for doc_id in to_delete:
+            self.delete_by_id(doc_id)
+        return bool(to_delete)
 
     # ---- VectorDb protocol: search ----------------------------------------
 
@@ -429,7 +488,7 @@ class TurboQuantVectorDb(VectorDb):
         limit: int = 5,
         filters: Optional[Union[Dict[str, Any], List[Any]]] = None,
     ) -> List[Document]:
-        if len(self._index) == 0:
+        if self._index is None or len(self._index) == 0:
             return []
 
         query_embedding = self.embedder.get_embedding(query)
@@ -463,7 +522,7 @@ class TurboQuantVectorDb(VectorDb):
         limit: int = 5,
         filters: Optional[Union[Dict[str, Any], List[Any]]] = None,
     ) -> List[Document]:
-        if len(self._index) == 0:
+        if self._index is None or len(self._index) == 0:
             return []
 
         if hasattr(self.embedder, "async_get_embedding"):
@@ -493,14 +552,18 @@ class TurboQuantVectorDb(VectorDb):
             results = self.reranker.rerank(query=query, documents=results)
         return results
 
-    def get_supported_search_types(self) -> List[str]:
+    def get_supported_search_types(self) -> List[SearchType]:
         # Only vector. Keyword and hybrid would require an external BM25
-        # / lexical index that turbovec doesn't ship.
-        return [SearchType.vector.value]
+        # / lexical index that turbovec doesn't ship. Return shape
+        # mirrors LanceDb: a list of SearchType enum members (not their
+        # `.value` strings).
+        return [SearchType.vector]
 
     # ---- VectorDb protocol: delete ----------------------------------------
 
     def delete_by_id(self, id: str) -> bool:
+        if self._index is None:
+            return False
         handle = self._str_to_u64.pop(id, None)
         if handle is None:
             return False
@@ -522,12 +585,16 @@ class TurboQuantVectorDb(VectorDb):
         return True
 
     def delete_by_name(self, name: str) -> bool:
+        if self._index is None:
+            return False
         ids = list(self._name_to_ids.get(name, set()))
         for doc_id in ids:
             self.delete_by_id(doc_id)
         return bool(ids)
 
     def delete_by_metadata(self, metadata: Dict[str, Any]) -> bool:
+        if self._index is None:
+            return False
         items = list(metadata.items())
         to_delete = [
             data["id"]
@@ -539,6 +606,8 @@ class TurboQuantVectorDb(VectorDb):
         return bool(to_delete)
 
     def delete_by_content_id(self, content_id: str) -> bool:
+        if self._index is None:
+            return False
         to_delete = [
             data["id"]
             for data in self._u64_to_doc.values()
@@ -549,13 +618,25 @@ class TurboQuantVectorDb(VectorDb):
         return bool(to_delete)
 
     def update_metadata(self, content_id: str, metadata: Dict[str, Any]) -> None:
-        """Merge ``metadata`` into ``meta_data`` of every document whose
-        ``content_id`` matches. Overrides the base-class no-op log."""
+        """Merge ``metadata`` into both ``meta_data`` and the ``filters``
+        payload field of every document whose ``content_id`` matches.
+        Mirrors LanceDb's update_metadata semantic which writes to both
+        fields (used by callers that pass filter-style restrictions at
+        retrieval time)."""
+        if self._index is None:
+            return
         for data in self._u64_to_doc.values():
             if data.get("content_id") == content_id:
                 meta = dict(data.get("meta_data") or {})
                 meta.update(metadata)
                 data["meta_data"] = meta
+                filters = data.get("filters")
+                if isinstance(filters, dict):
+                    filters = dict(filters)
+                    filters.update(metadata)
+                    data["filters"] = filters
+                else:
+                    data["filters"] = dict(metadata)
 
     # ---- Persistence (JSON side-car) --------------------------------------
 
@@ -575,6 +656,10 @@ class TurboQuantVectorDb(VectorDb):
             raise ValueError(
                 "No path to save to. Pass `folder_path=` here or set "
                 "`path=` on the constructor."
+            )
+        if self._index is None:
+            raise RuntimeError(
+                "TurboQuantVectorDb has no index to save — call create() first."
             )
         folder = Path(path)
         folder.mkdir(parents=True, exist_ok=True)

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -1,0 +1,444 @@
+"""Tests for the Agno VectorDb integration."""
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+pytest.importorskip("agno")
+
+from agno.knowledge.document import Document
+from agno.vectordb.distance import Distance
+from agno.vectordb.search import SearchType
+
+from turbovec.agno import TurboQuantVectorDb
+
+
+DIM = 64
+
+
+class StubEmbedder:
+    """Deterministic Agno-style embedder for tests.
+
+    Implements the minimal embedder surface the integration uses:
+    ``dimensions`` attribute, ``get_embedding(text)`` method,
+    ``enable_batch`` attribute (False — we don't exercise batch).
+    """
+
+    enable_batch = False
+
+    def __init__(self, dim: int = DIM) -> None:
+        self.dimensions = dim
+
+    def _embed(self, text: str) -> list[float]:
+        rng = np.random.default_rng(abs(hash(text)) % (2**32))
+        v = rng.standard_normal(self.dimensions).astype(np.float32)
+        v /= np.linalg.norm(v) + 1e-9
+        return v.tolist()
+
+    def get_embedding(self, text: str) -> list[float]:
+        return self._embed(text)
+
+    async def async_get_embedding(self, text: str) -> list[float]:
+        return self._embed(text)
+
+
+def _doc(content: str, *, doc_id: str | None = None, name: str | None = None,
+         meta_data: dict | None = None, content_id: str | None = None,
+         pre_embed: bool = True) -> Document:
+    embedder = StubEmbedder(DIM)
+    return Document(
+        id=doc_id,
+        name=name,
+        content=content,
+        meta_data=meta_data or {},
+        content_id=content_id,
+        embedding=embedder._embed(content) if pre_embed else None,
+    )
+
+
+# ---- Constructor validation -----------------------------------------------
+
+
+def test_constructor_requires_embedder():
+    with pytest.raises(ValueError, match="embedder.*required"):
+        TurboQuantVectorDb()
+
+
+def test_constructor_rejects_embedder_without_dimensions():
+    class NoDimEmbedder:
+        dimensions = None
+        enable_batch = False
+        def get_embedding(self, t): return [0.0] * 64
+
+    with pytest.raises(ValueError, match="dimensions"):
+        TurboQuantVectorDb(embedder=NoDimEmbedder())
+
+
+def test_constructor_rejects_keyword_search_type():
+    with pytest.raises(ValueError, match="search_type"):
+        TurboQuantVectorDb(embedder=StubEmbedder(), search_type=SearchType.keyword)
+
+
+def test_constructor_rejects_non_cosine_distance():
+    with pytest.raises(ValueError, match="distance"):
+        TurboQuantVectorDb(embedder=StubEmbedder(), distance=Distance.l2)
+
+
+def test_constructor_rejects_invalid_bit_width():
+    with pytest.raises(ValueError, match="bit_width"):
+        TurboQuantVectorDb(embedder=StubEmbedder(), bit_width=8)
+
+
+def test_dim_inferred_from_embedder():
+    db = TurboQuantVectorDb(embedder=StubEmbedder(dim=128))
+    assert db.dimensions == 128
+    assert db._index.dim == 128
+
+
+# ---- Basic insert / search ------------------------------------------------
+
+
+def test_create_initializes_store():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    assert db._index.dim == DIM
+    assert db.exists() is False  # empty
+
+
+def test_insert_and_search_returns_documents():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("hash-1", [_doc("alpha"), _doc("beta"), _doc("gamma")])
+    assert db.exists() is True
+    results = db.search("alpha", limit=2)
+    assert len(results) == 2
+    assert all(isinstance(r, Document) for r in results)
+
+
+def test_insert_raises_on_document_without_embedding():
+    # When the embedder can't produce an embedding (returns None), insert
+    # must raise rather than silently dropping the document.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+
+    class FailingEmbedder:
+        dimensions = DIM
+        enable_batch = False
+        # Document.embed() actually goes through get_embedding_and_usage.
+        def get_embedding(self, t): return None
+        def get_embedding_and_usage(self, t): return None, None
+
+    db.embedder = FailingEmbedder()
+    no_emb = _doc("x", pre_embed=False)
+    no_emb.embedding = None
+    with pytest.raises(ValueError, match="failed to embed"):
+        db.insert("h", [no_emb])
+
+
+def test_insert_batches_into_single_add_call():
+    # Exercising a batch larger than one. We can't directly observe that the
+    # underlying add_with_ids was called once, but we can confirm the result
+    # is correct and the index size is right.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    docs = [_doc(f"text-{i}", doc_id=f"d-{i}") for i in range(8)]
+    db.insert("hash-batch", docs)
+    assert len(db._index) == 8
+
+
+# ---- Existence checks -----------------------------------------------------
+
+
+def test_name_exists():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("content", name="my-file.pdf")])
+    assert db.name_exists("my-file.pdf") is True
+    assert db.name_exists("nope.pdf") is False
+
+
+def test_id_exists_uses_derived_id():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("content", doc_id="base-id")])
+    # id_exists must use the *derived* id (md5(base_id + content_hash)),
+    # not the input id directly.
+    derived = next(iter(db._str_to_u64.keys()))
+    assert db.id_exists(derived) is True
+    assert db.id_exists("base-id") is False
+
+
+def test_content_hash_exists_o1():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("unique-hash", [_doc("x")])
+    assert db.content_hash_exists("unique-hash") is True
+    assert db.content_hash_exists("other-hash") is False
+
+
+# ---- Filters (kernel allowlist) -------------------------------------------
+
+
+def test_search_with_metadata_filter():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    docs = [
+        _doc("alpha", doc_id="a", meta_data={"tag": "keep"}),
+        _doc("beta",  doc_id="b", meta_data={"tag": "drop"}),
+        _doc("gamma", doc_id="g", meta_data={"tag": "keep"}),
+    ]
+    db.insert("h", docs)
+    results = db.search("alpha", limit=10, filters={"tag": "keep"})
+    assert len(results) == 2
+    assert all(r.meta_data["tag"] == "keep" for r in results)
+
+
+def test_search_with_selective_filter_returns_top_k():
+    # Regression for the over-fetch / post-filter recall hit: filter that
+    # matches 3 of 50 docs with limit=3 must return all 3, even when those
+    # docs aren't in the unfiltered top-3 by raw score.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    docs = []
+    for i in range(50):
+        meta = {"tag": "needle"} if i in (7, 23, 41) else {"tag": "hay"}
+        docs.append(_doc(f"text-{i}", doc_id=f"d-{i}", meta_data=meta))
+    db.insert("h", docs)
+    results = db.search("text-0", limit=3, filters={"tag": "needle"})
+    assert len(results) == 3
+    assert all(r.meta_data["tag"] == "needle" for r in results)
+
+
+def test_search_with_no_matching_filter_returns_empty():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("alpha", meta_data={"tag": "a"})])
+    results = db.search("alpha", limit=5, filters={"tag": "nonexistent"})
+    assert results == []
+
+
+def test_search_list_filter_silently_ignored():
+    # Match LanceDb behavior: list-of-FilterExpr filters are ignored.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a"), _doc("b")])
+    results = db.search("a", limit=2, filters=["something"])
+    assert len(results) == 2  # filter ignored, full search
+
+
+# ---- Similarity threshold -------------------------------------------------
+
+
+def test_similarity_threshold_filters_low_scores():
+    # threshold=1.0 should drop everything except an exact self-match.
+    db = TurboQuantVectorDb(embedder=StubEmbedder(), similarity_threshold=0.99)
+    db.create()
+    db.insert("h", [_doc("alpha"), _doc("very different content here")])
+    results = db.search("alpha", limit=5)
+    # Self-match scaled to ~1.0; the other doc much lower.
+    assert len(results) >= 1
+    assert results[0].content == "alpha"
+
+
+# ---- Upsert ---------------------------------------------------------------
+
+
+def test_upsert_replaces_existing_doc_id():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("v1", doc_id="same")])
+    handle_before = next(iter(db._str_to_u64.values()))
+    db.upsert("h", [_doc("v1", doc_id="same")])
+    handle_after = next(iter(db._str_to_u64.values()))
+    assert len(db._index) == 1
+    # Handle should have changed (entry was removed and re-added).
+    assert handle_after != handle_before
+
+
+def test_upsert_distinct_content_hashes_keep_separate_entries():
+    # The doc_id is derived from (base_id, content_hash). Same base_id with
+    # different content_hash should produce two distinct stored entries.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.upsert("hash-A", [_doc("x", doc_id="same-base")])
+    db.upsert("hash-B", [_doc("x", doc_id="same-base")])
+    assert len(db._index) == 2
+
+
+# ---- Delete ---------------------------------------------------------------
+
+
+def test_delete_by_id_returns_bool():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a", doc_id="x")])
+    derived = next(iter(db._str_to_u64.keys()))
+    assert db.delete_by_id(derived) is True
+    assert db.delete_by_id("nonexistent") is False
+    assert len(db._index) == 0
+
+
+def test_delete_by_name_removes_all_matching():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [
+        _doc("a", name="paper.pdf"),
+        _doc("b", name="paper.pdf"),
+        _doc("c", name="other.pdf"),
+    ])
+    assert db.delete_by_name("paper.pdf") is True
+    assert db.delete_by_name("paper.pdf") is False  # already gone
+    assert len(db._index) == 1
+
+
+def test_delete_by_metadata_uses_and_semantics():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [
+        _doc("a", meta_data={"tag": "x", "src": "web"}),
+        _doc("b", meta_data={"tag": "x", "src": "pdf"}),
+        _doc("c", meta_data={"tag": "y", "src": "web"}),
+    ])
+    assert db.delete_by_metadata({"tag": "x", "src": "web"}) is True
+    assert len(db._index) == 2
+
+
+def test_delete_by_content_id():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [
+        _doc("a", content_id="cid-1"),
+        _doc("b", content_id="cid-2"),
+    ])
+    assert db.delete_by_content_id("cid-1") is True
+    assert db.delete_by_content_id("cid-1") is False
+    assert len(db._index) == 1
+
+
+def test_drop_clears_all_state():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a", name="foo")])
+    db.drop()
+    assert len(db._index) == 0
+    assert db._str_to_u64 == {}
+    assert db._u64_to_doc == {}
+    assert db._content_hashes == set()
+    assert db._name_to_ids == {}
+
+
+def test_delete_returns_true():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a")])
+    assert db.delete() is True
+    assert len(db._index) == 0
+
+
+# ---- update_metadata ------------------------------------------------------
+
+
+def test_update_metadata_merges_by_content_id():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a", content_id="cid", meta_data={"old": 1})])
+    db.update_metadata("cid", {"new": 2})
+    docs = list(db._u64_to_doc.values())
+    assert docs[0]["meta_data"] == {"old": 1, "new": 2}
+
+
+# ---- Persistence ---------------------------------------------------------
+
+
+def test_save_writes_json_sidecar(tmp_path):
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a", doc_id="x"), _doc("b", doc_id="y")])
+    db.save(str(tmp_path))
+    assert (tmp_path / "index.tvim").exists()
+    assert (tmp_path / "docstore.json").exists()
+    assert not (tmp_path / "docstore.pkl").exists()
+    with open(tmp_path / "docstore.json") as f:
+        data = json.load(f)
+    assert data["schema_version"] == 1
+    assert data["dimensions"] == DIM
+
+
+def test_save_and_load_via_path_param(tmp_path):
+    embedder = StubEmbedder()
+    db = TurboQuantVectorDb(embedder=embedder, path=str(tmp_path))
+    db.create()
+    db.insert("h", [_doc("a"), _doc("b"), _doc("c")])
+    db.save()
+
+    # Fresh store with same path should load on create().
+    db2 = TurboQuantVectorDb(embedder=embedder, path=str(tmp_path))
+    db2.create()
+    assert len(db2._index) == 3
+    # Query through the loaded store still works.
+    results = db2.search("a", limit=3)
+    assert len(results) == 3
+
+
+def test_save_requires_path():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    with pytest.raises(ValueError, match="path"):
+        db.save()
+
+
+def test_load_rejects_unknown_schema_version(tmp_path):
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a")])
+    db.save(str(tmp_path))
+    with open(tmp_path / "docstore.json") as f:
+        data = json.load(f)
+    data["schema_version"] = 99
+    with open(tmp_path / "docstore.json", "w") as f:
+        json.dump(data, f)
+    with pytest.raises(ValueError, match="schema_version"):
+        TurboQuantVectorDb(embedder=StubEmbedder(), path=str(tmp_path)).create()
+
+
+def test_load_rejects_dimension_mismatch(tmp_path):
+    db = TurboQuantVectorDb(embedder=StubEmbedder(dim=64))
+    db.create()
+    db.insert("h", [_doc("a")])
+    db.save(str(tmp_path))
+    # New store with a different-dim embedder must refuse to load.
+    with pytest.raises(ValueError, match="dimensions"):
+        TurboQuantVectorDb(embedder=StubEmbedder(dim=128), path=str(tmp_path)).create()
+
+
+# ---- Protocol coverage ----------------------------------------------------
+
+
+def test_supported_search_types():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    assert db.get_supported_search_types() == [SearchType.vector.value]
+
+
+def test_upsert_available():
+    assert TurboQuantVectorDb(embedder=StubEmbedder()).upsert_available() is True
+
+
+# ---- Async coverage -------------------------------------------------------
+
+
+def test_async_round_trip():
+    import asyncio
+
+    async def runner():
+        db = TurboQuantVectorDb(embedder=StubEmbedder())
+        await db.async_create()
+        await db.async_insert("h", [_doc("a"), _doc("b"), _doc("c")])
+        assert await db.async_exists() is True
+        results = await db.async_search("a", limit=2)
+        assert len(results) == 2
+        await db.async_drop()
+        assert await db.async_exists() is False
+
+    asyncio.run(runner())

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -94,7 +94,91 @@ def test_constructor_rejects_invalid_bit_width():
 def test_dim_inferred_from_embedder():
     db = TurboQuantVectorDb(embedder=StubEmbedder(dim=128))
     assert db.dimensions == 128
+    # The underlying index isn't constructed until create() (LanceDb's
+    # contract: store object exists, but the "table" doesn't until you
+    # ask for it). dim is on the embedder regardless.
+    assert db._index is None
+    db.create()
     assert db._index.dim == 128
+
+
+# ---- Lifecycle (create / exists / drop / delete / get_count) -------------
+
+
+def test_exists_false_until_create():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    assert db.exists() is False
+    db.create()
+    assert db.exists() is True
+
+
+def test_create_is_idempotent():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    first_index = db._index
+    db.create()
+    # Second call doesn't blow away the existing index.
+    assert db._index is first_index
+
+
+def test_drop_returns_to_uncreated_state():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a")])
+    assert db.exists() is True
+    db.drop()
+    assert db.exists() is False
+    assert db._index is None
+    # Re-create works and gives a fresh store.
+    db.create()
+    assert db.exists() is True
+    assert db.get_count() == 0
+
+
+def test_delete_returns_false_per_lancedb_contract():
+    # LanceDb's delete() unconditionally returns False — actual removal
+    # is via drop(). Mirror that exactly.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a")])
+    assert db.delete() is False
+    # delete() is a no-op; the index is still there.
+    assert db.exists() is True
+
+
+def test_get_count():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    assert db.get_count() == 0  # before create
+    db.create()
+    assert db.get_count() == 0  # empty after create
+    db.insert("h", [_doc("a"), _doc("b"), _doc("c")])
+    assert db.get_count() == 3
+
+
+def test_optimize_is_noop():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    # Must not raise NotImplementedError (which the base class does).
+    db.optimize()
+
+
+def test_insert_before_create_raises():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    with pytest.raises(RuntimeError, match="not initialized"):
+        db.insert("h", [_doc("a")])
+
+
+def test_search_before_create_returns_empty():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    assert db.search("anything", limit=5) == []
+
+
+def test_delete_methods_before_create_return_false():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    assert db.delete_by_id("x") is False
+    assert db.delete_by_name("x") is False
+    assert db.delete_by_metadata({"a": 1}) is False
+    assert db.delete_by_content_id("x") is False
 
 
 # ---- Basic insert / search ------------------------------------------------
@@ -102,9 +186,11 @@ def test_dim_inferred_from_embedder():
 
 def test_create_initializes_store():
     db = TurboQuantVectorDb(embedder=StubEmbedder())
+    assert db.exists() is False
     db.create()
+    assert db.exists() is True
     assert db._index.dim == DIM
-    assert db.exists() is False  # empty
+    assert db.get_count() == 0
 
 
 def test_insert_and_search_returns_documents():
@@ -232,39 +318,47 @@ def test_search_list_filter_silently_ignored():
 
 
 def test_similarity_threshold_filters_low_scores():
-    # threshold=1.0 should drop everything except an exact self-match.
-    db = TurboQuantVectorDb(embedder=StubEmbedder(), similarity_threshold=0.99)
+    # similarity_threshold drops results whose scaled cosine is below
+    # the threshold. Use a generous margin: the StubEmbedder produces
+    # vectors that hash random text to roughly orthogonal directions
+    # (raw cosine near 0 -> scaled ~0.5), so threshold=0.9 reliably
+    # excludes the unrelated doc while letting the self-match through.
+    db = TurboQuantVectorDb(embedder=StubEmbedder(), similarity_threshold=0.9)
     db.create()
     db.insert("h", [_doc("alpha"), _doc("very different content here")])
     results = db.search("alpha", limit=5)
-    # Self-match scaled to ~1.0; the other doc much lower.
+    # Self-match scales to ~1.0; the unrelated doc to ~0.5. Threshold
+    # filters out the unrelated one.
     assert len(results) >= 1
-    assert results[0].content == "alpha"
+    assert all(r.content == "alpha" for r in results)
 
 
 # ---- Upsert ---------------------------------------------------------------
 
 
-def test_upsert_replaces_existing_doc_id():
+def test_upsert_replaces_entire_batch_under_content_hash():
+    # LanceDb's contract: upsert deletes EVERY existing document under
+    # the given content_hash before inserting the new batch. The unit of
+    # replacement is the content_hash, not the doc_id.
     db = TurboQuantVectorDb(embedder=StubEmbedder())
     db.create()
-    db.insert("h", [_doc("v1", doc_id="same")])
-    handle_before = next(iter(db._str_to_u64.values()))
-    db.upsert("h", [_doc("v1", doc_id="same")])
-    handle_after = next(iter(db._str_to_u64.values()))
-    assert len(db._index) == 1
-    # Handle should have changed (entry was removed and re-added).
-    assert handle_after != handle_before
+    db.insert("h-v1", [_doc("a"), _doc("b"), _doc("c")])
+    assert db.get_count() == 3
+    # Re-upsert under the same content_hash with a smaller batch — the
+    # original 3 docs go away and only the new ones remain.
+    db.upsert("h-v1", [_doc("z")])
+    assert db.get_count() == 1
 
 
 def test_upsert_distinct_content_hashes_keep_separate_entries():
-    # The doc_id is derived from (base_id, content_hash). Same base_id with
-    # different content_hash should produce two distinct stored entries.
+    # The doc_id is derived from (base_id, content_hash). Different
+    # content_hashes don't collide, so upserting under a new hash leaves
+    # existing entries alone.
     db = TurboQuantVectorDb(embedder=StubEmbedder())
     db.create()
     db.upsert("hash-A", [_doc("x", doc_id="same-base")])
     db.upsert("hash-B", [_doc("x", doc_id="same-base")])
-    assert len(db._index) == 2
+    assert db.get_count() == 2
 
 
 # ---- Delete ---------------------------------------------------------------
@@ -322,19 +416,12 @@ def test_drop_clears_all_state():
     db.create()
     db.insert("h", [_doc("a", name="foo")])
     db.drop()
-    assert len(db._index) == 0
+    # drop() releases the underlying index; exists() goes back to False.
+    assert db._index is None
     assert db._str_to_u64 == {}
     assert db._u64_to_doc == {}
     assert db._content_hashes == set()
     assert db._name_to_ids == {}
-
-
-def test_delete_returns_true():
-    db = TurboQuantVectorDb(embedder=StubEmbedder())
-    db.create()
-    db.insert("h", [_doc("a")])
-    assert db.delete() is True
-    assert len(db._index) == 0
 
 
 # ---- update_metadata ------------------------------------------------------
@@ -347,6 +434,18 @@ def test_update_metadata_merges_by_content_id():
     db.update_metadata("cid", {"new": 2})
     docs = list(db._u64_to_doc.values())
     assert docs[0]["meta_data"] == {"old": 1, "new": 2}
+
+
+def test_update_metadata_writes_filters_field():
+    # LanceDb's update_metadata writes to BOTH `meta_data` and a separate
+    # `filters` payload field. Mirror that — drop-in callers reading the
+    # filters field after an update expect to find it.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a", content_id="cid", meta_data={"old": 1})])
+    db.update_metadata("cid", {"new": 2})
+    docs = list(db._u64_to_doc.values())
+    assert docs[0]["filters"] == {"new": 2}
 
 
 # ---- Persistence ---------------------------------------------------------
@@ -417,8 +516,13 @@ def test_load_rejects_dimension_mismatch(tmp_path):
 
 
 def test_supported_search_types():
+    # Mirror LanceDb's return shape: a list of SearchType enum members
+    # (not their `.value` strings). Drop-in callers iterating this list
+    # would unwrap enum members, so the return type matters.
     db = TurboQuantVectorDb(embedder=StubEmbedder())
-    assert db.get_supported_search_types() == [SearchType.vector.value]
+    types = db.get_supported_search_types()
+    assert types == [SearchType.vector]
+    assert isinstance(types[0], SearchType)
 
 
 def test_upsert_available():
@@ -442,3 +546,61 @@ def test_async_round_trip():
         assert await db.async_exists() is False
 
     asyncio.run(runner())
+
+
+# ---- End-to-end smoke test: framework wiring -----------------------------
+
+
+def test_knowledge_search_routes_through_vector_db():
+    # Smoke test: build an Agno Knowledge with our vector_db and call
+    # Knowledge.search() — the framework's top-level retrieval API.
+    # Exercises the wiring between Knowledge and VectorDb.search.
+    from agno.knowledge import Knowledge
+
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    # Seed the underlying vector_db directly — Knowledge.add_content's
+    # real path goes through readers, which we don't need to exercise
+    # here. The smoke test target is the search-routing surface.
+    db.insert(
+        "seed",
+        [
+            _doc("alpha", doc_id="d1", meta_data={"category": "a"}),
+            _doc("beta",  doc_id="d2", meta_data={"category": "b"}),
+            _doc("gamma", doc_id="d3", meta_data={"category": "a"}),
+        ],
+    )
+
+    knowledge = Knowledge(vector_db=db)
+    results = knowledge.search("alpha", max_results=3)
+    assert len(results) == 3
+    assert all(isinstance(r, Document) for r in results)
+
+
+def test_knowledge_search_with_filter_routes_through_kernel_allowlist():
+    # Verify the filter kwarg reaches our search() through Knowledge's
+    # wrapper, and that the kernel-level allowlist path is used (not
+    # post-filtering).
+    from agno.knowledge import Knowledge
+
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert(
+        "seed",
+        [
+            _doc(f"text-{i}", doc_id=f"d-{i}",
+                 meta_data={"tag": "needle" if i in (7, 23, 41) else "hay"})
+            for i in range(50)
+        ],
+    )
+
+    knowledge = Knowledge(vector_db=db)
+    results = knowledge.search(
+        "text-0",
+        max_results=3,
+        filters={"tag": "needle"},
+    )
+    # Selective filter: 3 of 50 match; max_results=3 must return all 3.
+    # Post-filter+over-fetch would have returned <3 results.
+    assert len(results) == 3
+    assert all(r.meta_data["tag"] == "needle" for r in results)

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -58,6 +58,41 @@ def _doc(content: str, *, doc_id: str | None = None, name: str | None = None,
     )
 
 
+class BatchEmbedder(StubEmbedder):
+    """Embedder that advertises ``enable_batch`` and exposes both sync
+    and async batch methods. Used to verify the integration takes the
+    batch path when it's available."""
+
+    enable_batch = True
+
+    def __init__(self, dim: int = DIM) -> None:
+        super().__init__(dim)
+        self.sync_batch_calls = 0
+        self.async_batch_calls = 0
+
+    def get_embeddings_batch_and_usage(self, texts):
+        self.sync_batch_calls += 1
+        return [self._embed(t) for t in texts], [{"tokens": 1} for _ in texts]
+
+    async def async_get_embeddings_batch_and_usage(self, texts):
+        self.async_batch_calls += 1
+        return [self._embed(t) for t in texts], [{"tokens": 1} for _ in texts]
+
+
+from agno.knowledge.reranker.base import Reranker as _AgnoReranker
+
+
+class ReverseReranker(_AgnoReranker):
+    """Trivial reranker that returns documents in reversed order. Used
+    to verify the integration calls .rerank() on the result list."""
+
+    calls: int = 0
+
+    def rerank(self, query: str, documents):
+        type(self).calls += 1
+        return list(reversed(documents))
+
+
 # ---- Constructor validation -----------------------------------------------
 
 
@@ -604,3 +639,195 @@ def test_knowledge_search_with_filter_routes_through_kernel_allowlist():
     # Post-filter+over-fetch would have returned <3 results.
     assert len(results) == 3
     assert all(r.meta_data["tag"] == "needle" for r in results)
+
+
+# ---- Reranker integration -------------------------------------------------
+
+
+def test_reranker_called_on_search_results():
+    # Verify the constructor's `reranker` is actually invoked on the
+    # search() result list and that its return value replaces the
+    # unranked order.
+    ReverseReranker.calls = 0
+    reranker = ReverseReranker()
+    db = TurboQuantVectorDb(embedder=StubEmbedder(), reranker=reranker)
+    db.create()
+    db.insert("h", [_doc("a"), _doc("b"), _doc("c")])
+    results = db.search("a", limit=3)
+    assert ReverseReranker.calls == 1
+    # ReverseReranker reverses, so the natural top-result (the self-match
+    # 'a') ends up last after rerank.
+    assert results[-1].content == "a"
+
+
+def test_reranker_called_on_async_search_results():
+    import asyncio
+
+    async def runner():
+        ReverseReranker.calls = 0
+        reranker = ReverseReranker()
+        db = TurboQuantVectorDb(embedder=StubEmbedder(), reranker=reranker)
+        await db.async_create()
+        await db.async_insert("h", [_doc("a"), _doc("b"), _doc("c")])
+        results = await db.async_search("a", limit=3)
+        assert ReverseReranker.calls == 1
+        assert results[-1].content == "a"
+
+    asyncio.run(runner())
+
+
+def test_reranker_not_called_on_empty_results():
+    # Defensive: an empty results list shouldn't go to the reranker —
+    # nothing to rank. Avoids unnecessary work.
+    ReverseReranker.calls = 0
+    reranker = ReverseReranker()
+    db = TurboQuantVectorDb(embedder=StubEmbedder(), reranker=reranker)
+    db.create()
+    # No documents inserted -> empty search results.
+    results = db.search("anything", limit=5)
+    assert results == []
+    assert ReverseReranker.calls == 0
+
+
+# ---- insert(filters=) merges into meta_data -------------------------------
+
+
+def test_insert_filters_kwarg_merges_into_doc_metadata():
+    # The `filters` kwarg on insert should merge into each document's
+    # meta_data — matches LanceDb's contract where these become part of
+    # the doc's stored metadata and are searchable later.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    docs = [
+        _doc("a", doc_id="d1", meta_data={"existing": 1}),
+        _doc("b", doc_id="d2", meta_data={"existing": 2}),
+    ]
+    db.insert("h", docs, filters={"tenant": "acme", "tier": "pro"})
+    for data in db._u64_to_doc.values():
+        # Original meta_data preserved...
+        assert "existing" in data["meta_data"]
+        # ...and the filter kwargs merged in.
+        assert data["meta_data"]["tenant"] == "acme"
+        assert data["meta_data"]["tier"] == "pro"
+
+
+def test_insert_filters_kwarg_is_searchable_after_insert():
+    # The merged filter values should be visible to subsequent
+    # search(..., filters={...}) calls — they're real metadata now.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h-a", [_doc("alpha")], filters={"tenant": "acme"})
+    db.insert("h-b", [_doc("beta")],  filters={"tenant": "globex"})
+    results = db.search("alpha", limit=5, filters={"tenant": "acme"})
+    assert len(results) == 1
+    assert results[0].content == "alpha"
+
+
+# ---- Async-only coverage --------------------------------------------------
+
+
+def test_async_name_exists():
+    import asyncio
+
+    async def runner():
+        db = TurboQuantVectorDb(embedder=StubEmbedder())
+        await db.async_create()
+        await db.async_insert("h", [_doc("a", name="foo.pdf")])
+        assert await db.async_name_exists("foo.pdf") is True
+        assert await db.async_name_exists("missing.pdf") is False
+
+    asyncio.run(runner())
+
+
+def test_async_get_count():
+    import asyncio
+
+    async def runner():
+        db = TurboQuantVectorDb(embedder=StubEmbedder())
+        assert await db.async_get_count() == 0  # before create
+        await db.async_create()
+        await db.async_insert("h", [_doc("a"), _doc("b")])
+        assert await db.async_get_count() == 2
+
+    asyncio.run(runner())
+
+
+def test_async_upsert_replaces_by_content_hash():
+    # Same contract as sync upsert: replace everything under the
+    # given content_hash. Exercises the async code path explicitly.
+    import asyncio
+
+    async def runner():
+        db = TurboQuantVectorDb(embedder=StubEmbedder())
+        await db.async_create()
+        await db.async_insert("hv1", [_doc("a"), _doc("b"), _doc("c")])
+        assert db.get_count() == 3
+        await db.async_upsert("hv1", [_doc("z")])
+        assert db.get_count() == 1
+
+    asyncio.run(runner())
+
+
+# ---- Batch embedder paths -------------------------------------------------
+
+
+def test_insert_uses_sync_batch_embedder_path():
+    # When embedder.enable_batch is True AND it exposes
+    # get_embeddings_batch_and_usage, insert() should route through that
+    # batch method instead of per-document embed() calls.
+    emb = BatchEmbedder()
+    db = TurboQuantVectorDb(embedder=emb)
+    db.create()
+    # Docs without embeddings → must be embedded by the integration.
+    docs = [
+        _doc("a", doc_id="d1", pre_embed=False),
+        _doc("b", doc_id="d2", pre_embed=False),
+        _doc("c", doc_id="d3", pre_embed=False),
+    ]
+    db.insert("h", docs)
+    assert emb.sync_batch_calls == 1
+    assert db.get_count() == 3
+
+
+def test_async_insert_uses_async_batch_embedder_path():
+    import asyncio
+
+    async def runner():
+        emb = BatchEmbedder()
+        db = TurboQuantVectorDb(embedder=emb)
+        await db.async_create()
+        docs = [
+            _doc("a", doc_id="d1", pre_embed=False),
+            _doc("b", doc_id="d2", pre_embed=False),
+        ]
+        await db.async_insert("h", docs)
+        assert emb.async_batch_calls == 1
+        assert db.get_count() == 2
+
+    asyncio.run(runner())
+
+
+# ---- Defensive None-guard paths ------------------------------------------
+
+
+def test_save_before_create_raises():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    with pytest.raises(RuntimeError, match="no index to save"):
+        db.save("/tmp/nonexistent-turbovec-store")
+
+
+def test_update_metadata_before_create_is_noop():
+    # Defensive: calling update_metadata before create() shouldn't
+    # raise; it just has no documents to touch.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.update_metadata("any-content-id", {"key": "value"})  # no assertion: must not raise
+
+
+def test_update_metadata_unknown_content_id_is_noop():
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a", content_id="cid-known", meta_data={"k": 1})])
+    db.update_metadata("cid-not-in-store", {"k": 2})
+    # Nothing changed on the known doc.
+    docs = list(db._u64_to_doc.values())
+    assert docs[0]["meta_data"] == {"k": 1}


### PR DESCRIPTION
## Summary

New `turbovec.agno.TurboQuantVectorDb` implementing Agno's `VectorDb` interface. Structurally aligned with `agno.vectordb.lancedb.LanceDb` (the closest in-tree single-machine backend) so it's a drop-in for callers using LanceDb as their Agno knowledge store.

Closes #23. Supersedes #24.

## Why this and not #24

PR #24 (by @raghavenderreddygrudhanti) implemented the same surface, but pre-dates #22 which standardized three things across the existing integrations:

- **Kernel-level filtering** via `IdMapIndex.search(..., allowlist=)`. No over-fetch, no recall hit on selective filters.
- **JSON side-cars with `schema_version`.** No pickle. No `allow_dangerous_deserialization` flag.
- **Lazy / embedder-sourced `dim`.** No baked-in default that silently mismatches non-OpenAI embedders.

This PR follows those standards. Detail in the audit comment on #24: https://github.com/RyanCodrai/turbovec/pull/24#issuecomment-4472136536. The implementation owes its protocol-method shape (`name_exists` / `id_exists` / `delete_by_*` / etc.) to that PR's groundwork even where the internals differ.

## Drop-in mapping to `LanceDb`

| LanceDb | TurboQuantVectorDb |
|---|---|
| `dim` from `embedder.dimensions` | Same |
| `search(query, limit, filters)` — dict filter post-applied | Same signature, kernel-level allowlist instead of post-filter |
| `Distance.cosine` (default) | Only `Distance.cosine` allowed |
| `SearchType.vector` / `keyword` / `hybrid` | Only `vector` allowed (no BM25 in turbovec) |
| `reranker` optional | Same |
| `similarity_threshold` (cosine relevance in `[0, 1]`) | Same — clamped `(s + 1) / 2` |
| `doc_id = md5(f"{base_id}_{content_hash}")` | Identical contract, so cross-store id stability holds |
| `meta_data` merged with `filters` on insert | Same |

## Tests

35 new tests in `tests/test_agno.py`. Coverage:

- Constructor validation (required embedder, dimensions, search_type, distance, bit_width).
- Insert: batched single `add_with_ids` call per batch, raises on missing embedding, doc_id derivation matches LanceDb, multiple content_hashes coexist.
- Filter: kernel-level allowlist; **selective-filter recall regression** (3 of 50 docs filter, `limit=3` returns 3 — the thing post-filter+over-fetch can't guarantee).
- Existence: `name_exists` / `id_exists` / `content_hash_exists` semantics.
- Delete: each `delete_by_*` returns the right `bool`, content-hash set updates on removal.
- `update_metadata` merges by `content_id`.
- Persistence: writes JSON not pickle, `schema_version` rejection, dimension-mismatch on load raises.
- Async round-trip.

Full Python suite: 167 → 202, all green on ARM.

## What's not in scope

- **Keyword / hybrid search.** Constructor raises `ValueError` on `SearchType.keyword` and `SearchType.hybrid` — turbovec doesn't ship a BM25 / lexical index. Listed under "Known limitations" in the doc.
- **Non-cosine distance.** Same — turbovec stores unit-normalized vectors only.

## Test plan

- [ ] x86 smoke test on GCP (`cargo test -p turbovec --release` + `LD_PRELOAD=… python -m pytest`).
- [ ] Smoke test the published wheel after release: `pip install turbovec[agno]==0.4.x` in a fresh venv, run a minimal Agno `Knowledge` + `Agent` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)