### PR TITLE
fix: add __repr__ to TurboQuantIndex and IdMapIndex

### DIFF
--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -114,9 +114,13 @@ impl TurboQuantIndex {
     }
 
     fn __repr__(&self) -> String {
+        let dim = self
+            .inner
+            .dim_opt()
+            .map_or_else(|| "None".to_string(), |d| d.to_string());
         format!(
-            "turbovec.TurboQuantIndex(dim={:?}, bit_width={}, n_vectors={})",
-            self.inner.dim_opt(),
+            "turbovec.TurboQuantIndex(dim={}, bit_width={}, n_vectors={})",
+            dim,
             self.inner.bit_width(),
             self.inner.len()
         )
@@ -279,9 +283,13 @@ impl IdMapIndex {
     }
 
     fn __repr__(&self) -> String {
+        let dim = self
+            .inner
+            .dim_opt()
+            .map_or_else(|| "None".to_string(), |d| d.to_string());
         format!(
-            "turbovec.IdMapIndex(dim={:?}, bit_width={}, n_vectors={})",
-            self.inner.dim_opt(),
+            "turbovec.IdMapIndex(dim={}, bit_width={}, n_vectors={})",
+            dim,
             self.inner.bit_width(),
             self.inner.len()
         )

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -113,6 +113,15 @@ impl TurboQuantIndex {
         self.inner.len()
     }
 
+    fn __repr__(&self) -> String {
+        format!(
+            "turbovec.TurboQuantIndex(dim={:?}, bit_width={}, n_vectors={})",
+            self.inner.dim_opt(),
+            self.inner.bit_width(),
+            self.inner.len()
+        )
+    }
+
     /// Vector dimensionality. Returns ``None`` when the index was
     /// constructed lazily (no ``dim=``) and hasn't seen an add yet;
     /// otherwise an ``int``.
@@ -267,6 +276,15 @@ impl IdMapIndex {
 
     fn __len__(&self) -> usize {
         self.inner.len()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "turbovec.IdMapIndex(dim={:?}, bit_width={}, n_vectors={})",
+            self.inner.dim_opt(),
+            self.inner.bit_width(),
+            self.inner.len()
+        )
     }
 
     fn __contains__(&self, id: u64) -> bool {


### PR DESCRIPTION
## Summary

Added __repr__ methods to TurboQuantIndex and IdMapIndex Python classes. Both classes already had __len__ and __contains__ but were missing a repr, making REPL debugging harder.

## Problem

When inspecting a TurboQuantIndex or IdMapIndex in a Python REPL, users see only the default object repr with no useful state information.

## Solution

Added __repr__ to both classes returning the index type name, dim, bit_width and n_vectors. Uses existing getter methods so no new internal API introduced.

## Risk / Compatibility

No API change, no behavior change, no new dependencies. Adds only new dunder methods for introspection.

## Tests

Manual verification in Python REPL confirms formatted output.