### PR TITLE
Cache TurboQuant codebook state during incremental adds

### DIFF
--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -81,10 +81,11 @@ pub struct TurboQuantIndex {
     // already has `&mut self` for the underlying extend on
     // `packed_codes` and `scales`).
     //
-    // `rotation` and `centroids` are deterministic functions of `(dim,
-    // ROTATION_SEED)` and `(bit_width, dim)` respectively, so they
-    // never need to be invalidated.
+    // `rotation`, `boundaries`, and `centroids` are deterministic functions
+    // of `(dim, ROTATION_SEED)` and `(bit_width, dim)`, so they never need
+    // to be invalidated.
     rotation: OnceLock<Vec<f32>>,
+    boundaries: OnceLock<Vec<f32>>,
     centroids: OnceLock<Vec<f32>>,
     blocked: OnceLock<BlockedCache>,
 }
@@ -121,6 +122,7 @@ impl TurboQuantIndex {
             packed_codes: Vec::new(),
             scales: Vec::new(),
             rotation: OnceLock::new(),
+            boundaries: OnceLock::new(),
             centroids: OnceLock::new(),
             blocked: OnceLock::new(),
         }
@@ -138,6 +140,7 @@ impl TurboQuantIndex {
             packed_codes: Vec::new(),
             scales: Vec::new(),
             rotation: OnceLock::new(),
+            boundaries: OnceLock::new(),
             centroids: OnceLock::new(),
             blocked: OnceLock::new(),
         }
@@ -160,14 +163,26 @@ impl TurboQuantIndex {
         let rotation = self
             .rotation
             .get_or_init(|| rotation::make_rotation_matrix(dim));
-        let (boundaries, centroids) = codebook::codebook(self.bit_width, dim);
+        if self.boundaries.get().is_none() || self.centroids.get().is_none() {
+            let (boundaries, centroids) = codebook::codebook(self.bit_width, dim);
+            let _ = self.boundaries.set(boundaries);
+            let _ = self.centroids.set(centroids);
+        }
+        let boundaries = self
+            .boundaries
+            .get()
+            .expect("boundaries cache is initialized");
+        let centroids = self
+            .centroids
+            .get()
+            .expect("centroids cache is initialized");
         let (packed, scales) = encode::encode(
             vectors,
             n,
             dim,
             rotation,
-            &boundaries,
-            &centroids,
+            boundaries,
+            centroids,
             self.bit_width,
         );
 
@@ -182,8 +197,8 @@ impl TurboQuantIndex {
 
         // Invalidate the blocked cache — it was derived from the old
         // `packed_codes` and no longer matches the extended vector set.
-        // Rotation and centroids remain valid (they only depend on
-        // `(dim, ROTATION_SEED)` and `(bit_width, dim)`).
+        // Rotation, boundaries, and centroids remain valid (they only depend
+        // on `(dim, ROTATION_SEED)` and `(bit_width, dim)`).
         self.blocked = OnceLock::new();
     }
 
@@ -380,6 +395,7 @@ impl TurboQuantIndex {
             packed_codes,
             scales,
             rotation: OnceLock::new(),
+            boundaries: OnceLock::new(),
             centroids: OnceLock::new(),
             blocked: OnceLock::new(),
         }


### PR DESCRIPTION
## Related issue

Closes #62

## Summary

Cherry-picked from @faysou (see [their branch](https://github.com/faysou/turbovec/tree/cache-add)) — adds a `boundaries: OnceLock<Vec<f32>>` field to `TurboQuantIndex` and uses it (alongside the existing `centroids` cache) inside `add` so the codebook isn't reconstructed on every call.

## Motivation

The codebook (Lloyd-Max boundaries + centroids) is a deterministic function of `(bit_width, dim)` — your own struct doc comment already says so. The cache infrastructure for `centroids` exists and `search` uses it correctly via `get_or_init`, but `add` ignored it and called `codebook::codebook(...)` fresh on every invocation. `boundaries` had no cache at all.

After this change:
- First `add` (or `search`) on a fresh index pays the codebook construction cost
- Subsequent `add` calls reuse from cache
- Search continues to use the shared `centroids` cache
- `load` / `from_parts` correctly leave both caches empty for lazy init

## Author credit

The commit on this branch is authored by Faysal Aberkane (`faysou`). They followed the new contribution workflow — they wanted to open the PR themselves but the collaborators-only setting blocked them, so they filed #62 describing the change and linked their fork branch. Cherry-picked rather than re-implemented to preserve their authorship.

## Test plan

- [x] `cargo test -p turbovec --release` — 86 tests across 13 suites, all green
- [x] `pytest turbovec-python/tests/` — 227 tests, all green (with all integration extras installed)
- [ ] No micro-benchmark of the codebook-construction time vs total encode time — would be a useful follow-up to quantify the win, but the change is correctness-preserving so I didn't gate the PR on it

## Note on overlap with #32

@raghavenderreddygrudhanti's in-flight PR #57 (encode SIMD + Rayon) also touches the encode path. Not in conflict with this change (this is a higher-level cache hit, #57 is SIMD-ing inner loops), but worth being aware of the merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)