### PR TITLE
Regenerate benchmark diagrams from TQ+ JSON updates

### DIFF
--- a/docs/arm_speed_mt.svg
+++ b/docs/arm_speed_mt.svg
@@ -29,28 +29,28 @@
 <text x="74" y="86.0" text-anchor="end" class="tick">1.00</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Multi-threaded</text>
-<rect x="135.0" y="323.1" width="44" height="28.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="185.0" y="316.9" width="44" height="35.1" rx="6" fill="#9aa7b6" />
-<text x="157.0" y="317.1" text-anchor="middle" class="value-accent">0.107</text>
-<text x="207.0" y="310.9" text-anchor="middle" class="value">0.130</text>
+<rect x="135.0" y="322.6" width="44" height="29.4" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="185.0" y="319.1" width="44" height="32.9" rx="6" fill="#9aa7b6" />
+<text x="157.0" y="316.6" text-anchor="middle" class="value-accent">0.109</text>
+<text x="207.0" y="313.1" text-anchor="middle" class="value">0.122</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="331.0" y="299.9" width="44" height="52.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="381.0" y="286.7" width="44" height="65.3" rx="6" fill="#9aa7b6" />
-<text x="353.0" y="293.9" text-anchor="middle" class="value-accent">0.193</text>
-<text x="403.0" y="280.7" text-anchor="middle" class="value">0.242</text>
+<rect x="331.0" y="298.5" width="44" height="53.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="381.0" y="287.2" width="44" height="64.8" rx="6" fill="#9aa7b6" />
+<text x="353.0" y="292.5" text-anchor="middle" class="value-accent">0.198</text>
+<text x="403.0" y="281.2" text-anchor="middle" class="value">0.240</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="527.0" y="296.4" width="44" height="55.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="577.0" y="288.8" width="44" height="63.2" rx="6" fill="#9aa7b6" />
-<text x="549.0" y="290.4" text-anchor="middle" class="value-accent">0.206</text>
-<text x="599.0" y="282.8" text-anchor="middle" class="value">0.234</text>
+<rect x="527.0" y="295.6" width="44" height="56.4" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="577.0" y="289.6" width="44" height="62.4" rx="6" fill="#9aa7b6" />
+<text x="549.0" y="289.6" text-anchor="middle" class="value-accent">0.209</text>
+<text x="599.0" y="283.6" text-anchor="middle" class="value">0.231</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="723.0" y="250.8" width="44" height="101.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="773.0" y="227.8" width="44" height="124.2" rx="6" fill="#9aa7b6" />
-<text x="745.0" y="244.8" text-anchor="middle" class="value-accent">0.375</text>
-<text x="795.0" y="221.8" text-anchor="middle" class="value">0.460</text>
+<rect x="723.0" y="244.5" width="44" height="107.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="773.0" y="222.7" width="44" height="129.3" rx="6" fill="#9aa7b6" />
+<text x="745.0" y="238.5" text-anchor="middle" class="value-accent">0.398</text>
+<text x="795.0" y="216.7" text-anchor="middle" class="value">0.479</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">ms / query</text>

--- a/docs/arm_speed_st.svg
+++ b/docs/arm_speed_st.svg
@@ -29,28 +29,28 @@
 <text x="74" y="86.0" text-anchor="end" class="tick">10.0</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Single-threaded</text>
-<rect x="135.0" y="323.2" width="44" height="28.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="185.0" y="318.4" width="44" height="33.6" rx="6" fill="#9aa7b6" />
-<text x="157.0" y="317.2" text-anchor="middle" class="value-accent">1.07</text>
-<text x="207.0" y="312.4" text-anchor="middle" class="value">1.25</text>
+<rect x="135.0" y="322.2" width="44" height="29.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="185.0" y="318.1" width="44" height="33.9" rx="6" fill="#9aa7b6" />
+<text x="157.0" y="316.2" text-anchor="middle" class="value-accent">1.10</text>
+<text x="207.0" y="312.1" text-anchor="middle" class="value">1.26</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="331.0" y="298.0" width="44" height="54.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="381.0" y="285.1" width="44" height="66.9" rx="6" fill="#9aa7b6" />
-<text x="353.0" y="292.0" text-anchor="middle" class="value-accent">2.00</text>
-<text x="403.0" y="279.1" text-anchor="middle" class="value">2.48</text>
+<rect x="331.0" y="297.3" width="44" height="54.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="381.0" y="284.7" width="44" height="67.3" rx="6" fill="#9aa7b6" />
+<text x="353.0" y="291.3" text-anchor="middle" class="value-accent">2.03</text>
+<text x="403.0" y="278.7" text-anchor="middle" class="value">2.49</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="527.0" y="294.3" width="44" height="57.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="577.0" y="285.3" width="44" height="66.7" rx="6" fill="#9aa7b6" />
-<text x="549.0" y="288.3" text-anchor="middle" class="value-accent">2.14</text>
-<text x="599.0" y="279.3" text-anchor="middle" class="value">2.47</text>
+<rect x="527.0" y="293.7" width="44" height="58.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="577.0" y="284.9" width="44" height="67.1" rx="6" fill="#9aa7b6" />
+<text x="549.0" y="287.7" text-anchor="middle" class="value-accent">2.16</text>
+<text x="599.0" y="278.9" text-anchor="middle" class="value">2.49</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="723.0" y="244.5" width="44" height="107.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="773.0" y="218.2" width="44" height="133.8" rx="6" fill="#9aa7b6" />
-<text x="745.0" y="238.5" text-anchor="middle" class="value-accent">3.98</text>
-<text x="795.0" y="212.2" text-anchor="middle" class="value">4.96</text>
+<rect x="723.0" y="242.0" width="44" height="110.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="773.0" y="216.7" width="44" height="135.3" rx="6" fill="#9aa7b6" />
+<text x="745.0" y="236.0" text-anchor="middle" class="value-accent">4.07</text>
+<text x="795.0" y="210.7" text-anchor="middle" class="value">5.01</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">ms / query</text>

--- a/docs/recall_d1536.svg
+++ b/docs/recall_d1536.svg
@@ -36,10 +36,10 @@
 <text x="606.7" y="372" text-anchor="middle" class="label">16</text>
 <text x="737.3" y="372" text-anchor="middle" class="label">32</text>
 <text x="868.0" y="372" text-anchor="middle" class="label">64</text>
-<path d="M 84.0,254.5 L 214.7,132.5 L 345.3,92.5 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#635bff" stroke-width="2.25" />
-<circle cx="84.0" cy="254.5" r="3.5" fill="#635bff" />
-<circle cx="214.7" cy="132.5" r="3.5" fill="#635bff" />
-<circle cx="345.3" cy="92.5" r="3.5" fill="#635bff" />
+<path d="M 84.0,280.6 L 214.7,127.3 L 345.3,94.2 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#635bff" stroke-width="2.25" />
+<circle cx="84.0" cy="280.6" r="3.5" fill="#635bff" />
+<circle cx="214.7" cy="127.3" r="3.5" fill="#635bff" />
+<circle cx="345.3" cy="94.2" r="3.5" fill="#635bff" />
 <circle cx="476.0" cy="90.7" r="3.5" fill="#635bff" />
 <circle cx="606.7" cy="90.7" r="3.5" fill="#635bff" />
 <circle cx="737.3" cy="90.7" r="3.5" fill="#635bff" />
@@ -52,9 +52,9 @@
 <circle cx="606.7" cy="90.7" r="3.5" fill="#9aa7b6" />
 <circle cx="737.3" cy="90.7" r="3.5" fill="#9aa7b6" />
 <circle cx="868.0" cy="90.7" r="3.5" fill="#9aa7b6" />
-<path d="M 84.0,143.0 L 214.7,95.9 L 345.3,90.7 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#0f766e" stroke-width="2.25" />
-<circle cx="84.0" cy="143.0" r="3.5" fill="#0f766e" />
-<circle cx="214.7" cy="95.9" r="3.5" fill="#0f766e" />
+<path d="M 84.0,136.0 L 214.7,94.2 L 345.3,90.7 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#0f766e" stroke-width="2.25" />
+<circle cx="84.0" cy="136.0" r="3.5" fill="#0f766e" />
+<circle cx="214.7" cy="94.2" r="3.5" fill="#0f766e" />
 <circle cx="345.3" cy="90.7" r="3.5" fill="#0f766e" />
 <circle cx="476.0" cy="90.7" r="3.5" fill="#0f766e" />
 <circle cx="606.7" cy="90.7" r="3.5" fill="#0f766e" />

--- a/docs/recall_d3072.svg
+++ b/docs/recall_d3072.svg
@@ -36,9 +36,9 @@
 <text x="606.7" y="372" text-anchor="middle" class="label">16</text>
 <text x="737.3" y="372" text-anchor="middle" class="label">32</text>
 <text x="868.0" y="372" text-anchor="middle" class="label">64</text>
-<path d="M 84.0,223.1 L 214.7,104.6 L 345.3,92.5 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#635bff" stroke-width="2.25" />
-<circle cx="84.0" cy="223.1" r="3.5" fill="#635bff" />
-<circle cx="214.7" cy="104.6" r="3.5" fill="#635bff" />
+<path d="M 84.0,214.4 L 214.7,111.6 L 345.3,92.5 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#635bff" stroke-width="2.25" />
+<circle cx="84.0" cy="214.4" r="3.5" fill="#635bff" />
+<circle cx="214.7" cy="111.6" r="3.5" fill="#635bff" />
 <circle cx="345.3" cy="92.5" r="3.5" fill="#635bff" />
 <circle cx="476.0" cy="90.7" r="3.5" fill="#635bff" />
 <circle cx="606.7" cy="90.7" r="3.5" fill="#635bff" />
@@ -52,9 +52,9 @@
 <circle cx="606.7" cy="90.7" r="3.5" fill="#9aa7b6" />
 <circle cx="737.3" cy="90.7" r="3.5" fill="#9aa7b6" />
 <circle cx="868.0" cy="90.7" r="3.5" fill="#9aa7b6" />
-<path d="M 84.0,125.5 L 214.7,90.7 L 345.3,90.7 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#0f766e" stroke-width="2.25" />
-<circle cx="84.0" cy="125.5" r="3.5" fill="#0f766e" />
-<circle cx="214.7" cy="90.7" r="3.5" fill="#0f766e" />
+<path d="M 84.0,136.0 L 214.7,92.5 L 345.3,90.7 L 476.0,90.7 L 606.7,90.7 L 737.3,90.7 L 868.0,90.7" fill="none" stroke="#0f766e" stroke-width="2.25" />
+<circle cx="84.0" cy="136.0" r="3.5" fill="#0f766e" />
+<circle cx="214.7" cy="92.5" r="3.5" fill="#0f766e" />
 <circle cx="345.3" cy="90.7" r="3.5" fill="#0f766e" />
 <circle cx="476.0" cy="90.7" r="3.5" fill="#0f766e" />
 <circle cx="606.7" cy="90.7" r="3.5" fill="#0f766e" />

--- a/docs/recall_glove.svg
+++ b/docs/recall_glove.svg
@@ -36,14 +36,14 @@
 <text x="606.7" y="372" text-anchor="middle" class="label">16</text>
 <text x="737.3" y="372" text-anchor="middle" class="label">32</text>
 <text x="868.0" y="372" text-anchor="middle" class="label">64</text>
-<path d="M 84.0,284.0 L 214.7,214.9 L 345.3,161.3 L 476.0,124.4 L 606.7,101.0 L 737.3,90.8 L 868.0,86.2" fill="none" stroke="#635bff" stroke-width="2.25" />
-<circle cx="84.0" cy="284.0" r="3.5" fill="#635bff" />
-<circle cx="214.7" cy="214.9" r="3.5" fill="#635bff" />
-<circle cx="345.3" cy="161.3" r="3.5" fill="#635bff" />
-<circle cx="476.0" cy="124.4" r="3.5" fill="#635bff" />
-<circle cx="606.7" cy="101.0" r="3.5" fill="#635bff" />
-<circle cx="737.3" cy="90.8" r="3.5" fill="#635bff" />
-<circle cx="868.0" cy="86.2" r="3.5" fill="#635bff" />
+<path d="M 84.0,278.9 L 214.7,208.8 L 345.3,153.7 L 476.0,118.3 L 606.7,98.7 L 737.3,89.1 L 868.0,85.7" fill="none" stroke="#635bff" stroke-width="2.25" />
+<circle cx="84.0" cy="278.9" r="3.5" fill="#635bff" />
+<circle cx="214.7" cy="208.8" r="3.5" fill="#635bff" />
+<circle cx="345.3" cy="153.7" r="3.5" fill="#635bff" />
+<circle cx="476.0" cy="118.3" r="3.5" fill="#635bff" />
+<circle cx="606.7" cy="98.7" r="3.5" fill="#635bff" />
+<circle cx="737.3" cy="89.1" r="3.5" fill="#635bff" />
+<circle cx="868.0" cy="85.7" r="3.5" fill="#635bff" />
 <path d="M 84.0,278.7 L 214.7,209.7 L 345.3,153.6 L 476.0,117.6 L 606.7,97.6 L 737.3,88.3 L 868.0,85.1" fill="none" stroke="#9aa7b6" stroke-width="2.25" stroke-dasharray="6 4" />
 <circle cx="84.0" cy="278.7" r="3.5" fill="#9aa7b6" />
 <circle cx="214.7" cy="209.7" r="3.5" fill="#9aa7b6" />
@@ -52,11 +52,11 @@
 <circle cx="606.7" cy="97.6" r="3.5" fill="#9aa7b6" />
 <circle cx="737.3" cy="88.3" r="3.5" fill="#9aa7b6" />
 <circle cx="868.0" cy="85.1" r="3.5" fill="#9aa7b6" />
-<path d="M 84.0,153.9 L 214.7,104.0 L 345.3,87.3 L 476.0,84.4 L 606.7,84.2 L 737.3,84.2 L 868.0,84.2" fill="none" stroke="#0f766e" stroke-width="2.25" />
-<circle cx="84.0" cy="153.9" r="3.5" fill="#0f766e" />
-<circle cx="214.7" cy="104.0" r="3.5" fill="#0f766e" />
-<circle cx="345.3" cy="87.3" r="3.5" fill="#0f766e" />
-<circle cx="476.0" cy="84.4" r="3.5" fill="#0f766e" />
+<path d="M 84.0,151.3 L 214.7,102.8 L 345.3,87.1 L 476.0,84.3 L 606.7,84.2 L 737.3,84.2 L 868.0,84.2" fill="none" stroke="#0f766e" stroke-width="2.25" />
+<circle cx="84.0" cy="151.3" r="3.5" fill="#0f766e" />
+<circle cx="214.7" cy="102.8" r="3.5" fill="#0f766e" />
+<circle cx="345.3" cy="87.1" r="3.5" fill="#0f766e" />
+<circle cx="476.0" cy="84.3" r="3.5" fill="#0f766e" />
 <circle cx="606.7" cy="84.2" r="3.5" fill="#0f766e" />
 <circle cx="737.3" cy="84.2" r="3.5" fill="#0f766e" />
 <circle cx="868.0" cy="84.2" r="3.5" fill="#0f766e" />


### PR DESCRIPTION
## Summary

- Regenerates the SVGs in `docs/` after #71 (TQ+) updated the benchmark JSONs.
- 5 of 8 diagrams change: `arm_speed_st.svg`, `arm_speed_mt.svg`, `recall_glove.svg`, `recall_d1536.svg`, `recall_d3072.svg`.
- `x86_speed_{st,mt}.svg` and `compression.svg` are unchanged — x86 speed JSONs haven't been re-run on the GCP bench instance yet, and compression is unaffected by TQ+.

## Test plan

- [x] `python3 benchmarks/create_diagrams.py` ran clean
- [x] Diff matches only the 5 SVGs whose source JSON changed
- [ ] Eyeball the rendered SVGs in `docs/` to confirm the new TQ+ numbers come through correctly (recall bars taller on GloVe, ARM speed bars slightly taller — both small)

Follow-up to #71.