### PR TITLE
Constructor input validation: Result/ValueError instead of panic

### DIFF
--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -15,13 +15,13 @@ impl TurboQuantIndex {
     /// array's shape.
     #[new]
     #[pyo3(signature = (dim=None, bit_width=4))]
-    fn new(dim: Option<usize>, bit_width: usize) -> Self {
-        Self {
-            inner: match dim {
-                Some(d) => turbovec_core::TurboQuantIndex::new(d, bit_width),
-                None => turbovec_core::TurboQuantIndex::new_lazy(bit_width),
-            },
+    fn new(dim: Option<usize>, bit_width: usize) -> PyResult<Self> {
+        let inner = match dim {
+            Some(d) => turbovec_core::TurboQuantIndex::new(d, bit_width),
+            None => turbovec_core::TurboQuantIndex::new_lazy(bit_width),
         }
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        Ok(Self { inner })
     }
 
     fn add(&mut self, vectors: PyReadonlyArray2<f32>) -> PyResult<()> {
@@ -154,13 +154,13 @@ impl IdMapIndex {
     /// `add_with_ids` call, picking up dim from the input array shape.
     #[new]
     #[pyo3(signature = (dim=None, bit_width=4))]
-    fn new(dim: Option<usize>, bit_width: usize) -> Self {
-        Self {
-            inner: match dim {
-                Some(d) => turbovec_core::IdMapIndex::new(d, bit_width),
-                None => turbovec_core::IdMapIndex::new_lazy(bit_width),
-            },
+    fn new(dim: Option<usize>, bit_width: usize) -> PyResult<Self> {
+        let inner = match dim {
+            Some(d) => turbovec_core::IdMapIndex::new(d, bit_width),
+            None => turbovec_core::IdMapIndex::new_lazy(bit_width),
         }
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        Ok(Self { inner })
     }
 
     /// Add `n = vectors.shape[0]` vectors with the given external `ids`.

--- a/turbovec-python/tests/test_id_map.py
+++ b/turbovec-python/tests/test_id_map.py
@@ -112,3 +112,22 @@ def test_write_and_load_round_trip(tmp_path):
 def test_load_rejects_nonexistent_file():
     with pytest.raises(IOError):
         IdMapIndex.load("/nonexistent/path/does-not-exist.tvim")
+
+
+@pytest.mark.parametrize("bad_bit_width", [0, 1, 5, 8])
+def test_constructor_rejects_bad_bit_width(bad_bit_width):
+    with pytest.raises(ValueError, match="bit_width"):
+        IdMapIndex(dim=128, bit_width=bad_bit_width)
+
+
+@pytest.mark.parametrize("bad_dim", [0, 1, 4, 7, 9])
+def test_constructor_rejects_bad_dim(bad_dim):
+    with pytest.raises(ValueError, match="dim"):
+        IdMapIndex(dim=bad_dim, bit_width=4)
+
+
+def test_search_on_empty_eager_index_returns_zero_effective_k():
+    idx = IdMapIndex(dim=128, bit_width=4)
+    q = unit_vectors(1, 128)
+    _, ids = idx.search(q, k=3)
+    assert ids.shape == (1, 0)

--- a/turbovec-python/tests/test_index.py
+++ b/turbovec-python/tests/test_index.py
@@ -170,3 +170,23 @@ def test_add_with_mismatched_dim_raises_value_error():
     idx = TurboQuantIndex(dim=128, bit_width=4)
     with pytest.raises(ValueError, match="dim mismatch"):
         idx.add(unit_vectors(3, 256))
+
+
+@pytest.mark.parametrize("bad_bit_width", [0, 1, 5, 8])
+def test_constructor_rejects_bad_bit_width(bad_bit_width):
+    with pytest.raises(ValueError, match="bit_width"):
+        TurboQuantIndex(dim=128, bit_width=bad_bit_width)
+
+
+@pytest.mark.parametrize("bad_dim", [0, 1, 4, 7, 9])
+def test_constructor_rejects_bad_dim(bad_dim):
+    with pytest.raises(ValueError, match="dim"):
+        TurboQuantIndex(dim=bad_dim, bit_width=4)
+
+
+def test_search_on_empty_eager_index_returns_zero_effective_k():
+    idx = TurboQuantIndex(dim=128, bit_width=4)
+    q = unit_vectors(1, 128)
+    scores, indices = idx.search(q, k=3)
+    assert scores.shape == (1, 0)
+    assert indices.shape == (1, 0)

--- a/turbovec-python/tests/test_index.py
+++ b/turbovec-python/tests/test_index.py
@@ -26,7 +26,7 @@ def test_new_reports_dim_and_bit_width():
     assert len(idx) == 0
 
 
-@pytest.mark.parametrize("bit_width", [2, 4])
+@pytest.mark.parametrize("bit_width", [2, 3, 4])
 def test_bit_width_options(bit_width):
     idx = TurboQuantIndex(dim=128, bit_width=bit_width)
     assert idx.bit_width == bit_width

--- a/turbovec/src/error.rs
+++ b/turbovec/src/error.rs
@@ -1,13 +1,21 @@
-//! Errors returned by the user-facing `add` paths
+//! Errors returned by the user-facing add and construct paths.
+//!
+//! [`AddError`] is returned by the add paths
 //! ([`TurboQuantIndex::add_2d`](crate::TurboQuantIndex::add_2d),
 //! [`IdMapIndex::add_with_ids_2d`](crate::IdMapIndex::add_with_ids_2d),
 //! [`IdMapIndex::add_with_ids`](crate::IdMapIndex::add_with_ids)).
 //!
-//! These are all forms of user input error — wrong shape, wrong dim, or
-//! duplicate id — that callers can recover from. Internal preconditions
-//! (e.g. calling the low-level `add(&self, &[f32])` on a lazy index that
-//! hasn't been committed) still panic, since that signals a contract
-//! violation rather than bad input.
+//! [`ConstructError`] is returned by the constructors
+//! ([`TurboQuantIndex::new`](crate::TurboQuantIndex::new),
+//! [`TurboQuantIndex::new_lazy`](crate::TurboQuantIndex::new_lazy),
+//! [`IdMapIndex::new`](crate::IdMapIndex::new),
+//! [`IdMapIndex::new_lazy`](crate::IdMapIndex::new_lazy)).
+//!
+//! Both are forms of user input error — wrong shape, wrong dim, wrong
+//! bit_width, or duplicate id — that callers can recover from. Internal
+//! preconditions (e.g. calling the low-level `add(&self, &[f32])` on a
+//! lazy index that hasn't been committed) still panic, since that
+//! signals a contract violation rather than bad input.
 
 use std::error::Error;
 use std::fmt;
@@ -54,3 +62,27 @@ impl fmt::Display for AddError {
 }
 
 impl Error for AddError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConstructError {
+    /// `bit_width` must be 2, 3, or 4.
+    BitWidthOutOfRange(usize),
+
+    /// `dim` must be a positive multiple of 8.
+    DimNotPositiveMultipleOf8(usize),
+}
+
+impl fmt::Display for ConstructError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BitWidthOutOfRange(bw) => {
+                write!(f, "bit_width must be 2, 3, or 4, got {bw}")
+            }
+            Self::DimNotPositiveMultipleOf8(dim) => {
+                write!(f, "dim must be a positive multiple of 8, got {dim}")
+            }
+        }
+    }
+}
+
+impl Error for ConstructError {}

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -15,7 +15,7 @@
 //! ```no_run
 //! use turbovec::IdMapIndex;
 //!
-//! let mut index = IdMapIndex::new(1536, 4);
+//! let mut index = IdMapIndex::new(1536, 4).unwrap();
 //! let vectors: Vec<f32> = vec![0.0; 1536 * 3];
 //! index.add_with_ids(&vectors, &[1001, 1002, 1003]).unwrap();
 //!
@@ -39,7 +39,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::io;
-use crate::{AddError, TurboQuantIndex};
+use crate::{AddError, ConstructError, TurboQuantIndex};
 
 /// ID-addressed wrapper around [`TurboQuantIndex`].
 pub struct IdMapIndex {
@@ -53,24 +53,25 @@ pub struct IdMapIndex {
 
 impl IdMapIndex {
     /// Construct an id-map index with a known dim. The dim is locked at
-    /// construction.
-    pub fn new(dim: usize, bit_width: usize) -> Self {
-        Self {
-            inner: TurboQuantIndex::new(dim, bit_width),
+    /// construction. Propagates the same errors as
+    /// [`TurboQuantIndex::new`].
+    pub fn new(dim: usize, bit_width: usize) -> Result<Self, ConstructError> {
+        Ok(Self {
+            inner: TurboQuantIndex::new(dim, bit_width)?,
             slot_to_id: Vec::new(),
             id_to_slot: HashMap::new(),
-        }
+        })
     }
 
     /// Construct an empty id-map index without committing to a dim. The
     /// dim is inferred and locked on the first [`Self::add_with_ids_2d`]
-    /// call.
-    pub fn new_lazy(bit_width: usize) -> Self {
-        Self {
-            inner: TurboQuantIndex::new_lazy(bit_width),
+    /// call. Propagates the same errors as [`TurboQuantIndex::new_lazy`].
+    pub fn new_lazy(bit_width: usize) -> Result<Self, ConstructError> {
+        Ok(Self {
+            inner: TurboQuantIndex::new_lazy(bit_width)?,
             slot_to_id: Vec::new(),
             id_to_slot: HashMap::new(),
-        }
+        })
     }
 
     /// Add `n = vectors.len() / dim` vectors with the given external ids.

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -7,7 +7,7 @@
 //! use turbovec::TurboQuantIndex;
 //!
 //! // 1536-dim vectors compressed to 4 bits per coordinate.
-//! let mut index = TurboQuantIndex::new(1536, 4);
+//! let mut index = TurboQuantIndex::new(1536, 4).unwrap();
 //!
 //! // `vectors` is a flat [f32] of length n * dim, `queries` likewise.
 //! let vectors: Vec<f32> = vec![0.0; 1536 * 10];
@@ -43,7 +43,7 @@ pub mod pack;
 pub mod rotation;
 pub mod search;
 
-pub use error::AddError;
+pub use error::{AddError, ConstructError};
 pub use id_map::IdMapIndex;
 
 use std::path::Path;
@@ -111,11 +111,19 @@ impl TurboQuantIndex {
     /// Construct an index with a known dimensionality. The dim is locked
     /// at construction; subsequent [`Self::add`] / [`Self::add_2d`] calls
     /// must match.
-    pub fn new(dim: usize, bit_width: usize) -> Self {
-        assert!((2..=4).contains(&bit_width), "bit_width must be 2, 3, or 4");
-        assert!(dim % 8 == 0, "dim must be a multiple of 8");
+    ///
+    /// Returns [`ConstructError::BitWidthOutOfRange`] if `bit_width` is
+    /// not in `{2, 3, 4}` and [`ConstructError::DimNotPositiveMultipleOf8`]
+    /// if `dim == 0` or `dim % 8 != 0`.
+    pub fn new(dim: usize, bit_width: usize) -> Result<Self, ConstructError> {
+        if !(2..=4).contains(&bit_width) {
+            return Err(ConstructError::BitWidthOutOfRange(bit_width));
+        }
+        if dim == 0 || dim % 8 != 0 {
+            return Err(ConstructError::DimNotPositiveMultipleOf8(dim));
+        }
 
-        Self {
+        Ok(Self {
             dim: Some(dim),
             bit_width,
             n_vectors: 0,
@@ -125,15 +133,20 @@ impl TurboQuantIndex {
             boundaries: OnceLock::new(),
             centroids: OnceLock::new(),
             blocked: OnceLock::new(),
-        }
+        })
     }
 
     /// Construct an empty index without committing to a dimensionality.
     /// The dim is inferred and locked on the first [`Self::add_2d`] call
     /// (or [`Self::add`] if the caller wires dim in separately).
-    pub fn new_lazy(bit_width: usize) -> Self {
-        assert!((2..=4).contains(&bit_width), "bit_width must be 2, 3, or 4");
-        Self {
+    ///
+    /// Returns [`ConstructError::BitWidthOutOfRange`] if `bit_width` is
+    /// not in `{2, 3, 4}`.
+    pub fn new_lazy(bit_width: usize) -> Result<Self, ConstructError> {
+        if !(2..=4).contains(&bit_width) {
+            return Err(ConstructError::BitWidthOutOfRange(bit_width));
+        }
+        Ok(Self {
             dim: None,
             bit_width,
             n_vectors: 0,
@@ -143,7 +156,7 @@ impl TurboQuantIndex {
             boundaries: OnceLock::new(),
             centroids: OnceLock::new(),
             blocked: OnceLock::new(),
-        }
+        })
     }
 
     /// Add a flat batch of vectors. `dim` must be set (either eagerly at

--- a/turbovec/tests/concurrent_search.rs
+++ b/turbovec/tests/concurrent_search.rs
@@ -45,7 +45,7 @@ fn build_index() -> TurboQuantIndex {
     let n = 1_024;
 
     let vectors = make_vectors(n, dim, 1);
-    let mut index = TurboQuantIndex::new(dim, bit_width);
+    let mut index = TurboQuantIndex::new(dim, bit_width).unwrap();
     index.add(&vectors);
     assert_eq!(index.len(), n);
     index

--- a/turbovec/tests/distortion.rs
+++ b/turbovec/tests/distortion.rs
@@ -196,7 +196,7 @@ fn self_query_recall_at_1() {
     let n = 200;
     let vectors = unit_sphere_vectors(n, dim, 0);
 
-    let mut index = TurboQuantIndex::new(dim, 4);
+    let mut index = TurboQuantIndex::new(dim, 4).unwrap();
     index.add(&vectors);
     index.prepare();
 
@@ -224,7 +224,7 @@ struct ScoreStats {
 /// Mean and stddev of top-1 self-query scores.
 fn self_score_stats(vectors: &[f32], dim: usize, bits: usize) -> ScoreStats {
     let n = vectors.len() / dim;
-    let mut index = TurboQuantIndex::new(dim, bits);
+    let mut index = TurboQuantIndex::new(dim, bits).unwrap();
     index.add(vectors);
     index.prepare();
 
@@ -246,7 +246,7 @@ fn self_score_stats(vectors: &[f32], dim: usize, bits: usize) -> ScoreStats {
 /// longer exposes under the corrected estimator.
 fn cross_score_stats(database: &[f32], queries: &[f32], dim: usize, bits: usize) -> ScoreStats {
     let n_q = queries.len() / dim;
-    let mut index = TurboQuantIndex::new(dim, bits);
+    let mut index = TurboQuantIndex::new(dim, bits).unwrap();
     index.add(database);
     index.prepare();
 

--- a/turbovec/tests/filtering.rs
+++ b/turbovec/tests/filtering.rs
@@ -55,7 +55,7 @@ fn gaussian_normalized(n: usize, dim: usize, seed: u64) -> Vec<f32> {
 
 fn build_index(n: usize, dim: usize, seed: u64) -> TurboQuantIndex {
     let data = gaussian_normalized(n, dim, seed);
-    let mut idx = TurboQuantIndex::new(dim, 4);
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
     idx.add(&data);
     idx
 }
@@ -240,7 +240,7 @@ fn allowlist_returns_only_listed_ids() {
     let n = 100;
     let data = gaussian_normalized(n, dim, 0xF11D_1001);
     let ids: Vec<u64> = (0..n as u64).map(|i| 1000 + i).collect();
-    let mut idx = IdMapIndex::new(dim, 4);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
     idx.add_with_ids(&data, &ids).unwrap();
 
     let query = gaussian_normalized(1, dim, 0xF11D_1002);
@@ -264,7 +264,7 @@ fn allowlist_none_equivalent_to_plain_search() {
     let n = 80;
     let data = gaussian_normalized(n, dim, 0xF11D_1003);
     let ids: Vec<u64> = (0..n as u64).map(|i| 7000 + i * 13).collect();
-    let mut idx = IdMapIndex::new(dim, 4);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
     idx.add_with_ids(&data, &ids).unwrap();
 
     let query = gaussian_normalized(1, dim, 0xF11D_1004);
@@ -280,7 +280,7 @@ fn empty_allowlist_panics() {
     let dim = 64;
     let data = gaussian_normalized(10, dim, 0xF11D_1005);
     let ids: Vec<u64> = (0..10).collect();
-    let mut idx = IdMapIndex::new(dim, 4);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
     idx.add_with_ids(&data, &ids).unwrap();
 
     let query = gaussian_normalized(1, dim, 0xF11D_1006);
@@ -293,7 +293,7 @@ fn unknown_id_in_allowlist_panics() {
     let dim = 64;
     let data = gaussian_normalized(10, dim, 0xF11D_1007);
     let ids: Vec<u64> = (0..10).collect();
-    let mut idx = IdMapIndex::new(dim, 4);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
     idx.add_with_ids(&data, &ids).unwrap();
 
     let query = gaussian_normalized(1, dim, 0xF11D_1008);
@@ -310,7 +310,7 @@ fn block_skip_at_one_percent_selectivity_matches_post_filter() {
     let dim = 128;
     let n = 4096;  // 128 blocks of 32 — gives the skip path plenty to skip
     let data = gaussian_normalized(n, dim, 0xB10C_5417);
-    let mut idx = TurboQuantIndex::new(dim, 4);
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
     idx.add(&data);
     idx.prepare();
 
@@ -366,7 +366,7 @@ fn block_skip_at_extreme_selectivity_returns_only_allowed() {
     let dim = 64;
     let n = 8192;
     let data = gaussian_normalized(n, dim, 0xB10C_5419);
-    let mut idx = TurboQuantIndex::new(dim, 4);
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
     idx.add(&data);
     idx.prepare();
 
@@ -407,7 +407,7 @@ fn block_skip_path_actually_fires_under_selective_mask() {
     let dim = 64;
     let n = 4096; // 128 blocks of 32
     let data = gaussian_normalized(n, dim, 0xC0DE_5417);
-    let mut idx = TurboQuantIndex::new(dim, 4);
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
     idx.add(&data);
     idx.prepare();
 
@@ -454,7 +454,7 @@ fn block_skip_with_all_slots_allowed_matches_unmasked() {
     let dim = 64;
     let n = 1024;
     let data = gaussian_normalized(n, dim, 0xB10C_541B);
-    let mut idx = TurboQuantIndex::new(dim, 4);
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
     idx.add(&data);
     idx.prepare();
 
@@ -477,7 +477,7 @@ fn allowlist_survives_swap_remove() {
     let n = 30;
     let data = gaussian_normalized(n, dim, 0xF11D_1009);
     let ids: Vec<u64> = (0..n as u64).map(|i| 5000 + i).collect();
-    let mut idx = IdMapIndex::new(dim, 4);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
     idx.add_with_ids(&data, &ids).unwrap();
 
     let allowed: Vec<u64> = vec![5005, 5015, 5020];

--- a/turbovec/tests/id_map.rs
+++ b/turbovec/tests/id_map.rs
@@ -56,7 +56,7 @@ fn gaussian_normalized(n: usize, dim: usize, seed: u64) -> Vec<f32> {
 fn add_with_ids_updates_len_and_contains() {
     let dim = 128;
     let data = gaussian_normalized(5, dim, 0xA11D_0000);
-    let mut idx = IdMapIndex::new(dim, 4);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
     idx.add_with_ids(&data, &[100, 200, 300, 400, 500]).unwrap();
 
     assert_eq!(idx.len(), 5);
@@ -68,7 +68,7 @@ fn add_with_ids_updates_len_and_contains() {
 fn search_returns_ids_not_slots() {
     let dim = 256;
     let data = gaussian_normalized(10, dim, 0xA11D_0001);
-    let mut idx = IdMapIndex::new(dim, 4);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
     let ids: Vec<u64> = (1_000_000..1_000_010).collect();
     idx.add_with_ids(&data, &ids).unwrap();
 
@@ -84,7 +84,7 @@ fn search_returns_ids_not_slots() {
 fn remove_returns_false_for_missing_id() {
     let dim = 128;
     let data = gaussian_normalized(3, dim, 0xA11D_0002);
-    let mut idx = IdMapIndex::new(dim, 4);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
     idx.add_with_ids(&data, &[1, 2, 3]).unwrap();
 
     assert!(!idx.remove(999));
@@ -95,7 +95,7 @@ fn remove_returns_false_for_missing_id() {
 fn remove_existing_id_shrinks_and_hides_it() {
     let dim = 256;
     let data = gaussian_normalized(10, dim, 0xA11D_0003);
-    let mut idx = IdMapIndex::new(dim, 4);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
     let ids: Vec<u64> = (0..10).map(|i| i as u64 * 7 + 11).collect();
     idx.add_with_ids(&data, &ids).unwrap();
 
@@ -115,7 +115,7 @@ fn remove_existing_id_shrinks_and_hides_it() {
 fn remaining_ids_still_self_query_after_mixed_removes() {
     let dim = 384;
     let data = gaussian_normalized(20, dim, 0xA11D_0004);
-    let mut idx = IdMapIndex::new(dim, 4);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
     let ids: Vec<u64> = (0..20).map(|i| i as u64 * 100 + 5).collect();
     idx.add_with_ids(&data, &ids).unwrap();
 
@@ -148,7 +148,7 @@ fn remaining_ids_still_self_query_after_mixed_removes() {
 fn remove_then_re_add_same_id_is_allowed() {
     let dim = 128;
     let data = gaussian_normalized(5, dim, 0xA11D_0005);
-    let mut idx = IdMapIndex::new(dim, 4);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
     idx.add_with_ids(&data, &[1, 2, 3, 4, 5]).unwrap();
 
     assert!(idx.remove(3));
@@ -165,7 +165,7 @@ fn remove_then_re_add_same_id_is_allowed() {
 fn add_with_ids_rejects_duplicate_id() {
     let dim = 128;
     let data = gaussian_normalized(5, dim, 0xA11D_0006);
-    let mut idx = IdMapIndex::new(dim, 4);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
     idx.add_with_ids(&data[..2 * dim], &[1, 2]).unwrap();
     // Same id "2" already present.
     let err = idx
@@ -178,7 +178,7 @@ fn add_with_ids_rejects_duplicate_id() {
 fn add_with_ids_rejects_length_mismatch() {
     let dim = 128;
     let data = gaussian_normalized(5, dim, 0xA11D_0007);
-    let mut idx = IdMapIndex::new(dim, 4);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
     // 5 vectors, only 3 ids.
     let err = idx.add_with_ids(&data, &[1, 2, 3]).unwrap_err();
     assert_eq!(
@@ -196,7 +196,7 @@ fn write_and_load_round_trips() {
     let data = gaussian_normalized(10, dim, 0xA11D_0100);
     let ids: Vec<u64> = (2000..2010).collect();
 
-    let mut idx = IdMapIndex::new(dim, 4);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
     idx.add_with_ids(&data, &ids).unwrap();
 
     // Delete a few to exercise non-identity slot_to_id mapping.
@@ -236,7 +236,7 @@ fn load_rejects_wrong_magic() {
     // Write a file that starts with the `.tv` format instead of `TVIM`.
     let dim = 64;
     let data = gaussian_normalized(2, dim, 0xA11D_0101);
-    let mut inner = IdMapIndex::new(dim, 4);
+    let mut inner = IdMapIndex::new(dim, 4).unwrap();
     inner.add_with_ids(&data, &[1, 2]).unwrap();
     // Use the inner TurboQuantIndex's write to produce a .tv file.
     // We can't do that directly since inner is private; simulate with
@@ -250,7 +250,7 @@ fn load_rejects_wrong_magic() {
 #[test]
 fn empty_index_round_trip() {
     let dim = 128;
-    let idx = IdMapIndex::new(dim, 4);
+    let idx = IdMapIndex::new(dim, 4).unwrap();
 
     let tmp = std::env::temp_dir().join(format!(
         "turbovec_idmap_empty_{}.tvim",

--- a/turbovec/tests/kernel_correctness.rs
+++ b/turbovec/tests/kernel_correctness.rs
@@ -85,7 +85,7 @@ fn self_query_returns_self_top1_4bit() {
 
     for &n in TAIL_SIZES {
         let data = gaussian_normalized(n, dim, 0x5EED_0000 ^ n as u64);
-        let mut idx = TurboQuantIndex::new(dim, bits);
+        let mut idx = TurboQuantIndex::new(dim, bits).unwrap();
         idx.add(&data);
         assert_eq!(idx.len(), n);
 
@@ -114,7 +114,7 @@ fn self_query_returns_self_top3_2bit() {
 
     for &n in TAIL_SIZES {
         let data = gaussian_normalized(n, dim, 0xC0FF_EE00 ^ n as u64);
-        let mut idx = TurboQuantIndex::new(dim, bits);
+        let mut idx = TurboQuantIndex::new(dim, bits).unwrap();
         idx.add(&data);
 
         let nq = n.min(8);
@@ -145,7 +145,7 @@ fn search_scores_are_sorted_descending() {
     for bits in [2usize, 3, 4] {
         for &n in &[64usize, 100, 128, 200, 256, 500] {
             let data = gaussian_normalized(n, dim, 0xA11CE ^ (n as u64) ^ (bits as u64));
-            let mut idx = TurboQuantIndex::new(dim, bits);
+            let mut idx = TurboQuantIndex::new(dim, bits).unwrap();
             idx.add(&data);
 
             let q = &data[..4 * dim];
@@ -175,7 +175,7 @@ fn search_is_deterministic_for_same_query() {
     let bits = 4;
     for &n in &[64usize, 65, 127, 128, 129, 500] {
         let data = gaussian_normalized(n, dim, 0xD0D0_D0D0 ^ n as u64);
-        let mut idx = TurboQuantIndex::new(dim, bits);
+        let mut idx = TurboQuantIndex::new(dim, bits).unwrap();
         idx.add(&data);
 
         let q = &data[..3 * dim];
@@ -203,7 +203,7 @@ fn single_query_matches_batched_query() {
     let bits = 4;
     let n = 500;
     let data = gaussian_normalized(n, dim, 0x1234_5678);
-    let mut idx = TurboQuantIndex::new(dim, bits);
+    let mut idx = TurboQuantIndex::new(dim, bits).unwrap();
     idx.add(&data);
 
     let batch = &data[..5 * dim];
@@ -247,7 +247,7 @@ fn concurrent_search_matches_serial() {
     let bits = 4;
     let n = 500;
     let data = gaussian_normalized(n, dim, 0xFACE_CAFE);
-    let mut idx = TurboQuantIndex::new(dim, bits);
+    let mut idx = TurboQuantIndex::new(dim, bits).unwrap();
     idx.add(&data);
     let idx = Arc::new(idx);
 

--- a/turbovec/tests/lazy_init.rs
+++ b/turbovec/tests/lazy_init.rs
@@ -63,7 +63,7 @@ fn unit_vectors(n: usize, dim: usize, seed: u64) -> Vec<f32> {
 
 #[test]
 fn new_lazy_starts_with_no_dim() {
-    let idx = TurboQuantIndex::new_lazy(4);
+    let idx = TurboQuantIndex::new_lazy(4).unwrap();
     assert_eq!(idx.dim_opt(), None);
     assert_eq!(idx.dim(), 0, "dim() returns 0 as sentinel");
     assert_eq!(idx.len(), 0);
@@ -72,7 +72,7 @@ fn new_lazy_starts_with_no_dim() {
 
 #[test]
 fn add_2d_locks_dim_on_first_call() {
-    let mut idx = TurboQuantIndex::new_lazy(4);
+    let mut idx = TurboQuantIndex::new_lazy(4).unwrap();
     let data = unit_vectors(3, DIM, 0xA00D_0001);
     idx.add_2d(&data, DIM).unwrap();
     assert_eq!(idx.dim_opt(), Some(DIM));
@@ -81,7 +81,7 @@ fn add_2d_locks_dim_on_first_call() {
 
 #[test]
 fn add_2d_subsequent_calls_must_match_dim() {
-    let mut idx = TurboQuantIndex::new_lazy(4);
+    let mut idx = TurboQuantIndex::new_lazy(4).unwrap();
     let data1 = unit_vectors(2, DIM, 0xA00D_0002);
     idx.add_2d(&data1, DIM).unwrap();
     let data2 = unit_vectors(2, DIM, 0xA00D_0003);
@@ -91,11 +91,11 @@ fn add_2d_subsequent_calls_must_match_dim() {
 
 #[test]
 fn add_2d_rejects_dim_change() {
-    let mut idx = TurboQuantIndex::new_lazy(4);
+    let mut idx = TurboQuantIndex::new_lazy(4).unwrap();
     let data = unit_vectors(1, DIM, 0xA00D_0004);
     idx.add_2d(&data, DIM).unwrap();
     let wrong = unit_vectors(1, DIM * 2, 0xA00D_0005);
-    let err = idx.add_2d(&wrong, DIM * 2).unwrap_err();
+    let err = idx.add_2d(&wrong, DIM * 2).err().unwrap();
     assert_eq!(
         err,
         turbovec::AddError::DimMismatch {
@@ -108,14 +108,14 @@ fn add_2d_rejects_dim_change() {
 #[test]
 #[should_panic(expected = "dim is not set")]
 fn plain_add_panics_on_lazy_uncommitted() {
-    let mut idx = TurboQuantIndex::new_lazy(4);
+    let mut idx = TurboQuantIndex::new_lazy(4).unwrap();
     let data = unit_vectors(1, DIM, 0xA00D_0006);
     idx.add(&data);
 }
 
 #[test]
 fn search_on_lazy_uncommitted_returns_empty() {
-    let idx = TurboQuantIndex::new_lazy(4);
+    let idx = TurboQuantIndex::new_lazy(4).unwrap();
     let queries = unit_vectors(2, DIM, 0xA00D_0007);
     let res = idx.search(&queries, 5);
     assert_eq!(res.scores.len(), 0);
@@ -125,7 +125,7 @@ fn search_on_lazy_uncommitted_returns_empty() {
 
 #[test]
 fn prepare_on_lazy_uncommitted_is_noop() {
-    let idx = TurboQuantIndex::new_lazy(4);
+    let idx = TurboQuantIndex::new_lazy(4).unwrap();
     idx.prepare(); // should not panic
 }
 
@@ -133,7 +133,7 @@ fn prepare_on_lazy_uncommitted_is_noop() {
 fn write_load_round_trip_lazy_uncommitted() {
     let tmp = std::env::temp_dir().join("turbovec_lazy_uncommitted.tv");
     {
-        let idx = TurboQuantIndex::new_lazy(4);
+        let idx = TurboQuantIndex::new_lazy(4).unwrap();
         idx.write(&tmp).unwrap();
     }
     let loaded = TurboQuantIndex::load(&tmp).unwrap();
@@ -148,7 +148,7 @@ fn write_load_round_trip_eager_index_still_works() {
     // Regression: the dim=0 sentinel logic must not affect normal indexes.
     let tmp = std::env::temp_dir().join("turbovec_lazy_eager.tv");
     {
-        let mut idx = TurboQuantIndex::new(DIM, 4);
+        let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
         idx.add(&unit_vectors(4, DIM, 0xA00D_0008));
         idx.write(&tmp).unwrap();
     }
@@ -162,7 +162,7 @@ fn write_load_round_trip_eager_index_still_works() {
 fn write_load_round_trip_lazy_after_committed_add() {
     let tmp = std::env::temp_dir().join("turbovec_lazy_committed.tv");
     {
-        let mut idx = TurboQuantIndex::new_lazy(2);
+        let mut idx = TurboQuantIndex::new_lazy(2).unwrap();
         idx.add_2d(&unit_vectors(3, DIM, 0xA00D_0009), DIM).unwrap();
         idx.write(&tmp).unwrap();
     }
@@ -177,7 +177,7 @@ fn write_load_round_trip_lazy_after_committed_add() {
 
 #[test]
 fn id_map_new_lazy_starts_with_no_dim() {
-    let idx = IdMapIndex::new_lazy(4);
+    let idx = IdMapIndex::new_lazy(4).unwrap();
     assert_eq!(idx.dim_opt(), None);
     assert_eq!(idx.dim(), 0);
     assert_eq!(idx.len(), 0);
@@ -185,7 +185,7 @@ fn id_map_new_lazy_starts_with_no_dim() {
 
 #[test]
 fn id_map_add_with_ids_2d_locks_dim() {
-    let mut idx = IdMapIndex::new_lazy(4);
+    let mut idx = IdMapIndex::new_lazy(4).unwrap();
     let data = unit_vectors(3, DIM, 0xA00D_0010);
     let ids: Vec<u64> = vec![10, 20, 30];
     idx.add_with_ids_2d(&data, DIM, &ids).unwrap();
@@ -197,14 +197,14 @@ fn id_map_add_with_ids_2d_locks_dim() {
 #[test]
 #[should_panic(expected = "dim is not set")]
 fn id_map_plain_add_with_ids_panics_on_lazy_uncommitted() {
-    let mut idx = IdMapIndex::new_lazy(4);
+    let mut idx = IdMapIndex::new_lazy(4).unwrap();
     let data = unit_vectors(1, DIM, 0xA00D_0011);
     idx.add_with_ids(&data, &[42]).unwrap();
 }
 
 #[test]
 fn id_map_search_on_lazy_uncommitted_returns_empty() {
-    let idx = IdMapIndex::new_lazy(4);
+    let idx = IdMapIndex::new_lazy(4).unwrap();
     let queries = unit_vectors(1, DIM, 0xA00D_0012);
     let (scores, ids) = idx.search(&queries, 5);
     assert!(scores.is_empty());
@@ -215,7 +215,7 @@ fn id_map_search_on_lazy_uncommitted_returns_empty() {
 fn id_map_write_load_round_trip_lazy_uncommitted() {
     let tmp = std::env::temp_dir().join("turbovec_idmap_lazy_uncommitted.tvim");
     {
-        let idx = IdMapIndex::new_lazy(2);
+        let idx = IdMapIndex::new_lazy(2).unwrap();
         idx.write(&tmp).unwrap();
     }
     let loaded = IdMapIndex::load(&tmp).unwrap();
@@ -230,7 +230,7 @@ fn id_map_write_load_round_trip_lazy_after_committed_add() {
     let tmp = std::env::temp_dir().join("turbovec_idmap_lazy_committed.tvim");
     let ids: Vec<u64> = vec![100, 200, 300];
     {
-        let mut idx = IdMapIndex::new_lazy(4);
+        let mut idx = IdMapIndex::new_lazy(4).unwrap();
         idx.add_with_ids_2d(&unit_vectors(3, DIM, 0xA00D_0013), DIM, &ids).unwrap();
         idx.write(&tmp).unwrap();
     }
@@ -241,4 +241,42 @@ fn id_map_write_load_round_trip_lazy_after_committed_add() {
         assert!(loaded.contains(id));
     }
     fs::remove_file(&tmp).ok();
+}
+
+// ---- Constructor input validation ----
+
+#[test]
+fn new_rejects_bad_bit_width() {
+    for bw in [0usize, 1, 5, 8, 100] {
+        let err = TurboQuantIndex::new(DIM, bw).err().unwrap();
+        assert_eq!(err, turbovec::ConstructError::BitWidthOutOfRange(bw));
+    }
+}
+
+#[test]
+fn new_rejects_bad_dim() {
+    for dim in [0usize, 1, 4, 7, 9, 15] {
+        let err = TurboQuantIndex::new(dim, 4).err().unwrap();
+        assert_eq!(err, turbovec::ConstructError::DimNotPositiveMultipleOf8(dim));
+    }
+}
+
+#[test]
+fn new_lazy_rejects_bad_bit_width() {
+    for bw in [0usize, 1, 5, 8] {
+        let err = TurboQuantIndex::new_lazy(bw).err().unwrap();
+        assert_eq!(err, turbovec::ConstructError::BitWidthOutOfRange(bw));
+    }
+}
+
+#[test]
+fn id_map_new_rejects_bad_bit_width() {
+    let err = IdMapIndex::new(DIM, 5).err().unwrap();
+    assert_eq!(err, turbovec::ConstructError::BitWidthOutOfRange(5));
+}
+
+#[test]
+fn id_map_new_rejects_bad_dim() {
+    let err = IdMapIndex::new(0, 4).err().unwrap();
+    assert_eq!(err, turbovec::ConstructError::DimNotPositiveMultipleOf8(0));
 }

--- a/turbovec/tests/swap_remove.rs
+++ b/turbovec/tests/swap_remove.rs
@@ -57,7 +57,7 @@ fn gaussian_normalized(n: usize, dim: usize, seed: u64) -> Vec<f32> {
 fn swap_remove_shrinks_length_and_returns_last_index() {
     let dim = 256;
     let data = gaussian_normalized(10, dim, 0xDE1E_7E00);
-    let mut idx = TurboQuantIndex::new(dim, 4);
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
     idx.add(&data);
     assert_eq!(idx.len(), 10);
 
@@ -70,7 +70,7 @@ fn swap_remove_shrinks_length_and_returns_last_index() {
 fn swap_remove_last_is_no_swap() {
     let dim = 256;
     let data = gaussian_normalized(5, dim, 0xDE1E_7E01);
-    let mut idx = TurboQuantIndex::new(dim, 4);
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
     idx.add(&data);
 
     // Removing the last element: moved_from == idx, no actual swap.
@@ -88,7 +88,7 @@ fn search_after_swap_remove_reflects_new_layout() {
     let n = 100;
     let data = gaussian_normalized(n, dim, 0xDE1E_7E02);
 
-    let mut idx = TurboQuantIndex::new(dim, 4);
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
     idx.add(&data);
 
     // Prime the cache with a self-query.
@@ -119,7 +119,7 @@ fn deleted_vector_no_longer_returned() {
     let n = 64;
     let data = gaussian_normalized(n, dim, 0xDE1E_7E03);
 
-    let mut idx = TurboQuantIndex::new(dim, 4);
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
     idx.add(&data);
 
     // Remove vector 7. Query with it: top-1 must NOT be 7 (that slot
@@ -144,7 +144,7 @@ fn remaining_vectors_still_self_query_correctly() {
     let n = 80;
     let data = gaussian_normalized(n, dim, 0xDE1E_7E04);
 
-    let mut idx = TurboQuantIndex::new(dim, 4);
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
     idx.add(&data);
 
     // Delete a handful of non-adjacent positions.
@@ -178,7 +178,7 @@ fn remaining_vectors_still_self_query_correctly() {
 fn swap_remove_out_of_bounds_panics() {
     let dim = 128;
     let data = gaussian_normalized(3, dim, 0xDE1E_7E05);
-    let mut idx = TurboQuantIndex::new(dim, 4);
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
     idx.add(&data);
     idx.swap_remove(3); // valid range is 0..3
 }


### PR DESCRIPTION
## Related issues

Closes #50, #51, #52

## Summary

- Adds `ConstructError` enum to `turbovec::error` (alongside `AddError`) with `BitWidthOutOfRange` and `DimNotPositiveMultipleOf8` variants
- `TurboQuantIndex::new`, `TurboQuantIndex::new_lazy`, `IdMapIndex::new`, `IdMapIndex::new_lazy` now return `Result<Self, ConstructError>` instead of panicking on bad input
- pyo3 binding's `__new__` maps `ConstructError` → `PyValueError`, so Python users get a catchable `ValueError` instead of an uncatchable `PanicException`
- Closes the **`dim=0` hole** (#50): the previous assert `dim % 8 == 0` passed vacuously for zero, silently producing an index that would divide-by-zero on the first `add`. The new check is `dim != 0 && dim % 8 == 0`.
- Adds Python tests for the eager-empty search case (#51) — pure test addition, behaviour was already correct.

## Motivation

Mirrors the architectural change in PR #43, which converted the add path's user-input panics to `AddError` / `PyValueError`. The constructor was explicitly out of scope at the time. Three subsequent contributor-submitted issues (#50, #51, #52) and a stream of broken PRs all surfaced the same gap — the constructor's panic-based input validation:

- `PanicException` subclasses `BaseException`, not `Exception`, so `try: ... except Exception:` doesn't catch it
- A Rust backtrace crossing the FFI is bad UX for a user error
- The `dim=0` case slipped through entirely, producing a silently-broken index

After this PR the construct-path matches the add-path's error surface.

## Migration impact

**Breaking** for direct Rust callers of `TurboQuantIndex::new` / `IdMapIndex::new` / `_lazy`. Append `?` or `.unwrap()` to existing calls. Match on `ConstructError` for recovery. Bump to `0.6.0` at release time.

**No change** for Python callers using valid inputs. Invalid inputs now raise `ValueError` instead of `PanicException` — that's strictly more recoverable, but technically a behaviour change if anyone was catching the panic class specifically.

## Test plan

- [x] `cargo test -p turbovec --release` — 91 tests, all pass (was 86; +5 new constructor validation tests)
- [x] `pytest turbovec-python/tests/` — 247 tests pass (was 227; +20 new parametrized constructor tests + eager-empty search tests for #51)
- [x] All existing tests updated via mechanical `.unwrap()` insertion at callsites
- [ ] CI run — recommend triggering before merge; we have install+import smoke tests on Linux jobs from PR #61 that exercise the BLAS path

🤖 Generated with [Claude Code](https://claude.com/claude-code)