### PR TITLE
Fix Linux wheel ImportError: missing libopenblas in DT_NEEDED

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -35,7 +35,15 @@ jobs:
             elif command -v yum >/dev/null 2>&1; then
               yum install -y openblas-devel openssl-devel pkgconfig
             elif command -v apt-get >/dev/null 2>&1; then
-              apt-get update && apt-get install -y libopenblas-dev libssl-dev pkg-config
+              # The maturin-action container is x86_64 even when targeting
+              # aarch64 (cross-compilation). Enable multi-arch and install
+              # libopenblas for both arches so the cross-linker can find
+              # the aarch64 variant when needed.
+              dpkg --add-architecture arm64
+              apt-get update
+              apt-get install -y \
+                libopenblas-dev libopenblas-dev:arm64 \
+                libssl-dev pkg-config
             else
               echo "No supported package manager found" && exit 1
             fi

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -42,6 +42,19 @@ jobs:
             else
               echo "No supported package manager found" && exit 1
             fi
+      # Install the freshly-built wheel and run the core test suite on
+      # the runner (outside the build container). This catches linkage
+      # regressions that produce structurally-correct .so files which
+      # fail at Python import time — exactly the class of bug that was
+      # silently shipping in Linux wheels until this PR.
+      - name: Install wheel and smoke test
+        shell: bash
+        working-directory: turbovec-python
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install dist/*.whl
+          python -m pytest tests/test_index.py tests/test_id_map.py tests/test_filtering.py -v
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -12,7 +12,10 @@ permissions:
 jobs:
   linux:
     name: Linux ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    # Build each target on a runner of its own architecture, so the build
+    # is native and the in-container `apt-get install libopenblas-dev`
+    # picks up the right openblas variant without cross-compile gymnastics.
+    runs-on: ${{ matrix.target == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -35,29 +38,7 @@ jobs:
             elif command -v yum >/dev/null 2>&1; then
               yum install -y openblas-devel openssl-devel pkgconfig
             elif command -v apt-get >/dev/null 2>&1; then
-              # The maturin-action container is x86_64 even when targeting
-              # aarch64 (cross-compilation). Enable multi-arch and install
-              # libopenblas for both arches so the cross-linker can find
-              # the aarch64 variant when needed.
-              #
-              # Ubuntu hosts arm64 packages on ports.ubuntu.com rather than
-              # archive.ubuntu.com, so we have to restrict the existing
-              # sources to amd64 and add an arm64 source pointing at the
-              # right mirror, otherwise `apt-get update` returns 404 on the
-              # arm64 indices.
-              dpkg --add-architecture arm64
-              . /etc/os-release
-              sed -i 's|^deb http://archive.ubuntu.com/ubuntu/|deb [arch=amd64] http://archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list
-              sed -i 's|^deb http://security.ubuntu.com/ubuntu/|deb [arch=amd64] http://security.ubuntu.com/ubuntu/|g' /etc/apt/sources.list
-              {
-                printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s main restricted universe multiverse\n' "$VERSION_CODENAME"
-                printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s-updates main restricted universe multiverse\n' "$VERSION_CODENAME"
-                printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s-security main restricted universe multiverse\n' "$VERSION_CODENAME"
-              } >> /etc/apt/sources.list
-              apt-get update
-              apt-get install -y \
-                libopenblas-dev libopenblas-dev:arm64 \
-                libssl-dev pkg-config
+              apt-get update && apt-get install -y libopenblas-dev libssl-dev pkg-config
             else
               echo "No supported package manager found" && exit 1
             fi

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -39,7 +39,21 @@ jobs:
               # aarch64 (cross-compilation). Enable multi-arch and install
               # libopenblas for both arches so the cross-linker can find
               # the aarch64 variant when needed.
+              #
+              # Ubuntu hosts arm64 packages on ports.ubuntu.com rather than
+              # archive.ubuntu.com, so we have to restrict the existing
+              # sources to amd64 and add an arm64 source pointing at the
+              # right mirror, otherwise `apt-get update` returns 404 on the
+              # arm64 indices.
               dpkg --add-architecture arm64
+              . /etc/os-release
+              sed -i 's|^deb http://archive.ubuntu.com/ubuntu/|deb [arch=amd64] http://archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list
+              sed -i 's|^deb http://security.ubuntu.com/ubuntu/|deb [arch=amd64] http://security.ubuntu.com/ubuntu/|g' /etc/apt/sources.list
+              {
+                printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s main restricted universe multiverse\n' "$VERSION_CODENAME"
+                printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s-updates main restricted universe multiverse\n' "$VERSION_CODENAME"
+                printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s-security main restricted universe multiverse\n' "$VERSION_CODENAME"
+              } >> /etc/apt/sources.list
               apt-get update
               apt-get install -y \
                 libopenblas-dev libopenblas-dev:arm64 \

--- a/turbovec-python/build.rs
+++ b/turbovec-python/build.rs
@@ -1,0 +1,17 @@
+// Force the linker to record libopenblas as a runtime dependency on Linux.
+//
+// Without this, the `.so` we produce references `cblas_sgemm` as an
+// undefined symbol but has no `DT_NEEDED` entry pointing at openblas, so
+// dynamic linking fails at Python import time:
+//
+//   ImportError: _turbovec.abi3.so: undefined symbol: cblas_sgemm
+//
+// The blas-src + openblas-src dependency chain doesn't reliably emit
+// the link flag through pyo3's build, so we emit it directly. On macOS
+// we rely on the Accelerate framework which `blas-src` wires up via its
+// `accelerate` feature; no extra link flag needed there.
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux") {
+        println!("cargo:rustc-link-lib=openblas");
+    }
+}


### PR DESCRIPTION
## Related issue

Closes #60

## Summary

- Adds `turbovec-python/build.rs` that emits `cargo:rustc-link-lib=openblas` on Linux targets
- Fixes the `ImportError: undefined symbol: cblas_sgemm` that every Linux user hits when `pip install turbovec` (reported in #60, but the wheel has been broken since Linux wheel publication started)
- Linux wheel grows from ~1.8 MB to ~11.5 MB because auditwheel now bundles `libopenblas` + transitive `libgfortran`. Self-contained: works on any Linux distro with no system OpenBLAS install required.

## Diagnosis

ELF inspection of the published `_turbovec.abi3.so` from PyPI:

| | Before (broken) | After (this PR) |
|---|---|---|
| `DT_NEEDED` includes openblas | ❌ | ✅ `libopenblas-…so.0` |
| `DT_RPATH` set | ❌ | ✅ `\$ORIGIN/../turbovec.libs` |
| `turbovec.libs/` directory exists | ❌ | ✅ contains openblas + libgfortran |
| Import on clean Linux | `ImportError: undefined symbol: cblas_sgemm` | works |

Root cause: the `blas-src` + `openblas-src` chain in Cargo.toml is supposed to emit `-lopenblas` to the linker, but empirically that signal isn't reaching the final link through pyo3/maturin. The compiled binary references `cblas_sgemm` as an undefined symbol without recording where to find it. Auditwheel then has nothing to bundle because no external dependency is declared on the binary.

The `build.rs` emits the link directive directly, which puts `libopenblas` into `DT_NEEDED`. Auditwheel sees it and bundles automatically.

## Why bundling (vs documenting a system OpenBLAS requirement)

- Matches scientific Python convention: numpy, scipy, scikit-learn all bundle their BLAS
- Single wheel works across Ubuntu / Fedora / Alpine / etc. — no per-distro instructions
- Eliminates the install-fails-because-system-deps support burden
- 11.5 MB is small in this category (numpy wheels ~20 MB, scipy ~30 MB)
- Auditwheel does it automatically; no ongoing maintenance

The main trade-off is multi-BLAS over-subscription (a user with numpy + turbovec has two independent OpenBLAS copies). In practice turbovec's BLAS call is a single short-lived matmul per encode batch, so this rarely matters.

## Test plan

- [x] Built the fixed wheel in the same `manylinux_2_28_aarch64` container the CI uses
- [x] Inspected the resulting ELF and confirmed `DT_NEEDED: libopenblas`, `DT_RPATH: \$ORIGIN/../turbovec.libs`, and `turbovec.libs/` populated with bundled libs
- [x] Installed the fixed wheel in a fresh `python:3.12-slim` container (no system openblas, no openblas-devel) — `import turbovec` works, `TurboQuantIndex` builds and searches successfully
- [ ] Verify the same on `manylinux_2_28_x86_64` via CI (couldn't reproduce locally due to Apple Silicon → x86_64 Docker emulation hitting SIGILL on Rust proc-macros; the CI builds will exercise this path properly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)