### PR TITLE
CONTRIBUTING: PRs by invitation + CODEOWNERS gates main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# All changes require review from @RyanCodrai before they can land on main.
+# Combined with branch protection on main (require review from Code Owners),
+# this means only @RyanCodrai can approve a merge to main.
+* @RyanCodrai

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,21 @@ Thanks for your interest in turbovec.
 
 ## Workflow
 
-The default contribution flow for everyone:
-
 1. **Open an issue** describing what you've spotted — a bug, a missing feature, a documentation gap, a performance question. Include enough context that the conversation can start without back-and-forth on what you mean.
-2. **Discuss.** If you want to suggest an implementation approach, do that in the issue. The issue is where the design conversation lives — and where most of the value of a contribution actually lives.
+2. **Discuss.** If you want to suggest an implementation approach, do that in the issue. This is where the design conversation lives.
+3. **Request contributor access** if you want to land code yourself. In your issue or in a follow-up, say so explicitly — e.g. "happy to take this; can I get contributor access?" I'll review the engagement so far and decide. If yes, I'll add you as a collaborator and you can open a PR for the issue.
 
-That's it for most people. **Pull requests on this repo are by invitation.** I add contributors as collaborators when their engagement on issues makes it clear we're aligned on direction and that a PR from them will be worth reviewing. There's no checklist for that; it's a judgment call based on whether the issue discussion is insightful and the technical understanding is solid.
+If you don't request contributor access, that's fine — the issue itself is a valuable contribution, and I (or another contributor) may pick it up.
 
-Once you're a collaborator and have an agreed-on approach on an issue, you can open a PR. Only I merge to `main`.
+Only I merge to `main`.
+
+## Why this is the workflow
+
+The contributions that move turbovec forward are **good ideas, clearly articulated** — a sharp framing of a real problem, the right question to ask, an insight about how something should work, a benchmark observation that points at a real gap. That's the work I most need help with, and the work hardest to delegate. A well-written issue is more valuable than a PR.
+
+The reason I've moved to invitation-only PRs is that the cost of reviewing a PR I have to mentally reconstruct from scratch — figure out what it's trying to do, why, whether it's correct, whether it fits the project's direction — is higher than just writing the change myself. This has become particularly acute with AI-assisted PRs that are technically clean but arrive without the design context or reasoning that makes review tractable. When the cognitive load of review exceeds the cognitive load of writing the change, the PR is a net loss for the project.
+
+The "by invitation" gate isn't about credentials — it's about making sure the issue-side work has happened first, so when a PR arrives, review can be about *the code* rather than reconstructing *the why*. Contributors who've done that work via issue engagement are a joy to review. PRs that arrive cold without context aren't.
 
 ## For invited contributors: commit and PR conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,19 +4,16 @@ Thanks for your interest in turbovec.
 
 ## Workflow
 
-1. **Open an issue** describing the change and your proposed approach.
-2. **Discuss** — leave space for a 👍 or design back-and-forth before writing code. The issue is where the design conversation lives.
-3. **Open a PR** referencing the issue with `Closes #N`.
+The default contribution flow for everyone:
 
-This applies to features, refactors, behaviour changes, and anything touching public API, on-disk format, or recall. The narrow exceptions that can skip the issue step:
+1. **Open an issue** describing what you've spotted — a bug, a missing feature, a documentation gap, a performance question. Include enough context that the conversation can start without back-and-forth on what you mean.
+2. **Discuss.** If you want to suggest an implementation approach, do that in the issue. The issue is where the design conversation lives — and where most of the value of a contribution actually lives.
 
-- Typo / wording fixes
-- One-line obvious bug fixes
-- Documentation-only PRs
+That's it for most people. **Pull requests on this repo are by invitation.** I add contributors as collaborators when their engagement on issues makes it clear we're aligned on direction and that a PR from them will be worth reviewing. There's no checklist for that; it's a judgment call based on whether the issue discussion is insightful and the technical understanding is solid.
 
-Everything else — including "I think this is small" — wants an issue first. The cost of writing one is low; the cost of building something that doesn't fit the project is high.
+Once you're a collaborator and have an agreed-on approach on an issue, you can open a PR. Only I merge to `main`.
 
-## Commit and PR conventions
+## For invited contributors: commit and PR conventions
 
 - **One logical change per PR.** Refactors get their own PR, separate from feature work.
 - **Commit messages:** short imperative title, body explaining *why* (the *what* is in the diff). Multi-line bodies should preserve formatting — use a HEREDOC if writing from the shell.
@@ -25,7 +22,7 @@ Everything else — including "I think this is small" — wants an issue first. 
 
 ## Integration contributions
 
-If you're adding or modifying an integration (LangChain, LlamaIndex, Haystack, Agno, or a new framework), structurally compare against the canonical in-tree reference store (`InMemoryVectorStore`, `SimpleVectorStore`, `InMemoryDocumentStore` etc.) for that framework. The wrappers should match the reference's surface and idioms — that's the bar for a drop-in replacement.
+If you're adding or modifying an integration (LangChain, LlamaIndex, Haystack, Agno, or a new framework), structurally compare against the canonical in-tree reference store (`InMemoryVectorStore`, `SimpleVectorStore`, `InMemoryDocumentStore`, etc.) for that framework. The wrappers should match the reference's surface and idioms — that's the bar for a drop-in replacement.
 
 ## Build, test, bench
 


### PR DESCRIPTION
## Summary

Updates `CONTRIBUTING.md` to reflect the new contribution policy and adds `.github/CODEOWNERS` so branch protection can enforce it.

- **CONTRIBUTING.md** — replaces the previous open-PR workflow with the three-tier model:
  - Anyone can open issues and discuss
  - PRs are by invitation (collaborator status, granted based on judgment of issue engagement)
  - Only the repo owner merges to `main`
- **`.github/CODEOWNERS`** — `* @RyanCodrai` so the "Require review from Code Owners" branch protection rule has someone to require

## How this is enforced

The file changes pair with three GitHub settings (configured separately in the UI):

1. **Settings → General → Features → Pull requests → "Collaborators only"** — locks PR creation to invited collaborators; everyone else can still open issues
2. **Settings → Branches → Branch protection rule on `main`:**
   - Require pull request before merging
   - Require approvals (1)
   - Require review from Code Owners
   - Restrict who can push to matching branches → allowlist only `@RyanCodrai`
3. CODEOWNERS file in this PR

## Test plan

- [x] CONTRIBUTING.md renders correctly on GitHub
- [x] CODEOWNERS syntax valid (`* @RyanCodrai`)
- [ ] After merge: branch protection rule applied; verify a test PR from a non-allowlisted user cannot be merged even after Code Owner approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)