### PR TITLE
Release: turbovec 0.5.3 (Python) + 0.6.0 (Rust crate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,80 @@ appears under each surface it touches.
 
 ## [Unreleased]
 
+## turbovec 0.5.3 (Python package) + turbovec 0.6.0 (Rust crate) — 2026-05-25
+
+### turbovec — Rust crate (current: 0.5.0 → next: 0.6.0)
+
+#### Changed
+
+- **BREAKING:** `TurboQuantIndex::new`, `TurboQuantIndex::new_lazy`,
+  `IdMapIndex::new`, and `IdMapIndex::new_lazy` now return
+  `Result<Self, ConstructError>` instead of panicking on invalid
+  input. The new `turbovec::ConstructError` enum covers `bit_width`
+  out of `{2, 3, 4}` and `dim` not a positive multiple of 8 (which
+  also closes a latent hole where `dim = 0` was silently accepted —
+  the previous `dim % 8 == 0` assertion vacuously passed for zero,
+  then divided-by-zero on the first `add`).
+
+  Migration: append `?` (or `.unwrap()` in tests/binaries) to
+  existing constructor calls. Mirrors the [`AddError`](src/error.rs)
+  pattern from the previous release.
+
+- **Encode is 2–3× faster on aarch64.** SIMD-ifies the quantize +
+  scale + bit-pack inner loop via NEON (compare against boundaries
+  in 8 lanes at a time, weighted horizontal-add for the bit-pack)
+  and fuses the three passes so there's no intermediate
+  `codes: Vec<u8>` allocation. Rayon parallelises across rows on
+  both aarch64 and x86_64; x86_64 keeps the existing scalar inner
+  loop. Recall is bit-identical to the previous release at every
+  published cell (verified against `benchmarks/suite/recall_*.py`
+  on M3 Max). Measured throughput on M2 Pro, single-threaded:
+  - d=768, 4-bit: 22.5K → 66.3K vec/sec (2.9×)
+  - d=1536, 4-bit: 9.5K → 21.9K vec/sec (2.3×)
+  - d=1536, 2-bit: 16.6K → 25.7K vec/sec (1.5×)
+
+- **Codebook is now cached across incremental `add` calls.** The
+  Lloyd-Max boundaries and centroids are a deterministic function
+  of `(bit_width, dim)`, so recomputing them on every `add` was
+  wasted work. They're now stored in `OnceLock` cells (the same
+  pattern already used for the rotation matrix) and reused across
+  calls. No behaviour change; faster incremental indexing.
+
+### turbovec — Python package (current: 0.5.2 → next: 0.5.3)
+
+#### Fixed
+
+- **Linux wheels now actually import.** Every Linux wheel since
+  Linux build support was added had a missing `DT_NEEDED` entry for
+  `libopenblas`, so `import turbovec` failed at the dynamic linker
+  step with `undefined symbol: cblas_sgemm` — even on systems that
+  had OpenBLAS installed. The wheel now declares the dependency
+  explicitly, and `auditwheel` bundles a self-contained copy of
+  `libopenblas` (plus its `libgfortran` / `libquadmath` runtime
+  deps) into `turbovec.libs/`. Linux wheel size grows from ~1.8 MB
+  to ~11 MB (aarch64) / ~42 MB (x86_64) as a consequence — the
+  bundled OpenBLAS contains kernel variants for many micro-archs
+  and dispatches at runtime. The Linux release CI now also runs
+  `pytest` against the freshly-built wheel on native runners so
+  this class of bug can't ship silently again.
+
+#### Changed
+
+- **`TurboQuantIndex` and `IdMapIndex` constructors raise
+  `ValueError` on bad input** (`bit_width` outside `{2, 3, 4}`,
+  `dim` not a positive multiple of 8, including the previously
+  silently-accepted `dim = 0` case). Previously these surfaced as
+  `pyo3_runtime.PanicException`, which subclasses `BaseException`
+  and so wasn't caught by `except Exception:` — user code can now
+  recover from a configuration error as a normal usage error.
+
+- **Encode (build-time, not query-time) is faster on aarch64.**
+  Same kernel-level change as the Rust crate; Python users see no
+  API change and bit-identical recall at every published cell.
+  Building an index with `TurboQuantIndex.add()` is ~2–3× faster on
+  M-series macOS and Linux aarch64. x86_64 sees the Rayon
+  parallelism but not the SIMD kernel.
+
 ## turbovec 0.5.2 (Python package) + turbovec 0.5.0 (Rust crate) — 2026-05-21
 
 ### turbovec — Rust crate (current: 0.4.1 → next: 0.5.0)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "turbovec"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "blas-src",
  "faer",
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "turbovec-python"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "numpy",
  "pyo3",

--- a/turbovec-python/Cargo.toml
+++ b/turbovec-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbovec-python"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 rust-version = "1.70"
 

--- a/turbovec-python/pyproject.toml
+++ b/turbovec-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "turbovec"
-version = "0.5.2"
+version = "0.5.3"
 description = "Fast vector quantization with 2-4 bit compression and SIMD search"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/turbovec/Cargo.toml
+++ b/turbovec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbovec"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.70"
 description = "Fast vector quantization with 2-4 bit compression and SIMD search"


### PR DESCRIPTION
## Summary

Cuts the next release pairing turbovec 0.5.3 (Python) + turbovec 0.6.0 (Rust crate).

**Rust crate goes to 0.6.0** because PR #64 was a breaking signature change on the constructors (now return `Result<Self, ConstructError>`).

**Python package stays in the 0.5.x line (0.5.3)** because the Python user-facing API is unchanged — the same `TurboQuantIndex(dim=128, bit_width=4)` calls still work; the only behavioural change is that invalid input now raises `ValueError` instead of `PanicException`, which is strictly more recoverable.

## What's in the release

- **Fix:** Linux wheel `ImportError: undefined symbol: cblas_sgemm` (#60 / #61). Every Linux user was hitting this; the published wheel had a missing `DT_NEEDED` entry for libopenblas. The fix bundles libopenblas (+libgfortran +libquadmath on x86) into `turbovec.libs/` and the Linux release CI now installs + smoke-tests the built wheel on native runners so this can't ship silently again.
- **Perf:** encode is 2-3× faster on aarch64 via NEON SIMD + Rayon + fused quantize/scale/pack (#32 / #57). x86_64 gets Rayon parallelism but keeps the scalar inner loop. Recall verified bit-identical to previous release at every published cell.
- **Perf:** codebook (Lloyd-Max boundaries + centroids) is now cached across incremental `add` calls instead of recomputed each time (#62 / #63).
- **API:** constructor input validation returns `Result`/`ValueError` instead of panicking (#50 / #51 / #52 / #64). Closes the latent `dim = 0` hole. **Breaking for Rust crate users** — see CHANGELOG migration note.

Plus docs-only PRs #46 and #59 (CONTRIBUTING.md + CODEOWNERS workflow) that don't get CHANGELOG entries.

## Test plan

- [x] `cargo test -p turbovec --release` — 91 tests pass
- [x] `pytest turbovec-python/tests/` — 248 tests pass (with all integration extras)
- [x] Recall sweep on native ARM (M-series) at every README-published cell — bit-identical to main's published baseline (verified prior to the release commit)
- [ ] CI on this release branch — runs on merge / tag push
- [ ] After merge: push tags `v0.6.0` and `py-v0.5.3` to trigger publish workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)