### PR TITLE
Haystack: clamp cosine scores to [-1, 1] before scale_score rescaling

### DIFF
--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -649,7 +649,13 @@ class TurboQuantDocumentStore:
             if self.embedding_similarity_function == "dot_product":
                 score = 1.0 / (1.0 + math.exp(-score / 100.0))
             elif self.embedding_similarity_function == "cosine":
-                score = (score + 1.0) / 2.0
+                # Clamp to the exact cosine range before rescaling. Cauchy–Schwarz
+                # bounds the true cosine in [-1, 1], but the LUT scoring kernel's
+                # float-precision noise can land slightly outside that range on
+                # near-identical document/query pairs (e.g. a self-query under the
+                # length-renormalized estimator produces ~1.00016). Clamping
+                # preserves the [0, 1] contract for ``scale_score=True`` consumers.
+                score = (max(-1.0, min(1.0, score)) + 1.0) / 2.0
         return Document(
             id=data["id"],
             content=data["content"],


### PR DESCRIPTION
## Summary

`TurboQuantDocumentStore._reconstruct` applies `(score + 1) / 2` to remap cosine scores from `[-1, 1]` to `[0, 1]` when `scale_score=True`. Cauchy–Schwarz bounds the true cosine in `[-1, 1]`, but the LUT scoring kernel's float-precision noise can produce values slightly outside it — pushing the rescaled score above `1.0` and violating Haystack's documented `[0, 1]` contract.

Most visible on a self-query under the length-renormalized estimator (#35, landed in `8e03739`), which is algebraically `1.0` but the kernel produces `~1.00016` after its per-sub-table `(scale, bias)` calibration. `(1.00016 + 1) / 2 = 1.00008 > 1.0`.

The fix is a one-line clamp inside the cosine branch:

```python
score = (max(-1.0, min(1.0, score)) + 1.0) / 2.0
```

The dot-product branch uses a sigmoid (`1 / (1 + exp(-score/100))`) that is already bounded, so it does not need a clamp.

## Why this matters

Without the clamp, downstream Haystack pipelines that filter by score (e.g. "include documents with `score >= 0.95`") and consumers that assert `0 <= score <= 1` get wrong behavior on near-duplicate documents.

## Test plan

- [x] `test_scale_score_cosine_formula` (the test that was failing on main): passes
- [x] Full `test_haystack.py` suite: 48 passed
- [x] No change to dot-product behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)