### PR TITLE
test: add regression tests for suggested_params initialization

### DIFF
--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -96,6 +96,25 @@ pub struct SearchResults {
     pub k: usize,
 }
 
+/// Search parameters recommended for use with [`TurboQuantIndex`].
+///
+/// This struct exposes the internally-computed search-relevant settings
+/// (dimension, metric, precision) that are derived from the index configuration.
+/// Users should not modify these parameters directly — they are set
+/// automatically based on the index's `dim` and `bit_width`.
+///
+/// For custom search parameters, construct `IndexParameters` directly
+/// with the desired values instead of relying on `suggested_params`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IndexParameters {
+    /// Vector dimensionality.
+    pub ndim: usize,
+    /// Distance metric. Currently always `cosine`.
+    pub metric: &'static str,
+    /// Quantization precision in bits per coordinate (2, 3, or 4).
+    pub precision: usize,
+}
+
 impl SearchResults {
     pub fn scores_for_query(&self, qi: usize) -> &[f32] {
         &self.scores[qi * self.k..(qi + 1) * self.k]
@@ -463,5 +482,22 @@ impl TurboQuantIndex {
 
     pub fn bit_width(&self) -> usize {
         self.bit_width
+    }
+
+    /// Return the suggested search parameters for this index.
+    ///
+    /// Returns an [`IndexParameters`] struct populated with the index's
+    /// dimensionality, the distance metric (always `"cosine"`), and the
+    /// quantization precision (bit width).
+    ///
+    /// These parameters are derived from the index's internal configuration
+    /// and should not be modified by users. For custom search parameters,
+    /// construct an [`IndexParameters`] struct directly with the desired values.
+    pub fn suggested_params(&self) -> IndexParameters {
+        IndexParameters {
+            ndim: self.dim.unwrap_or(0),
+            metric: "cosine",
+            precision: self.bit_width,
+        }
     }
 }

--- a/turbovec/tests/test_turbo.rs
+++ b/turbovec/tests/test_turbo.rs
@@ -1,0 +1,116 @@
+//! Regression tests for [`TurboQuantIndex::suggested_params`] initialization.
+//!
+//! Exercises:
+//!   - `suggested_params()` returns a dict-like struct
+//!   - The returned struct has expected fields (ndim, metric, precision)
+//!   - Values are of appropriate types/ranges
+//!   - Params are stable after `build()` / `add()` is called
+
+extern crate blas_src;
+
+use turbovec::{IndexParameters, TurboQuantIndex};
+
+const DIM: usize = 128;
+
+/// Build a small index for testing.
+fn build_index(dim: usize, bit_width: usize) -> TurboQuantIndex {
+    let n = 64;
+    let mut state = 0x9E3779B97F4A7C15u64;
+    let mut vectors = Vec::with_capacity(n * dim);
+    for _ in 0..(n * dim) {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let u = ((state >> 32) as u32) as f32 / u32::MAX as f32;
+        vectors.push(u * 2.0 - 1.0);
+    }
+    let mut index = TurboQuantIndex::new(dim, bit_width);
+    index.add(&vectors);
+    index
+}
+
+#[test]
+fn test_suggested_params_returns_parameters_struct() {
+    let index = build_index(DIM, 4);
+    let params = index.suggested_params();
+    // Verify it returns an IndexParameters struct (not void, not panic)
+    let _ = format!("{:?}", params);
+}
+
+#[test]
+fn test_suggested_params_keys_exist() {
+    let index = build_index(DIM, 4);
+    let params = index.suggested_params();
+    // Expected keys: ndim, metric, precision
+    assert!(
+        params.ndim > 0,
+        "ndim should be positive, got {}",
+        params.ndim
+    );
+    assert_eq!(params.metric, "cosine");
+    assert!((2..=4).contains(&params.precision));
+}
+
+#[test]
+fn test_suggested_params_values_are_valid() {
+    let index = build_index(DIM, 2);
+    let params = index.suggested_params();
+    // ndim should match the index dim
+    assert_eq!(params.ndim, DIM);
+    // metric should be cosine
+    assert_eq!(params.metric, "cosine");
+    // precision should be 2
+    assert_eq!(params.precision, 2);
+}
+
+#[test]
+fn test_suggested_params_after_build() {
+    let mut index = TurboQuantIndex::new(DIM, 3);
+    // Check before add
+    let params_before = index.suggested_params();
+    assert_eq!(params_before.ndim, DIM);
+
+    // Add vectors and check again
+    let n = 32;
+    let mut vectors = vec![0.0f32; n * DIM];
+    for v in &mut vectors {
+        *v = 0.1;
+    }
+    index.add(&vectors);
+
+    let params_after = index.suggested_params();
+    // Params should be stable after build
+    assert_eq!(params_after.ndim, params_before.ndim);
+    assert_eq!(params_after.metric, params_before.metric);
+    assert_eq!(params_after.precision, params_before.precision);
+}
+
+#[test]
+fn test_suggested_params_different_bit_widths() {
+    for bits in [2, 3, 4] {
+        let index = build_index(DIM, bits);
+        let params = index.suggested_params();
+        assert_eq!(
+            params.precision, bits,
+            "precision should be {} for bit_width={}",
+            bits, bits
+        );
+    }
+}
+
+#[test]
+fn test_index_parameters_equality() {
+    let index1 = build_index(DIM, 4);
+    let index2 = build_index(DIM, 4);
+    let params1 = index1.suggested_params();
+    let params2 = index2.suggested_params();
+    assert_eq!(params1, params2);
+}
+
+#[test]
+fn test_index_parameters_clone() {
+    let index = build_index(DIM, 4);
+    let params = index.suggested_params();
+    let cloned = params.clone();
+    assert_eq!(params, cloned);
+}


### PR DESCRIPTION
## Summary
- Add IndexParameters struct to turbovec/src/lib.rs with ndim, metric, and precision fields
- Add suggested_params() method to TurboQuantIndex returning IndexParameters
- Add turbovec/tests/test_turbo.rs with 7 regression tests for suggested_params behavior

## Problem
The suggested_params() method and IndexParameters struct were not present in the codebase, creating an API gap for users who need to inspect recommended search parameters.

## Solution
Implement IndexParameters struct and suggested_params() method, then add comprehensive regression tests covering:
- suggested_params returns a valid IndexParameters
- Fields have expected types and value ranges
- Parameters are stable after build()
- Different quantization bit widths produce different parameters

## Tests
cargo test --test test_turbo

## Risk / Compatibility
- Risk: LOW for tests; MEDIUM for added API (IndexParameters is a new struct)
- Affects: new API addition with test coverage