### PR TITLE
Return AddError instead of panicking on user-input errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ appears under each surface it touches.
 
 ## [Unreleased]
 
+### turbovec — Rust crate
+
+#### Changed
+
+- **BREAKING:** `TurboQuantIndex::add_2d`, `IdMapIndex::add_with_ids_2d`,
+  and `IdMapIndex::add_with_ids` now return `Result<(), AddError>`
+  instead of panicking on invalid input. The new `turbovec::AddError`
+  enum covers dim mismatch, `dim % 8 != 0` on lazy-commit, vector
+  buffer length not a multiple of `dim`, ids/vectors count mismatch,
+  and duplicate ids. The low-level `TurboQuantIndex::add(&[f32])` and
+  constructor asserts are unchanged — they still panic, since those
+  signal contract violations rather than user-input errors.
+
+  Migration: append `?` (or `.unwrap()` in tests/binaries) to existing
+  calls. Match on `AddError` if you need to recover from specific
+  failure modes.
+
+### turbovec — Python package
+
+#### Changed
+
+- **Dim mismatch on `add` / `add_with_ids` now raises `ValueError`**
+  instead of surfacing a `pyo3_runtime.PanicException` with a Rust
+  backtrace. The previous `PanicException` subclassed `BaseException`
+  and so was not caught by `except Exception:` — user code can now
+  recover from a wrong-shape batch as a normal usage error. The same
+  applies to duplicate ids and length mismatches on
+  `IdMapIndex.add_with_ids`.
+
 ## turbovec 0.5.1 (Python package) + turbovec 0.4.1 (Rust crate) — 2026-05-18
 
 ### turbovec — Rust crate (current: 0.4.0 → next: 0.4.1)

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,7 +41,7 @@ Before the first add, `idx.dim` is `None`, `len(idx)` is `0`, and `search()` ret
 | Method | Notes |
 |---|---|
 | `TurboQuantIndex(dim=None, bit_width=4)` | `bit_width ∈ {2, 4}`. `dim` is optional; when omitted it is inferred from the first `add` call. |
-| `add(vectors)` | `vectors` is a contiguous float32 array of shape `(n, dim)`. On a lazy index the first call locks `dim`; subsequent calls must match. |
+| `add(vectors)` | `vectors` is a contiguous float32 array of shape `(n, dim)`. On a lazy index the first call locks `dim`; subsequent calls must match. Raises `ValueError` on dim mismatch. |
 | `search(queries, k, *, mask=None)` | Returns `(scores, indices)`, both shape `(nq, effective_k)`. Indices are `int64` slot positions. `mask` is an optional `bool` array of length `len(idx)`; when given, only slots with `mask[i] == True` contribute. `effective_k = min(k, mask.sum())`. |
 | `swap_remove(idx)` | O(1). Moves the last vector into `idx`; returns the previous position of that moved vector (so external refs can be updated if needed). |
 | `prepare()` | Optional. Eagerly builds the rotation matrix, Lloyd-Max centroids and SIMD-blocked layout so the first `search` call doesn't pay the one-time cost. No-op on a lazy index that hasn't seen its first add. |
@@ -88,7 +88,7 @@ idx.add_with_ids(vectors, ids)           # locks dim to vectors.shape[1]
 | Method | Notes |
 |---|---|
 | `IdMapIndex(dim=None, bit_width=4)` | `dim` is optional; when omitted it is inferred from the first `add_with_ids` call. |
-| `add_with_ids(vectors, ids)` | `ids` is a `uint64` array with length `vectors.shape[0]`. Rejects duplicate ids (raises). On a lazy index the first call locks `dim`. |
+| `add_with_ids(vectors, ids)` | `ids` is a `uint64` array with length `vectors.shape[0]`. On a lazy index the first call locks `dim`. Raises `ValueError` on dim mismatch, duplicate ids, or `len(ids) != vectors.shape[0]`. |
 | `remove(id) -> bool` | `True` if the id was present and removed, `False` otherwise. O(1). |
 | `search(queries, k, *, allowlist=None)` | Returns `(scores, ids)` — `ids` are `uint64` external ids. `allowlist` is an optional `uint64` array of ids; when given, results are restricted to those ids and `effective_k = min(k, len(allowlist))`. Raises `ValueError` on empty allowlist and `KeyError` on unknown ids. |
 | `contains(id)` / `id in idx` | Membership. |

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -24,13 +24,15 @@ impl TurboQuantIndex {
         }
     }
 
-    fn add(&mut self, vectors: PyReadonlyArray2<f32>) {
+    fn add(&mut self, vectors: PyReadonlyArray2<f32>) -> PyResult<()> {
         let arr = vectors.as_array();
         let dim = arr.ncols();
         let slice = arr.as_slice().expect("vectors must be contiguous");
         // `add_2d` handles both eager (dim must match) and lazy (locks
         // dim on first call) cases.
-        self.inner.add_2d(slice, dim);
+        self.inner
+            .add_2d(slice, dim)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
     /// Run a top-`k` search against the index.
@@ -164,20 +166,22 @@ impl IdMapIndex {
     /// Add `n = vectors.shape[0]` vectors with the given external `ids`.
     ///
     /// `ids` must be a 1-D array of `uint64` with length equal to
-    /// `vectors.shape[0]`. Raises if any id is already present or if the
-    /// lengths don't match. On a lazy index, this call commits the
-    /// dimensionality from `vectors.shape[1]`.
+    /// `vectors.shape[0]`. Raises `ValueError` if any id is already
+    /// present or if the lengths don't match. On a lazy index, this
+    /// call commits the dimensionality from `vectors.shape[1]`.
     fn add_with_ids(
         &mut self,
         vectors: PyReadonlyArray2<f32>,
         ids: PyReadonlyArray1<u64>,
-    ) {
+    ) -> PyResult<()> {
         let v = vectors.as_array();
         let dim = v.ncols();
         let v_slice = v.as_slice().expect("vectors must be contiguous");
         let i = ids.as_array();
         let i_slice = i.as_slice().expect("ids must be contiguous");
-        self.inner.add_with_ids_2d(v_slice, dim, i_slice);
+        self.inner
+            .add_with_ids_2d(v_slice, dim, i_slice)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
     /// Remove the vector with external id `id`. Returns `True` if it was

--- a/turbovec-python/tests/test_index.py
+++ b/turbovec-python/tests/test_index.py
@@ -164,3 +164,9 @@ def test_search_after_swap_remove_reflects_new_layout():
 
     _, post = idx.search(vectors[19:20], k=1)
     assert post[0, 0] == 5, "vector that moved into slot 5 not found there"
+
+
+def test_add_with_mismatched_dim_raises_value_error():
+    idx = TurboQuantIndex(dim=128, bit_width=4)
+    with pytest.raises(ValueError, match="dim mismatch"):
+        idx.add(unit_vectors(3, 256))

--- a/turbovec/src/error.rs
+++ b/turbovec/src/error.rs
@@ -1,0 +1,56 @@
+//! Errors returned by the user-facing `add` paths
+//! ([`TurboQuantIndex::add_2d`](crate::TurboQuantIndex::add_2d),
+//! [`IdMapIndex::add_with_ids_2d`](crate::IdMapIndex::add_with_ids_2d),
+//! [`IdMapIndex::add_with_ids`](crate::IdMapIndex::add_with_ids)).
+//!
+//! These are all forms of user input error — wrong shape, wrong dim, or
+//! duplicate id — that callers can recover from. Internal preconditions
+//! (e.g. calling the low-level `add(&self, &[f32])` on a lazy index that
+//! hasn't been committed) still panic, since that signals a contract
+//! violation rather than bad input.
+
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AddError {
+    /// Batch dim does not match the index's already-locked dim.
+    DimMismatch { existing: usize, got: usize },
+
+    /// First-add dim on a lazy index must be a multiple of 8.
+    DimNotMultipleOf8(usize),
+
+    /// `vectors.len()` is not a whole multiple of `dim`.
+    VectorBufferNotMultipleOfDim { vectors_len: usize, dim: usize },
+
+    /// Number of ids does not equal number of vectors (`vectors.len() / dim`).
+    IdsCountMismatch { expected: usize, got: usize },
+
+    /// External id was already present in the index.
+    IdAlreadyPresent(u64),
+}
+
+impl fmt::Display for AddError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DimMismatch { existing, got } => {
+                write!(f, "dim mismatch: index dim={existing}, batch dim={got}")
+            }
+            Self::DimNotMultipleOf8(dim) => {
+                write!(f, "dim must be a multiple of 8, got {dim}")
+            }
+            Self::VectorBufferNotMultipleOfDim { vectors_len, dim } => write!(
+                f,
+                "vector buffer length {vectors_len} not a multiple of dim {dim}",
+            ),
+            Self::IdsCountMismatch { expected, got } => {
+                write!(f, "expected {expected} ids, got {got}")
+            }
+            Self::IdAlreadyPresent(id) => {
+                write!(f, "id {id} already present in index")
+            }
+        }
+    }
+}
+
+impl Error for AddError {}

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -17,7 +17,7 @@
 //!
 //! let mut index = IdMapIndex::new(1536, 4);
 //! let vectors: Vec<f32> = vec![0.0; 1536 * 3];
-//! index.add_with_ids(&vectors, &[1001, 1002, 1003]);
+//! index.add_with_ids(&vectors, &[1001, 1002, 1003]).unwrap();
 //!
 //! let queries: Vec<f32> = vec![0.0; 1536];
 //! let (scores, ids) = index.search(&queries, 3);
@@ -39,7 +39,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::io;
-use crate::TurboQuantIndex;
+use crate::{AddError, TurboQuantIndex};
 
 /// ID-addressed wrapper around [`TurboQuantIndex`].
 pub struct IdMapIndex {
@@ -77,15 +77,16 @@ impl IdMapIndex {
     /// Requires the inner index's dim to already be set (eager constructor
     /// or a previous lazy add).
     ///
-    /// Panics if `ids.len() != n`, if any id is already present in the
-    /// index, if `ids` contains duplicates within this call, or if the
-    /// inner index is still in lazy/uninitialized state.
-    pub fn add_with_ids(&mut self, vectors: &[f32], ids: &[u64]) {
+    /// Returns the same errors as
+    /// [`Self::add_with_ids_2d`]. Panics only if the inner index is still
+    /// in lazy/uninitialized state — that signals API misuse (use
+    /// `add_with_ids_2d` on a lazy index), not bad input.
+    pub fn add_with_ids(&mut self, vectors: &[f32], ids: &[u64]) -> Result<(), AddError> {
         let dim = self.inner.dim_opt().expect(
             "IdMapIndex dim is not set; use add_with_ids_2d(vectors, dim, ids) \
              on the first add or construct with IdMapIndex::new(dim, bit_width)",
         );
-        self.add_with_ids_2d(vectors, dim, ids);
+        self.add_with_ids_2d(vectors, dim, ids)
     }
 
     /// Add `vectors` of dimensionality `dim` with the given external ids.
@@ -95,36 +96,54 @@ impl IdMapIndex {
     /// This is the form bindings with shape information (e.g. the Python
     /// binding receiving a 2D ndarray) should use, since a flat
     /// `&[f32]` alone is ambiguous about shape.
-    pub fn add_with_ids_2d(&mut self, vectors: &[f32], dim: usize, ids: &[u64]) {
+    ///
+    /// Returns
+    /// [`AddError::VectorBufferNotMultipleOfDim`](crate::AddError::VectorBufferNotMultipleOfDim),
+    /// [`AddError::IdsCountMismatch`](crate::AddError::IdsCountMismatch),
+    /// [`AddError::IdAlreadyPresent`](crate::AddError::IdAlreadyPresent),
+    /// or any error returned by
+    /// [`TurboQuantIndex::add_2d`](crate::TurboQuantIndex::add_2d).
+    pub fn add_with_ids_2d(
+        &mut self,
+        vectors: &[f32],
+        dim: usize,
+        ids: &[u64],
+    ) -> Result<(), AddError> {
+        if dim == 0 || vectors.len() % dim != 0 {
+            return Err(AddError::VectorBufferNotMultipleOfDim {
+                vectors_len: vectors.len(),
+                dim,
+            });
+        }
         let n = vectors.len() / dim;
-        assert_eq!(
-            vectors.len(),
-            n * dim,
-            "vector buffer length {} not a multiple of dim {}",
-            vectors.len(),
-            dim,
-        );
-        assert_eq!(
-            ids.len(),
-            n,
-            "expected {n} ids, got {}",
-            ids.len(),
-        );
+        if ids.len() != n {
+            return Err(AddError::IdsCountMismatch {
+                expected: n,
+                got: ids.len(),
+            });
+        }
 
-        // Reserve first so that a partial failure is impossible.
+        // Validate all ids up-front so a partial failure is impossible.
+        // Reject both ids already in the index and duplicates within
+        // this call.
+        let mut seen_this_call: std::collections::HashSet<u64> =
+            std::collections::HashSet::with_capacity(n);
+        for &id in ids {
+            if self.id_to_slot.contains_key(&id) || !seen_this_call.insert(id) {
+                return Err(AddError::IdAlreadyPresent(id));
+            }
+        }
+
         self.id_to_slot.reserve(n);
         self.slot_to_id.reserve(n);
 
         let base_slot = self.inner.len();
         for (i, &id) in ids.iter().enumerate() {
-            let slot = base_slot + i;
-            if self.id_to_slot.insert(id, slot).is_some() {
-                panic!("id {id} already present in index");
-            }
+            self.id_to_slot.insert(id, base_slot + i);
         }
         self.slot_to_id.extend_from_slice(ids);
 
-        self.inner.add_2d(vectors, dim);
+        self.inner.add_2d(vectors, dim)
     }
 
     /// Remove the vector with the given external id.

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -36,12 +36,14 @@
 
 pub mod codebook;
 pub mod encode;
+pub mod error;
 pub mod id_map;
 pub mod io;
 pub mod pack;
 pub mod rotation;
 pub mod search;
 
+pub use error::AddError;
 pub use id_map::IdMapIndex;
 
 use std::path::Path;
@@ -192,18 +194,25 @@ impl TurboQuantIndex {
     /// This is the form that bindings with shape information (e.g. the
     /// Python binding receiving a 2D numpy array) should use, since a
     /// flat `&[f32]` alone is ambiguous about its shape.
-    pub fn add_2d(&mut self, vectors: &[f32], dim: usize) {
+    ///
+    /// Returns [`AddError::DimMismatch`] if `dim` does not match the
+    /// already-locked dim, and [`AddError::DimNotMultipleOf8`] when
+    /// committing a lazy index to a dim that is not a multiple of 8.
+    pub fn add_2d(&mut self, vectors: &[f32], dim: usize) -> Result<(), AddError> {
         match self.dim {
-            Some(existing) => assert_eq!(
-                existing, dim,
-                "dim mismatch: index dim={existing}, batch dim={dim}"
-            ),
+            Some(existing) if existing != dim => {
+                return Err(AddError::DimMismatch { existing, got: dim });
+            }
+            Some(_) => {}
             None => {
-                assert!(dim % 8 == 0, "dim must be a multiple of 8");
+                if dim % 8 != 0 {
+                    return Err(AddError::DimNotMultipleOf8(dim));
+                }
                 self.dim = Some(dim);
             }
         }
         self.add(vectors);
+        Ok(())
     }
 
     /// Run a top-`k` search against the index.

--- a/turbovec/tests/filtering.rs
+++ b/turbovec/tests/filtering.rs
@@ -241,7 +241,7 @@ fn allowlist_returns_only_listed_ids() {
     let data = gaussian_normalized(n, dim, 0xF11D_1001);
     let ids: Vec<u64> = (0..n as u64).map(|i| 1000 + i).collect();
     let mut idx = IdMapIndex::new(dim, 4);
-    idx.add_with_ids(&data, &ids);
+    idx.add_with_ids(&data, &ids).unwrap();
 
     let query = gaussian_normalized(1, dim, 0xF11D_1002);
     let allowed: Vec<u64> = vec![1003, 1010, 1042, 1077, 1099];
@@ -265,7 +265,7 @@ fn allowlist_none_equivalent_to_plain_search() {
     let data = gaussian_normalized(n, dim, 0xF11D_1003);
     let ids: Vec<u64> = (0..n as u64).map(|i| 7000 + i * 13).collect();
     let mut idx = IdMapIndex::new(dim, 4);
-    idx.add_with_ids(&data, &ids);
+    idx.add_with_ids(&data, &ids).unwrap();
 
     let query = gaussian_normalized(1, dim, 0xF11D_1004);
     let (s1, i1) = idx.search(&query, 5);
@@ -281,7 +281,7 @@ fn empty_allowlist_panics() {
     let data = gaussian_normalized(10, dim, 0xF11D_1005);
     let ids: Vec<u64> = (0..10).collect();
     let mut idx = IdMapIndex::new(dim, 4);
-    idx.add_with_ids(&data, &ids);
+    idx.add_with_ids(&data, &ids).unwrap();
 
     let query = gaussian_normalized(1, dim, 0xF11D_1006);
     let _ = idx.search_with_allowlist(&query, 3, Some(&[]));
@@ -294,7 +294,7 @@ fn unknown_id_in_allowlist_panics() {
     let data = gaussian_normalized(10, dim, 0xF11D_1007);
     let ids: Vec<u64> = (0..10).collect();
     let mut idx = IdMapIndex::new(dim, 4);
-    idx.add_with_ids(&data, &ids);
+    idx.add_with_ids(&data, &ids).unwrap();
 
     let query = gaussian_normalized(1, dim, 0xF11D_1008);
     let _ = idx.search_with_allowlist(&query, 3, Some(&[5, 999]));
@@ -478,7 +478,7 @@ fn allowlist_survives_swap_remove() {
     let data = gaussian_normalized(n, dim, 0xF11D_1009);
     let ids: Vec<u64> = (0..n as u64).map(|i| 5000 + i).collect();
     let mut idx = IdMapIndex::new(dim, 4);
-    idx.add_with_ids(&data, &ids);
+    idx.add_with_ids(&data, &ids).unwrap();
 
     let allowed: Vec<u64> = vec![5005, 5015, 5020];
     let query = gaussian_normalized(1, dim, 0xF11D_100A);

--- a/turbovec/tests/id_map.rs
+++ b/turbovec/tests/id_map.rs
@@ -1,7 +1,7 @@
 //! Correctness tests for `IdMapIndex` — the stable-id wrapper.
 //!
 //! Invariants exercised:
-//!   - `add_with_ids` panics on bad input (length mismatch, duplicate id).
+//!   - `add_with_ids` returns `Err` on bad input (length mismatch, duplicate id).
 //!   - `remove` returns true/false and keeps `len` consistent.
 //!   - After `remove`, search doesn't return the removed id, and every
 //!     remaining id still self-queries to itself.
@@ -57,7 +57,7 @@ fn add_with_ids_updates_len_and_contains() {
     let dim = 128;
     let data = gaussian_normalized(5, dim, 0xA11D_0000);
     let mut idx = IdMapIndex::new(dim, 4);
-    idx.add_with_ids(&data, &[100, 200, 300, 400, 500]);
+    idx.add_with_ids(&data, &[100, 200, 300, 400, 500]).unwrap();
 
     assert_eq!(idx.len(), 5);
     assert!(idx.contains(300));
@@ -70,7 +70,7 @@ fn search_returns_ids_not_slots() {
     let data = gaussian_normalized(10, dim, 0xA11D_0001);
     let mut idx = IdMapIndex::new(dim, 4);
     let ids: Vec<u64> = (1_000_000..1_000_010).collect();
-    idx.add_with_ids(&data, &ids);
+    idx.add_with_ids(&data, &ids).unwrap();
 
     // Self-query each vector: expect the matching external id as top-1.
     for (i, &expected_id) in ids.iter().enumerate() {
@@ -85,7 +85,7 @@ fn remove_returns_false_for_missing_id() {
     let dim = 128;
     let data = gaussian_normalized(3, dim, 0xA11D_0002);
     let mut idx = IdMapIndex::new(dim, 4);
-    idx.add_with_ids(&data, &[1, 2, 3]);
+    idx.add_with_ids(&data, &[1, 2, 3]).unwrap();
 
     assert!(!idx.remove(999));
     assert_eq!(idx.len(), 3);
@@ -97,7 +97,7 @@ fn remove_existing_id_shrinks_and_hides_it() {
     let data = gaussian_normalized(10, dim, 0xA11D_0003);
     let mut idx = IdMapIndex::new(dim, 4);
     let ids: Vec<u64> = (0..10).map(|i| i as u64 * 7 + 11).collect();
-    idx.add_with_ids(&data, &ids);
+    idx.add_with_ids(&data, &ids).unwrap();
 
     // Remove the third vector (id = 25, at slot 2).
     let target_id = ids[2];
@@ -117,7 +117,7 @@ fn remaining_ids_still_self_query_after_mixed_removes() {
     let data = gaussian_normalized(20, dim, 0xA11D_0004);
     let mut idx = IdMapIndex::new(dim, 4);
     let ids: Vec<u64> = (0..20).map(|i| i as u64 * 100 + 5).collect();
-    idx.add_with_ids(&data, &ids);
+    idx.add_with_ids(&data, &ids).unwrap();
 
     // Remove a few ids in different orders — some will trigger
     // swap-and-pop, some will be the last vector (no swap).
@@ -149,37 +149,45 @@ fn remove_then_re_add_same_id_is_allowed() {
     let dim = 128;
     let data = gaussian_normalized(5, dim, 0xA11D_0005);
     let mut idx = IdMapIndex::new(dim, 4);
-    idx.add_with_ids(&data, &[1, 2, 3, 4, 5]);
+    idx.add_with_ids(&data, &[1, 2, 3, 4, 5]).unwrap();
 
     assert!(idx.remove(3));
     assert!(!idx.contains(3));
 
     // Re-add a new vector with id 3.
     let new_vec = gaussian_normalized(1, dim, 0xA11D_BEEF);
-    idx.add_with_ids(&new_vec, &[3]);
+    idx.add_with_ids(&new_vec, &[3]).unwrap();
     assert!(idx.contains(3));
     assert_eq!(idx.len(), 5);
 }
 
 #[test]
-#[should_panic(expected = "already present")]
 fn add_with_ids_rejects_duplicate_id() {
     let dim = 128;
     let data = gaussian_normalized(5, dim, 0xA11D_0006);
     let mut idx = IdMapIndex::new(dim, 4);
-    idx.add_with_ids(&data[..2 * dim], &[1, 2]);
-    // Same id "2" already present -> panic.
-    idx.add_with_ids(&data[2 * dim..3 * dim], &[2]);
+    idx.add_with_ids(&data[..2 * dim], &[1, 2]).unwrap();
+    // Same id "2" already present.
+    let err = idx
+        .add_with_ids(&data[2 * dim..3 * dim], &[2])
+        .unwrap_err();
+    assert_eq!(err, turbovec::AddError::IdAlreadyPresent(2));
 }
 
 #[test]
-#[should_panic(expected = "expected")]
 fn add_with_ids_rejects_length_mismatch() {
     let dim = 128;
     let data = gaussian_normalized(5, dim, 0xA11D_0007);
     let mut idx = IdMapIndex::new(dim, 4);
-    // 5 vectors, only 3 ids -> panic.
-    idx.add_with_ids(&data, &[1, 2, 3]);
+    // 5 vectors, only 3 ids.
+    let err = idx.add_with_ids(&data, &[1, 2, 3]).unwrap_err();
+    assert_eq!(
+        err,
+        turbovec::AddError::IdsCountMismatch {
+            expected: 5,
+            got: 3,
+        },
+    );
 }
 
 #[test]
@@ -189,7 +197,7 @@ fn write_and_load_round_trips() {
     let ids: Vec<u64> = (2000..2010).collect();
 
     let mut idx = IdMapIndex::new(dim, 4);
-    idx.add_with_ids(&data, &ids);
+    idx.add_with_ids(&data, &ids).unwrap();
 
     // Delete a few to exercise non-identity slot_to_id mapping.
     idx.remove(2003);
@@ -229,7 +237,7 @@ fn load_rejects_wrong_magic() {
     let dim = 64;
     let data = gaussian_normalized(2, dim, 0xA11D_0101);
     let mut inner = IdMapIndex::new(dim, 4);
-    inner.add_with_ids(&data, &[1, 2]);
+    inner.add_with_ids(&data, &[1, 2]).unwrap();
     // Use the inner TurboQuantIndex's write to produce a .tv file.
     // We can't do that directly since inner is private; simulate with
     // arbitrary bytes of the right shape.

--- a/turbovec/tests/lazy_init.rs
+++ b/turbovec/tests/lazy_init.rs
@@ -74,7 +74,7 @@ fn new_lazy_starts_with_no_dim() {
 fn add_2d_locks_dim_on_first_call() {
     let mut idx = TurboQuantIndex::new_lazy(4);
     let data = unit_vectors(3, DIM, 0xA00D_0001);
-    idx.add_2d(&data, DIM);
+    idx.add_2d(&data, DIM).unwrap();
     assert_eq!(idx.dim_opt(), Some(DIM));
     assert_eq!(idx.len(), 3);
 }
@@ -83,20 +83,26 @@ fn add_2d_locks_dim_on_first_call() {
 fn add_2d_subsequent_calls_must_match_dim() {
     let mut idx = TurboQuantIndex::new_lazy(4);
     let data1 = unit_vectors(2, DIM, 0xA00D_0002);
-    idx.add_2d(&data1, DIM);
+    idx.add_2d(&data1, DIM).unwrap();
     let data2 = unit_vectors(2, DIM, 0xA00D_0003);
-    idx.add_2d(&data2, DIM);
+    idx.add_2d(&data2, DIM).unwrap();
     assert_eq!(idx.len(), 4);
 }
 
 #[test]
-#[should_panic(expected = "dim mismatch")]
-fn add_2d_panics_on_dim_change() {
+fn add_2d_rejects_dim_change() {
     let mut idx = TurboQuantIndex::new_lazy(4);
     let data = unit_vectors(1, DIM, 0xA00D_0004);
-    idx.add_2d(&data, DIM);
+    idx.add_2d(&data, DIM).unwrap();
     let wrong = unit_vectors(1, DIM * 2, 0xA00D_0005);
-    idx.add_2d(&wrong, DIM * 2);
+    let err = idx.add_2d(&wrong, DIM * 2).unwrap_err();
+    assert_eq!(
+        err,
+        turbovec::AddError::DimMismatch {
+            existing: DIM,
+            got: DIM * 2,
+        },
+    );
 }
 
 #[test]
@@ -157,7 +163,7 @@ fn write_load_round_trip_lazy_after_committed_add() {
     let tmp = std::env::temp_dir().join("turbovec_lazy_committed.tv");
     {
         let mut idx = TurboQuantIndex::new_lazy(2);
-        idx.add_2d(&unit_vectors(3, DIM, 0xA00D_0009), DIM);
+        idx.add_2d(&unit_vectors(3, DIM, 0xA00D_0009), DIM).unwrap();
         idx.write(&tmp).unwrap();
     }
     let loaded = TurboQuantIndex::load(&tmp).unwrap();
@@ -182,7 +188,7 @@ fn id_map_add_with_ids_2d_locks_dim() {
     let mut idx = IdMapIndex::new_lazy(4);
     let data = unit_vectors(3, DIM, 0xA00D_0010);
     let ids: Vec<u64> = vec![10, 20, 30];
-    idx.add_with_ids_2d(&data, DIM, &ids);
+    idx.add_with_ids_2d(&data, DIM, &ids).unwrap();
     assert_eq!(idx.dim_opt(), Some(DIM));
     assert_eq!(idx.len(), 3);
     assert!(idx.contains(20));
@@ -193,7 +199,7 @@ fn id_map_add_with_ids_2d_locks_dim() {
 fn id_map_plain_add_with_ids_panics_on_lazy_uncommitted() {
     let mut idx = IdMapIndex::new_lazy(4);
     let data = unit_vectors(1, DIM, 0xA00D_0011);
-    idx.add_with_ids(&data, &[42]);
+    idx.add_with_ids(&data, &[42]).unwrap();
 }
 
 #[test]
@@ -225,7 +231,7 @@ fn id_map_write_load_round_trip_lazy_after_committed_add() {
     let ids: Vec<u64> = vec![100, 200, 300];
     {
         let mut idx = IdMapIndex::new_lazy(4);
-        idx.add_with_ids_2d(&unit_vectors(3, DIM, 0xA00D_0013), DIM, &ids);
+        idx.add_with_ids_2d(&unit_vectors(3, DIM, 0xA00D_0013), DIM, &ids).unwrap();
         idx.write(&tmp).unwrap();
     }
     let loaded = IdMapIndex::load(&tmp).unwrap();


### PR DESCRIPTION
## Summary
- `TurboQuantIndex::add_2d`, `IdMapIndex::add_with_ids_2d`, and `IdMapIndex::add_with_ids` now return `Result<(), AddError>` instead of panicking on invalid input
- The pyo3 binding maps `AddError` → `PyValueError`, so a wrong-shape batch / duplicate id / length mismatch surfaces in Python as a catchable `ValueError` instead of a `PanicException` with a Rust backtrace
- Low-level `add(&[f32])` and constructor asserts stay panicking — those signal contract violations rather than user-input errors

## Motivation
Surfaced while reviewing #42: a test like `pytest.raises(Exception)` on a dim mismatch failed because the binding propagated `pyo3_runtime.PanicException` (subclass of `BaseException`, not `Exception`), making the error effectively unrecoverable from normal Python code. The fix replaces the user-input asserts with a proper error type so:

```
>>> idx = TurboQuantIndex(dim=128, bit_width=4)
>>> idx.add(np.zeros((3, 256), dtype=np.float32))
ValueError: dim mismatch: index dim=128, batch dim=256
```

## Scope (deliberate)
**In:** user-input asserts on the add path — dim mismatch, `dim % 8 != 0` on lazy commit, vector buffer length not a multiple of dim, ids/vectors count mismatch, duplicate ids.

**Out (separate concerns):** constructor asserts (`new`, `new_lazy`), search-path asserts (allowlist empty, unknown id, mask length), low-level `add(&[f32])`.

## Migration (Rust crate)
Breaking signature change — append `?` (or `.unwrap()` in tests/binaries) to existing calls. Match on `AddError` if you need to recover from specific failure modes. Bump to `0.5.0` at release time.

## Test plan
- [x] `cargo test -p turbovec --release` — 75 tests across all suites pass
- [x] `pytest turbovec-python/tests/` — 120 passed, 2 skipped (haystack/agno optional deps)
- [x] New `test_add_with_mismatched_dim_raises_value_error` in `test_index.py`
- [x] 3 existing `#[should_panic]` tests flipped to assert `Err(AddError::…)` variants
- [x] Manually verified end-to-end: dim-mismatch surfaces as a clean `ValueError` in Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)