### PR TITLE
README: describe TQ+ alongside the existing How-it-works steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 
 **A 10 million document corpus takes 31 GB of RAM as float32. turbovec fits it in 4 GB - and searches it faster than FAISS.**
 
-turbovec is a Rust vector index with Python bindings, built on Google Research's [**TurboQuant**](https://arxiv.org/abs/2504.19874) algorithm - a data-oblivious quantizer that matches the Shannon lower bound on distortion with zero training and zero data passes.
+turbovec is a Rust vector index with Python bindings, built on Google Research's [**TurboQuant**](https://arxiv.org/abs/2504.19874) algorithm — a data-oblivious quantizer that matches the Shannon lower bound on distortion, with no codebook training and no separate train phase.
 
-- **No codebook training.** Add vectors, they're indexed. No data-dependent calibration, no rebuilds as the corpus grows.
+- **Online ingest.** Add vectors, they're indexed — no train step, no parameter tuning, no rebuilds as the corpus grows.
 - **Faster than FAISS.** Hand-written NEON (ARM) and AVX-512BW (x86) kernels beat FAISS IndexPQFastScan by 12–20% on ARM and match-or-beat it on x86.
 - **Filter at search time.** Pass an id allowlist (or a slot bitmask) to `search()` and the kernel honours it directly. You always get up to `k` results from the allowed set — no over-fetching, no recall hit on selective filters.
 - **Pure local.** No managed service, no data leaving your machine or VPC. Pair with any open-source embedding model for a fully air-gapped RAG stack.
@@ -168,11 +168,13 @@ Each vector is a direction on a high-dimensional hypersphere. TurboQuant compres
 
 **2. Random rotation.** Multiply all vectors by the same random orthogonal matrix. After rotation, each coordinate independently follows a Beta distribution that converges to Gaussian N(0, 1/d) in high dimensions. This holds for any input data -- the rotation makes the coordinate distribution predictable.
 
-**3. Lloyd-Max scalar quantization.** Since the distribution is known, we can precompute the optimal way to bucket each coordinate. For 2-bit, that's 4 buckets; for 4-bit, 16 buckets. The [Lloyd-Max algorithm](https://en.wikipedia.org/wiki/Lloyd%27s_algorithm) finds bucket boundaries and centroids that minimize mean squared error. These are computed once from the math, not from the data.
+**3. Per-coordinate calibration (TQ+).** The Beta distribution from step 2 is asymptotic — at finite dimensions, individual coordinates drift from the canonical shape (especially low-bit and word-vector-style embeddings). TQ+ fits two scalars per coordinate — a shift and a scale — during the first add, mapping each coordinate's empirical 5/95% quantiles onto the canonical Beta marginal. The Lloyd-Max codebook then quantizes against the *target* distribution it was designed for. The calibration is frozen after the first add and reused by subsequent adds — no retraining, no rebuilds, no separate train phase. Recall gain: up to +1.4pp at @1 on the cells that drift most (e.g. GloVe at 2-bit).
 
-**4. Bit-pack.** Each coordinate is now a small integer (0-3 for 2-bit, 0-15 for 4-bit). Pack these tightly into bytes. A 1536-dim vector goes from 6,144 bytes (FP32) to 384 bytes (2-bit). That's 16x compression.
+**4. Lloyd-Max scalar quantization.** Since the distribution is known, we can precompute the optimal way to bucket each coordinate. For 2-bit, that's 4 buckets; for 4-bit, 16 buckets. The [Lloyd-Max algorithm](https://en.wikipedia.org/wiki/Lloyd%27s_algorithm) finds bucket boundaries and centroids that minimize mean squared error. These are computed once from the math, not from the data.
 
-**5. Length-renormalized scoring.** Scalar quantization systematically underestimates inner products — the reconstructed unit direction is a little shorter than the original. We compute one scalar per vector at encode time — the inner product of the rotated unit vector with its own centroid reconstruction — and store `||v|| / ⟨u, x̂⟩` alongside each compressed vector. The search kernel multiplies the per-candidate score by this scalar before heap insertion, turning the inner-product estimator from downward-biased into unbiased at zero search-time cost and zero extra storage. The recall gain shows up most at low bit widths, where the quantization shrinkage is largest.
+**5. Bit-pack.** Each coordinate is now a small integer (0-3 for 2-bit, 0-15 for 4-bit). Pack these tightly into bytes. A 1536-dim vector goes from 6,144 bytes (FP32) to 384 bytes (2-bit). That's 16x compression.
+
+**6. Length-renormalized scoring.** Scalar quantization systematically underestimates inner products — the reconstructed unit direction is a little shorter than the original. We compute one scalar per vector at encode time — the inner product of the rotated unit vector with its own centroid reconstruction — and store `||v|| / ⟨u, x̂⟩` alongside each compressed vector. The search kernel multiplies the per-candidate score by this scalar before heap insertion, turning the inner-product estimator from downward-biased into unbiased at zero search-time cost and zero extra storage. The recall gain shows up most at low bit widths, where the quantization shrinkage is largest.
 
 Encoding cost: one extra `d`-dimensional dot product per vector to compute `⟨u, x̂⟩`. On 1M vectors at d=1536 this is sub-second of additional encode time — a one-shot price paid at ingest, not at query.
 


### PR DESCRIPTION
## Summary

PR #71 added TQ+ per-coordinate calibration but left the README unchanged. Three updates so the README accurately describes what the codec does without diluting the existing positive framing.

## Changes

**1. Top blurb (line 16).** The "zero data passes" sub-claim is no longer strictly true under TQ+ (one quantile pass during the first add). Reworded to attribute data-obliviousness specifically to the core TurboQuant algorithm — which IS still data-oblivious — and drop the sub-claim:

> Before: "a data-oblivious quantizer that matches the Shannon lower bound on distortion **with zero training and zero data passes**."
> After:  "a data-oblivious quantizer that matches the Shannon lower bound on distortion, **with no codebook training and no separate train phase**."

**2. Feature bullet (line 18).** Same user-facing guarantee, more accurate wording. The codebook is still untrained; TQ+ is internal calibration the user never sees.

> Before: "**No codebook training.** Add vectors, they're indexed. No data-dependent calibration, no rebuilds as the corpus grows."
> After:  "**Online ingest.** Add vectors, they're indexed — no train step, no parameter tuning, no rebuilds as the corpus grows."

**3. New "How it works" step #3 (between rotation and Lloyd-Max).** Quantifies what TQ+ does and the recall it buys, frames as a finite-dim correction to the asymptotic Beta marginal assumption of step 2. Existing steps 3-5 renumber to 4-6.

## What does NOT change

- Online ingest workflow (add vectors, search, no rebuild — same as before)
- "No codebook training" claim (codebook is still deterministic from `(dim, bit_width)`)
- "No rebuilds as the corpus grows" (TQ+ is frozen after the first add, reused by subsequent adds)
- Performance / recall numbers (already updated in #71)

## Test plan

- [x] `git diff main` is README-only, +7/-5 lines
- [ ] Render check on GitHub once pushed