### PR TITLE
chore: add rustfmt CI workflow to enforce consistent formatting

### DIFF
--- a/turbovec/.github/workflows/rustfmt.yml
+++ b/turbovec/.github/workflows/rustfmt.yml
@@ -1,0 +1,18 @@
+name: Rustfmt
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  fmt:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt --check


### PR DESCRIPTION
## Summary
- Add .github/workflows/rustfmt.yml CI workflow
- Runs cargo fmt --check on every push to main and every PR
- Uses ubuntu-latest with rustup to install and run rustfmt

## Problem
The project lacked automated formatting enforcement, leading to inconsistent code style across contributions.

## Solution
New GitHub Actions workflow that:
- Triggers on push to main and pull requests
- Installs rustfmt via actions-rust-lang/setup-rust-toolchain
- Runs cargo fmt --check (fails if formatting issues exist)

## Tests
Reviewers can run: cargo fmt --check locally

## Risk / Compatibility
- Risk: LOW
- Affects: CI tooling only, no runtime changes