### PR TITLE
Add Python tests for search on eager-empty index

### DIFF
--- a/turbovec-python/tests/test_id_map.py
+++ b/turbovec-python/tests/test_id_map.py
@@ -112,3 +112,11 @@ def test_write_and_load_round_trip(tmp_path):
 def test_load_rejects_nonexistent_file():
     with pytest.raises(IOError):
         IdMapIndex.load("/nonexistent/path/does-not-exist.tvim")
+
+
+def test_search_on_empty_eager_index_returns_zero_effective_k():
+    idx = IdMapIndex(dim=128, bit_width=4)
+    q = unit_vectors(1, 128)
+    scores, indices = idx.search(q, k=3)
+    assert scores.shape == (1, 0)
+    assert indices.shape == (1, 0)

--- a/turbovec-python/tests/test_index.py
+++ b/turbovec-python/tests/test_index.py
@@ -170,3 +170,11 @@ def test_add_with_mismatched_dim_raises_value_error():
     idx = TurboQuantIndex(dim=128, bit_width=4)
     with pytest.raises(ValueError, match="dim mismatch"):
         idx.add(unit_vectors(3, 256))
+
+
+def test_search_on_empty_eager_index_returns_zero_effective_k():
+    idx = TurboQuantIndex(dim=128, bit_width=4)
+    q = unit_vectors(1, 128)
+    scores, indices = idx.search(q, k=3)
+    assert scores.shape == (1, 0)
+    assert indices.shape == (1, 0)


### PR DESCRIPTION
## Related issue
  
  Closes #51

  ## Summary

  - Add `test_search_on_empty_eager_index_returns_zero_effective_k` to `test_index.py` for `TurboQuantIndex`
  - Add the same test to `test_id_map.py` for `IdMapIndex`
  - Both assert shape `(nq, 0)` when searching an eager-constructed index with no vectors added

  ## Motivation

  Surfaced by #48. The lazy-uncommitted search path is already tested via the integration suites, but the
  eager-empty case (`TurboQuantIndex(dim=N, bit_width=B)` → `search()` with no `add()`) had no Python-layer
  coverage.

  ## Test plan

  - [x] `pytest turbovec-python/tests/` passes