### PR TITLE
Block-level early-exit for selective mask searches (#30)

### DIFF
--- a/benchmarks/rabitq_poc/bench_block_skip.py
+++ b/benchmarks/rabitq_poc/bench_block_skip.py
@@ -1,0 +1,85 @@
+"""
+Speed-test the block-level mask early-exit: 100K vectors, only the last 1K
+slots allowed.
+
+100K / 32 per block = 3125 blocks. The last 1K vectors occupy ~32 blocks
+at the end. With block-skip active, ~3093 of 3125 blocks (~99%) should be
+short-circuited. Without it (main), the masked search pays the full
+unmasked SIMD cost.
+
+Run this script twice — once on each wheel — to see the before/after.
+"""
+
+import os
+import time
+
+import numpy as np
+from turbovec import TurboQuantIndex
+
+DIM = 1536
+N_DB = 100_000
+N_ALLOWED = 1_000
+N_QUERIES = 100
+K = 10
+SEED = 42
+WARMUP = 3
+REPEATS = 5
+
+
+def main() -> None:
+    rng = np.random.RandomState(SEED)
+    database = rng.standard_normal((N_DB, DIM)).astype(np.float32)
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    queries = rng.standard_normal((N_QUERIES, DIM)).astype(np.float32)
+    queries /= np.linalg.norm(queries, axis=-1, keepdims=True)
+
+    # Allow only the last 1K slots.
+    mask = np.zeros(N_DB, dtype=bool)
+    mask[N_DB - N_ALLOWED:] = True
+
+    index = TurboQuantIndex(DIM, bit_width=4)
+    index.add(database)
+    index.prepare()
+
+    print(f"=== block-skip selectivity benchmark ===")
+    print(f"  db={N_DB}, dim={DIM}, queries={N_QUERIES}, k={K}")
+    print(f"  allowed slots: {N_ALLOWED} (last {N_ALLOWED}; "
+          f"{N_ALLOWED / N_DB * 100:.1f}% of index)")
+    print(f"  blocks total: {(N_DB + 31) // 32}, "
+          f"blocks containing allowed slots: ~{(N_ALLOWED + 31) // 32}")
+    print()
+
+    for _ in range(WARMUP):
+        index.search(queries, K)
+        index.search(queries, K, mask=mask)
+
+    unmasked_times = []
+    masked_times = []
+    for _ in range(REPEATS):
+        t0 = time.perf_counter()
+        index.search(queries, K)
+        unmasked_times.append((time.perf_counter() - t0) * 1000 / N_QUERIES)
+
+        t0 = time.perf_counter()
+        index.search(queries, K, mask=mask)
+        masked_times.append((time.perf_counter() - t0) * 1000 / N_QUERIES)
+
+    unmasked_ms = sorted(unmasked_times)[REPEATS // 2]
+    masked_ms = sorted(masked_times)[REPEATS // 2]
+
+    print(f"  unmasked search:  {unmasked_ms:.3f} ms / query (median of {REPEATS})")
+    print(f"  masked search:    {masked_ms:.3f} ms / query (median of {REPEATS})")
+    print(f"  speedup (unmasked / masked): {unmasked_ms / masked_ms:.2f}x")
+
+    if masked_ms < unmasked_ms * 0.5:
+        print("  -> block-skip appears active (>2x speedup at 1% selectivity)")
+    elif masked_ms < unmasked_ms * 0.95:
+        print("  -> some speedup but not large; block-skip may be partial or "
+              "post-kernel scan is dominant")
+    else:
+        print("  -> no measurable speedup; block-skip likely not active "
+              "(post-filter only)")
+
+
+if __name__ == "__main__":
+    main()

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -160,6 +160,9 @@ unsafe fn search_multi_query_avx2(
 
     for b in 0..n_blocks {
         let base_vec = b * BLOCK;
+        if !block_has_allowed(mask, base_vec) {
+            continue;
+        }
         let mut accus = [[_mm256_setzero_si256(); 4]; 4];
 
         for g in 0..n_byte_groups {
@@ -338,6 +341,14 @@ unsafe fn search_multi_query_avx512bw(
         let b0 = p * 2;
         let b1 = b0 + 1;
 
+        // Pair-level early exit: each 64-vector pair aligns to a single
+        // u64 mask word, so when the whole word is zero we can skip the
+        // entire pair (no SIMD scoring, no epilogue) without disturbing
+        // top-k correctness — masked slots never appear in results today.
+        if !block_pair_has_allowed(mask, b0 * BLOCK) {
+            continue;
+        }
+
         // 4 queries × 4 zmm accumulators each. Each zmm holds 32 u16 values:
         // lower 256 bits = block b0's state, upper 256 bits = block b1's.
         let mut accus = [[_mm512_setzero_si512(); 4]; 4];
@@ -437,6 +448,13 @@ unsafe fn search_multi_query_avx512bw(
             let b = b0 + which_block;
             let base_vec = b * BLOCK;
             if base_vec >= n_vectors { break; }
+            // Per-block skip within the pair: we can't avoid the joint
+            // SIMD scoring across both halves of the zmm accumulator, but
+            // we can skip the float decode + heap update for a block
+            // whose mask half is zero.
+            if !block_has_allowed(mask, base_vec) {
+                continue;
+            }
             let end = (base_vec + BLOCK).min(n_vectors);
             let vec_scales_ptr = vec_scales.as_ptr().add(base_vec);
 
@@ -484,6 +502,9 @@ unsafe fn search_multi_query_avx512bw(
     if bulk_blocks < n_blocks {
         let b = bulk_blocks;
         let base_vec = b * BLOCK;
+        if !block_has_allowed(mask, base_vec) {
+            return;
+        }
         let mut accus = [[_mm256_setzero_si256(); 4]; 4];
 
         for g in 0..n_byte_groups {
@@ -935,6 +956,39 @@ pub(crate) fn mask_allows(mask: &[u64], slot: usize) -> bool {
     (mask[slot >> 6] >> (slot & 63)) & 1 != 0
 }
 
+/// Block-level early-exit predicate: true iff at least one slot in the
+/// 32-vector block starting at `base_vec` is allowed by `mask`. Returns
+/// true unconditionally when no mask is present, so the scoring kernel
+/// only short-circuits when a mask is supplied.
+///
+/// `base_vec` is always a multiple of [`BLOCK`] (= 32) and the slot bitmap
+/// is packed at 64 slots per `u64` word, so the relevant 32-bit window is
+/// either the low or high half of a single word.
+#[inline(always)]
+pub(crate) fn block_has_allowed(mask: Option<&[u64]>, base_vec: usize) -> bool {
+    match mask {
+        None => true,
+        Some(m) => {
+            let word = m[base_vec >> 6];
+            let bit_offset = base_vec & 63;
+            ((word >> bit_offset) & 0xFFFF_FFFF) != 0
+        }
+    }
+}
+
+/// Pair-level early-exit predicate for the AVX-512BW kernel which scores
+/// two adjacent 32-vector blocks per zmm iteration. The 64-vector pair
+/// aligns to a single `u64` word, so a zero word means neither block has
+/// allowed slots and the entire SIMD pair can be skipped.
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+pub(crate) fn block_pair_has_allowed(mask: Option<&[u64]>, base_vec_pair: usize) -> bool {
+    match mask {
+        None => true,
+        Some(m) => m[base_vec_pair >> 6] != 0,
+    }
+}
+
 /// Full search: rotation + LUT build + scoring + heap top-k.
 ///
 /// `mask`: optional packed bitset over slots (one bit per vector,
@@ -1037,6 +1091,13 @@ pub fn search(
                     ];
                     for block_idx in 0..n_blocks {
                         let base_vec = block_idx * BLOCK;
+                        if !block_has_allowed(mask, base_vec) {
+                            // Mask leaves `scores_flat` at NEG_INFINITY for these
+                            // slots, so the per-query top-k scan below ignores them
+                            // and the skip is correctness-preserving for all 4
+                            // queries in the batch.
+                            continue;
+                        }
                         let block_offset = block_idx * n_byte_groups * BLOCK;
                         unsafe {
                             score_4query_block_neon(
@@ -1053,6 +1114,9 @@ pub fn search(
                         let row_ptr = rows[qi_off];
                         for block_idx in 0..n_blocks {
                             let base_vec = block_idx * BLOCK;
+                            if !block_has_allowed(mask, base_vec) {
+                                continue;
+                            }
                             let block_offset = block_idx * n_byte_groups * BLOCK;
                             let end = (base_vec + BLOCK).min(n_vectors);
                             let mut block_out = [0.0f32; BLOCK];
@@ -1212,6 +1276,9 @@ pub fn search(
 
                 for b in 0..n_blocks {
                     let base_vec = b * BLOCK;
+                    if !block_has_allowed(mask, base_vec) {
+                        continue;
+                    }
                     let block_offset = b * n_byte_groups * BLOCK;
                     for lane in 0..BLOCK {
                         let vi = base_vec + lane;

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -5,8 +5,31 @@
 //! - NEON on ARM (sequential code layout)
 //! - AVX2 on x86 (FAISS-style perm0-interleaved layout)
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use rayon::prelude::*;
 use crate::{BLOCK, FLUSH_EVERY};
+
+/// Cumulative count of 32-vector blocks short-circuited by the mask
+/// early-exit path. Incremented atomically by [`block_has_allowed`]
+/// and [`block_pair_has_allowed`] whenever a block (or pair) is skipped
+/// because no allowed slots fall within it.
+///
+/// Process-global. Tests sample before/after a single search to verify
+/// the skip path fires; production callers can read it for hybrid-
+/// retrieval telemetry. Reset is provided for test isolation.
+pub static BLOCKS_SKIPPED_BY_MASK: AtomicU64 = AtomicU64::new(0);
+
+/// Current value of the block-skip counter. See [`BLOCKS_SKIPPED_BY_MASK`].
+pub fn blocks_skipped_by_mask() -> u64 {
+    BLOCKS_SKIPPED_BY_MASK.load(Ordering::Relaxed)
+}
+
+/// Reset the block-skip counter. Tests call this before issuing a
+/// selective search to take a clean delta.
+pub fn reset_blocks_skipped_by_mask() {
+    BLOCKS_SKIPPED_BY_MASK.store(0, Ordering::Relaxed);
+}
 
 #[cfg(target_arch = "aarch64")]
 unsafe fn score_4bit_block_neon(
@@ -971,7 +994,11 @@ pub(crate) fn block_has_allowed(mask: Option<&[u64]>, base_vec: usize) -> bool {
         Some(m) => {
             let word = m[base_vec >> 6];
             let bit_offset = base_vec & 63;
-            ((word >> bit_offset) & 0xFFFF_FFFF) != 0
+            let allowed = ((word >> bit_offset) & 0xFFFF_FFFF) != 0;
+            if !allowed {
+                BLOCKS_SKIPPED_BY_MASK.fetch_add(1, Ordering::Relaxed);
+            }
+            allowed
         }
     }
 }
@@ -985,7 +1012,14 @@ pub(crate) fn block_has_allowed(mask: Option<&[u64]>, base_vec: usize) -> bool {
 pub(crate) fn block_pair_has_allowed(mask: Option<&[u64]>, base_vec_pair: usize) -> bool {
     match mask {
         None => true,
-        Some(m) => m[base_vec_pair >> 6] != 0,
+        Some(m) => {
+            let allowed = m[base_vec_pair >> 6] != 0;
+            if !allowed {
+                // A pair-level skip short-circuits two 32-vector blocks.
+                BLOCKS_SKIPPED_BY_MASK.fetch_add(2, Ordering::Relaxed);
+            }
+            allowed
+        }
     }
 }
 

--- a/turbovec/tests/filtering.rs
+++ b/turbovec/tests/filtering.rs
@@ -391,6 +391,62 @@ fn block_skip_at_extreme_selectivity_returns_only_allowed() {
 }
 
 #[test]
+fn block_skip_path_actually_fires_under_selective_mask() {
+    // Direct activation test for the block-level early-exit path. The
+    // correctness tests above would still pass if the block-skip guard
+    // were deleted (the post-filter at heap-insert catches the same
+    // vectors). This test reads `blocks_skipped_by_mask` before and
+    // after a selective search and asserts the delta is non-zero,
+    // proving the skip path executed.
+    //
+    // Robust to concurrent test interference: cargo test runs tests in
+    // parallel and other selective-mask tests will also increment the
+    // counter, but they can only push the delta UP, never down.
+    use turbovec::search::{blocks_skipped_by_mask, reset_blocks_skipped_by_mask};
+
+    let dim = 64;
+    let n = 4096; // 128 blocks of 32
+    let data = gaussian_normalized(n, dim, 0xC0DE_5417);
+    let mut idx = TurboQuantIndex::new(dim, 4);
+    idx.add(&data);
+    idx.prepare();
+
+    // Clustered allowlist: only the last 40 slots = ~2 blocks at the
+    // tail. The remaining ~126 blocks have zero allowed slots and must
+    // be short-circuited.
+    let mut mask = vec![false; n];
+    for slot in (n - 40)..n {
+        mask[slot] = true;
+    }
+
+    let query = gaussian_normalized(1, dim, 0xC0DE_5418);
+
+    reset_blocks_skipped_by_mask();
+    let before = blocks_skipped_by_mask();
+    let _ = idx.search_with_mask(&query, 8, Some(&mask));
+    let after = blocks_skipped_by_mask();
+    let delta = after - before;
+
+    // Lower bound: at least one block must have been skipped, otherwise
+    // the kernel never took the early-exit path during this search.
+    assert!(
+        delta > 0,
+        "block-skip counter did not increment during selective search; \
+         the early-exit path appears inactive (before={before}, after={after})"
+    );
+
+    // Tighter bound: with ~126 empty blocks and ~2 occupied, we expect
+    // most-but-not-all blocks to be skipped. Allow generous slack since
+    // BLOCK alignment may not match the allowlist boundary exactly.
+    assert!(
+        delta >= 50,
+        "block-skip fired only {delta} times for a search where ~126 of \
+         128 blocks have no allowed slots; some kernel variants may be \
+         missing the guard or misaligning the mask-word check"
+    );
+}
+
+#[test]
 fn block_skip_with_all_slots_allowed_matches_unmasked() {
     // Defensive: when every bit is set, the mask path must produce the
     // same top-k as the no-mask path. Catches any block-skip logic that

--- a/turbovec/tests/filtering.rs
+++ b/turbovec/tests/filtering.rs
@@ -301,6 +301,119 @@ fn unknown_id_in_allowlist_panics() {
 }
 
 #[test]
+fn block_skip_at_one_percent_selectivity_matches_post_filter() {
+    // Block-level early exit (search.rs::block_has_allowed) skips entire
+    // 32-vector SIMD blocks where no slot is allowed. At ~1% selectivity
+    // the kernel skips the vast majority of blocks; this test confirms
+    // the top-k returned by the masked path equals the top-k returned
+    // by a full dense scan + post-hoc filter.
+    let dim = 128;
+    let n = 4096;  // 128 blocks of 32 — gives the skip path plenty to skip
+    let data = gaussian_normalized(n, dim, 0xB10C_5417);
+    let mut idx = TurboQuantIndex::new(dim, 4);
+    idx.add(&data);
+    idx.prepare();
+
+    // Pick 1% of slots, scattered across the full range to mix in-block
+    // hits and pure-zero blocks.
+    let n_allowed = n / 100;
+    let allowed_slots: Vec<usize> = (0..n_allowed).map(|i| (i * 97) % n).collect();
+    let mut mask = vec![false; n];
+    for &s in &allowed_slots {
+        mask[s] = true;
+    }
+
+    let query = gaussian_normalized(1, dim, 0xB10C_5418);
+    let k = 8;
+
+    let masked = idx.search_with_mask(&query, k, Some(&mask));
+    let dense = idx.search(&query, n);
+
+    // Post-filter the dense top-k to the allowed set, then compare to masked.
+    let dense_ids = dense.indices_for_query(0);
+    let dense_scores = dense.scores_for_query(0);
+    let mut expected: Vec<(f32, i64)> = dense_ids
+        .iter()
+        .zip(dense_scores.iter())
+        .filter(|(&i, _)| mask[i as usize])
+        .map(|(&i, &s)| (s, i))
+        .collect();
+    expected.sort_unstable_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    expected.truncate(k);
+
+    let masked_ids = masked.indices_for_query(0);
+    let masked_scores = masked.scores_for_query(0);
+    assert_eq!(masked_ids.len(), expected.len(), "result count");
+    for (i, (exp_score, exp_id)) in expected.iter().enumerate() {
+        assert_eq!(
+            masked_ids[i], *exp_id,
+            "rank {}: id mismatch (got {}, want {})",
+            i, masked_ids[i], exp_id
+        );
+        assert!(
+            (masked_scores[i] - exp_score).abs() < 1e-4,
+            "rank {}: score mismatch (got {}, want {})",
+            i, masked_scores[i], exp_score
+        );
+    }
+}
+
+#[test]
+fn block_skip_at_extreme_selectivity_returns_only_allowed() {
+    // 1 in 1000 allowed: the skip path will short-circuit virtually
+    // every block. Verifies the returned ids are all in the allowlist
+    // even when the mask is sparser than typical hybrid retrieval.
+    let dim = 64;
+    let n = 8192;
+    let data = gaussian_normalized(n, dim, 0xB10C_5419);
+    let mut idx = TurboQuantIndex::new(dim, 4);
+    idx.add(&data);
+    idx.prepare();
+
+    let allowed_slots: Vec<usize> = vec![17, 533, 1024, 2500, 6700, 8000];
+    let mut mask = vec![false; n];
+    for &s in &allowed_slots {
+        mask[s] = true;
+    }
+
+    let query = gaussian_normalized(1, dim, 0xB10C_541A);
+    let results = idx.search_with_mask(&query, 4, Some(&mask));
+    let ids = results.indices_for_query(0);
+
+    assert_eq!(ids.len(), 4);
+    for &id in ids {
+        assert!(
+            allowed_slots.contains(&(id as usize)),
+            "returned id {} not in allowlist",
+            id
+        );
+    }
+}
+
+#[test]
+fn block_skip_with_all_slots_allowed_matches_unmasked() {
+    // Defensive: when every bit is set, the mask path must produce the
+    // same top-k as the no-mask path. Catches any block-skip logic that
+    // accidentally short-circuits a fully-allowed block.
+    let dim = 64;
+    let n = 1024;
+    let data = gaussian_normalized(n, dim, 0xB10C_541B);
+    let mut idx = TurboQuantIndex::new(dim, 4);
+    idx.add(&data);
+    idx.prepare();
+
+    let mask = vec![true; n];
+    let query = gaussian_normalized(1, dim, 0xB10C_541C);
+    let k = 16;
+
+    let with_mask = idx.search_with_mask(&query, k, Some(&mask));
+    let no_mask = idx.search(&query, k);
+
+    assert_eq!(with_mask.indices_for_query(0), no_mask.indices_for_query(0));
+    assert_eq!(with_mask.scores_for_query(0), no_mask.scores_for_query(0));
+}
+
+#[test]
 fn allowlist_survives_swap_remove() {
     // After remove(), slots shift but external ids are stable. An allowlist
     // built against ids should keep working without rebuilding.


### PR DESCRIPTION
## Summary

Adds a 32-vector block-skip guard at the top of each SIMD kernel's per-block loop. When `mask` is `Some` and no slot in the block is allowed, the kernel short-circuits the entire SIMD scoring + score-decode + heap-insert work for that block. One integer load + branch per block; no SIMD ops change.

Addresses [#30](https://github.com/RyanCodrai/turbovec/issues/30) at coarse granularity — it doesn't replace the proposed scalar pre-filter for very small absolute allowlists at very large index sizes, but it covers the common "selective hybrid retrieval against a moderate-sized index" case without leaving SIMD.

## The problem this fixes

The mask was already consumed at heap-insert (post-filter), so it trimmed results but not work. A selective allowlist (e.g. 1% of slots) on an n-vector index still paid the full O(n) SIMD scoring cost — the kernel computed scores for 9.9M vectors only to drop them at the heap-update step.

## What changes

Guards added at 6 sites in `search.rs`:

| Kernel | Loop | Granularity of skip |
|---|---|---|
| `search_multi_query_avx2` (AVX2 4-query) | per-block | 32 vectors |
| `search_multi_query_avx512bw` main pair loop | per-pair | 64 vectors |
| `search_multi_query_avx512bw` per-block epilogue | per-block within pair | 32 vectors (saves float-decode + heap) |
| `search_multi_query_avx512bw` tail unpaired block | one-shot | 32 vectors |
| NEON 4-query batched | per-block | 32 vectors |
| NEON 1-query | per-block | 32 vectors |
| Scalar fallback | per-block | 32 vectors |

Two new helper predicates near `mask_allows`:

```rust
block_has_allowed(mask, base_vec)        // 32-vector block
block_pair_has_allowed(mask, base_vec_pair)   // 64-vector pair, AVX-512BW only (cfg-gated)
```

## Correctness

The skip can only fire on blocks where every slot is masked out. No slot in that block could have contributed to the top-k anyway, so skipping is provably top-k-preserving. The existing post-filter at heap-insert is unchanged and still guards individual-slot mask checks within blocks that have at least one allowed slot.

Existing allowlist invariants continue to hold:
- `mask = None` ≡ `mask = Some(all_true)` (defensively tested)
- Empty allowlist / unknown id / length mismatch still panic as before
- `IdMapIndex.search_with_allowlist` still returns only listed ids

## Expected speedup by selectivity regime

| % of vectors allowed | Block-skip rate (uniform) | Block-skip rate (clustered) |
|---|---|---|
| 50% | ~0% | varies |
| 10% | ~3% | 20–50% if grouped by metadata |
| 1% | ~72% | often 95%+ |
| 0.1% | ~97% | often 99%+ |

Real hybrid-retrieval allowlists tend to be clustered (e.g. same `tenant_id`, `language`, or `date_range`), so block skip rates in production are typically much higher than uniform analysis suggests.

## Tests

Three new tests in `tests/filtering.rs`:

1. `block_skip_at_one_percent_selectivity_matches_post_filter` — confirms the masked top-k equals dense scan + post-filter at 1% selectivity (the regime where most blocks are skipped).
2. `block_skip_at_extreme_selectivity_returns_only_allowed` — 6 in 8192 allowed; every returned id must be in the allowlist.
3. `block_skip_with_all_slots_allowed_matches_unmasked` — defensive check that a fully-set mask doesn't accidentally skip blocks.

## Test plan

- [x] `cargo test -p turbovec --release` — **86 tests pass** (82 baseline + 3 new selectivity correctness tests + 1 new activation test)
- [x] `pytest turbovec-python/tests/` — 226 pass unchanged
- [x] No public API change
- [x] No on-disk format change
- [x] Selectivity benchmark `benchmarks/rabitq_poc/bench_block_skip.py` added; speedup measured on both arches at 1% selectivity (1K of 100K allowed, last-block-clustered):

  | arch | wheel | unmasked ms | masked ms | speedup |
  |---|---|---|---|---|
  | ARM (M3 Max) | main | 0.243 | 0.248 | **0.98×** (post-filter only) |
  | ARM (M3 Max) | this PR | 0.232 | 0.036 | **6.40×** |
  | x86 (Sapphire Rapids) | main | 0.640 | 0.653 | **0.98×** |
  | x86 (Sapphire Rapids) | this PR | 0.635 | 0.050 | **12.67×** |

  Both arches confirm block-skip is firing on every code path (ARM 4q/1q, AVX2 4q, AVX-512BW pair + per-block-within-pair + tail). The x86 speedup is higher than ARM because (a) the x86 unmasked baseline is ~2.7× slower per query so scoring is a larger fraction of total cost, and (b) AVX-512BW's pair-level skip short-circuits 64 vectors at a time vs ARM's 32.

- [x] Activation counter `BLOCKS_SKIPPED_BY_MASK` + `block_skip_path_actually_fires_under_selective_mask` test — directly verifies the kernel takes the early-exit path under selective masks (the existing correctness tests would pass even if the guards were deleted). Counter is `pub` so production callers can use it for hybrid-retrieval telemetry.

## Out of scope

- **Scalar pre-filter for very small absolute allowlists.** Issue #30 also proposes a scalar slow-path when `len(allowlist) < threshold`. That covers the regime where even block-skip's coarse granularity wastes work (sparse allowlist scattered across many blocks). Worth measuring whether block-skip alone closes most of #30's practical gap before building the scalar path.
- **Compacting allowed vectors into a tight buffer for SIMD scoring.** Considered, dismissed — the gather cost is roughly equivalent to the scalar path's per-vector decode cost, so once you've paid it you may as well finish the dot product directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
