### PR TITLE
README: describe hybrid-retrieval filtering as block-level early exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ allowed = np.array(db.execute("SELECT id FROM docs WHERE tenant=?", (t,)).fetcha
 scores, ids = idx.search(query, k=10, allowlist=allowed)
 ```
 
-The kernel only inserts allowed vectors into the per-query heap, so `len(allowed) < k` shrinks the output to `len(allowed)` rather than returning fewer than `k` valid results.
+Filtering happens inside the SIMD kernel at 32-vector block granularity: blocks with no allowed slots are short-circuited before any LUT lookup or scoring work, and individual non-allowed slots inside scored blocks are dropped at heap-insert. Selective allowlists (small fraction of the index allowed) therefore avoid most of the SIMD cost rather than paying it and discarding the result afterwards.
+
+The output length is `min(k, len(allowed))` — when the allowlist is smaller than `k` you get exactly `len(allowed)` results rather than padded fallbacks.
 
 See [`docs/api.md`](docs/api.md) for the full reference.
 


### PR DESCRIPTION
## Summary

The README's "Hybrid retrieval (filtered search)" section described filtering as only happening at heap-insert ("kernel only inserts allowed vectors into the per-query heap"). That was accurate before [#38](https://github.com/RyanCodrai/turbovec/pull/38) but understates the current behavior — selective allowlists now short-circuit whole 32-vector blocks before any LUT lookup or scoring, which is why hybrid retrieval is 6–13× faster at 1% selectivity than naive post-filtering.

Replaces the single sentence with two: one describing the kernel-level filtering mechanism (block-level early exit + heap-insert drop), and one preserving the output-length contract (`min(k, len(allowed))`).

## Diff

```
- The kernel only inserts allowed vectors into the per-query heap, so `len(allowed) < k`
- shrinks the output to `len(allowed)` rather than returning fewer than `k` valid results.

+ Filtering happens inside the SIMD kernel at 32-vector block granularity: blocks
+ with no allowed slots are short-circuited before any LUT lookup or scoring
+ work, and individual non-allowed slots inside scored blocks are dropped at
+ heap-insert. Selective allowlists (small fraction of the index allowed)
+ therefore avoid most of the SIMD cost rather than paying it and discarding
+ the result afterwards.
+
+ The output length is `min(k, len(allowed))` — when the allowlist is smaller
+ than `k` you get exactly `len(allowed)` results rather than padded fallbacks.
```

## Test plan

- [x] No code change
- [x] README renders correctly (markdown preview)
- [x] Behavior described matches `turbovec/src/search.rs` post-#38

🤖 Generated with [Claude Code](https://claude.com/claude-code)