### PR TITLE
ci: build + test Windows x64 wheel on release

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -65,6 +65,61 @@ jobs:
           name: wheels-macos-aarch64
           path: turbovec-python/dist
 
+  macos-x86:
+    name: macOS x86_64
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x86_64
+          args: --release --out dist
+          working-directory: turbovec-python
+      - name: Install wheel and run tests
+        working-directory: turbovec-python
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install dist/*.whl
+          python -m pytest tests/test_index.py tests/test_id_map.py tests/test_filtering.py -v
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-x86_64
+          path: turbovec-python/dist
+
+  windows:
+    name: Windows x64
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x64
+          args: --release --out dist
+          working-directory: turbovec-python
+      - name: Install wheel and run tests
+        shell: bash
+        working-directory: turbovec-python
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install dist/*.whl
+          python -m pytest tests/test_index.py tests/test_id_map.py tests/test_filtering.py -v
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-windows-x64
+          path: turbovec-python/dist
+
   sdist:
     name: sdist
     runs-on: ubuntu-latest
@@ -85,7 +140,7 @@ jobs:
   release:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [linux, macos, sdist]
+    needs: [linux, macos, macos-x86, windows, sdist]
     if: startsWith(github.ref, 'refs/tags/py-v')
     environment:
       name: pypi

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -65,33 +65,6 @@ jobs:
           name: wheels-macos-aarch64
           path: turbovec-python/dist
 
-  macos-x86:
-    name: macOS x86_64
-    runs-on: macos-13
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: x86_64
-          args: --release --out dist
-          working-directory: turbovec-python
-      - name: Install wheel and run tests
-        working-directory: turbovec-python
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pytest
-          python -m pip install dist/*.whl
-          python -m pytest tests/test_index.py tests/test_id_map.py tests/test_filtering.py -v
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-macos-x86_64
-          path: turbovec-python/dist
-
   windows:
     name: Windows x64
     runs-on: windows-latest
@@ -140,7 +113,7 @@ jobs:
   release:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [linux, macos, macos-x86, windows, sdist]
+    needs: [linux, macos, windows, sdist]
     if: startsWith(github.ref, 'refs/tags/py-v')
     environment:
       name: pypi


### PR DESCRIPTION
Closes #31.

## What

Adds one build job to `release-pypi.yml`: **Windows x64** (`windows-latest`, target=`x64`). The job builds the wheel via `maturin-action`, installs it into a fresh venv, and runs the core pytest suite (`test_index.py`, `test_id_map.py`, `test_filtering.py`) before uploading the artifact. If tests fail, the wheel does not ship.

Adds `windows` to the `release` job's `needs:` so PyPI publishing waits on it.

## Why

The user in #31 hit a `link.exe` linker error running `pip install turbovec` on Windows under Anaconda. PyPI 0.4.2 ships only Linux x86_64/aarch64, macOS aarch64, and sdist — pip on Windows finds no matching wheel and falls back to building from sdist, which needs a local Rust toolchain plus MSVC.

## Why not also Intel Mac

Originally this PR also added `macos-x86` on a `macos-13` runner. The `workflow_dispatch` dry-run revealed `macos-13` was [fully deprecated by GitHub on 2025-12-08](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/) — the label still gets accepted into the queue, but no runners are provisioned. The job hung for 19+ min with no runner assignment.

There is no free-tier Intel Mac runner on GitHub-hosted Actions any more (only paid `macos-13-large` / `macos-14-large`). Cross-compiling x86_64 from a `macos-14` ARM runner would build but cannot run pytest against the result, which defeats the "runner is the validation" approach this PR was built around.

Filed as a separate follow-up issue: Intel Mac wheel needs its own scope decision (drop permanently / pay for larger runner / ship untested cross-built wheel). Not bundled here.

## Why BLAS is a non-issue on Windows

`turbovec/Cargo.toml` only enables ndarray's `blas` feature for `target_os = "macos"` (Accelerate) and `target_os = "linux"` (OpenBLAS). Windows falls through to ndarray's pure-Rust `matrixmultiply` backend automatically. So no vcpkg dance, no MKL licensing, no static OpenBLAS — it just compiles. Slower than BLAS at encode time, but correct.

## Validation surface

Core pytest suite only. Skips the integration tests (`test_agno.py`, `test_haystack.py`, `test_langchain.py`, `test_llama_index.py`) because those validate third-party adapters, not the core wheel. If the core surface works on Windows, the wheel ships; integration testing on Windows can be a follow-up if it becomes interesting.

## Dispatch results

Validated on `workflow_dispatch` against the branch (run `26035052002`):

| Job | Result |
|---|---|
| Linux x86_64 | success |
| Linux aarch64 | success |
| macOS aarch64 | success |
| Windows x64 | **success — wheel built, pytest passed** |
| sdist | success |

## Follow-ups not in this PR

- Intel Mac wheel — separate ticket, decision pending on path
- Retrofit pytest-against-built-wheel to existing `linux` and `macos` jobs (currently build-only, untested before upload)
- README update listing the four supported platforms

## Test plan

- [x] `workflow_dispatch` on branch confirms Windows wheel builds + pytest passes
- [ ] Optional: send Windows artifact wheel to #31 reporter for real-world Anaconda validation before merging