### PR TITLE
Regenerate speed diagrams from post-kernel-fix JSONs

### DIFF
--- a/docs/arm_speed_mt.svg
+++ b/docs/arm_speed_mt.svg
@@ -29,28 +29,28 @@
 <text x="74" y="86.0" text-anchor="end" class="tick">1.00</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Multi-threaded</text>
-<rect x="135.0" y="322.6" width="44" height="29.4" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="185.0" y="319.1" width="44" height="32.9" rx="6" fill="#9aa7b6" />
-<text x="157.0" y="316.6" text-anchor="middle" class="value-accent">0.109</text>
-<text x="207.0" y="313.1" text-anchor="middle" class="value">0.122</text>
+<rect x="135.0" y="324.2" width="44" height="27.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="185.0" y="320.9" width="44" height="31.1" rx="6" fill="#9aa7b6" />
+<text x="157.0" y="318.2" text-anchor="middle" class="value-accent">0.103</text>
+<text x="207.0" y="314.9" text-anchor="middle" class="value">0.115</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="331.0" y="298.5" width="44" height="53.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="381.0" y="287.2" width="44" height="64.8" rx="6" fill="#9aa7b6" />
-<text x="353.0" y="292.5" text-anchor="middle" class="value-accent">0.198</text>
-<text x="403.0" y="281.2" text-anchor="middle" class="value">0.240</text>
+<rect x="331.0" y="302.1" width="44" height="50.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="381.0" y="292.6" width="44" height="59.4" rx="6" fill="#9aa7b6" />
+<text x="353.0" y="296.1" text-anchor="middle" class="value-accent">0.185</text>
+<text x="403.0" y="286.6" text-anchor="middle" class="value">0.220</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="527.0" y="295.6" width="44" height="56.4" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="577.0" y="289.6" width="44" height="62.4" rx="6" fill="#9aa7b6" />
-<text x="549.0" y="289.6" text-anchor="middle" class="value-accent">0.209</text>
-<text x="599.0" y="283.6" text-anchor="middle" class="value">0.231</text>
+<rect x="527.0" y="297.7" width="44" height="54.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="577.0" y="291.5" width="44" height="60.5" rx="6" fill="#9aa7b6" />
+<text x="549.0" y="291.7" text-anchor="middle" class="value-accent">0.201</text>
+<text x="599.0" y="285.5" text-anchor="middle" class="value">0.224</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="723.0" y="244.5" width="44" height="107.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="773.0" y="222.7" width="44" height="129.3" rx="6" fill="#9aa7b6" />
-<text x="745.0" y="238.5" text-anchor="middle" class="value-accent">0.398</text>
-<text x="795.0" y="216.7" text-anchor="middle" class="value">0.479</text>
+<rect x="723.0" y="250.8" width="44" height="101.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="773.0" y="231.0" width="44" height="121.0" rx="6" fill="#9aa7b6" />
+<text x="745.0" y="244.8" text-anchor="middle" class="value-accent">0.375</text>
+<text x="795.0" y="225.0" text-anchor="middle" class="value">0.448</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">ms / query</text>

--- a/docs/arm_speed_st.svg
+++ b/docs/arm_speed_st.svg
@@ -29,28 +29,28 @@
 <text x="74" y="86.0" text-anchor="end" class="tick">10.0</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Single-threaded</text>
-<rect x="135.0" y="322.2" width="44" height="29.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="185.0" y="318.1" width="44" height="33.9" rx="6" fill="#9aa7b6" />
-<text x="157.0" y="316.2" text-anchor="middle" class="value-accent">1.10</text>
-<text x="207.0" y="312.1" text-anchor="middle" class="value">1.26</text>
+<rect x="135.0" y="322.8" width="44" height="29.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="185.0" y="318.7" width="44" height="33.3" rx="6" fill="#9aa7b6" />
+<text x="157.0" y="316.8" text-anchor="middle" class="value-accent">1.08</text>
+<text x="207.0" y="312.7" text-anchor="middle" class="value">1.24</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="331.0" y="297.3" width="44" height="54.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="381.0" y="284.7" width="44" height="67.3" rx="6" fill="#9aa7b6" />
-<text x="353.0" y="291.3" text-anchor="middle" class="value-accent">2.03</text>
-<text x="403.0" y="278.7" text-anchor="middle" class="value">2.49</text>
+<rect x="331.0" y="298.2" width="44" height="53.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="381.0" y="285.9" width="44" height="66.2" rx="6" fill="#9aa7b6" />
+<text x="353.0" y="292.2" text-anchor="middle" class="value-accent">1.99</text>
+<text x="403.0" y="279.9" text-anchor="middle" class="value">2.45</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="527.0" y="293.7" width="44" height="58.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="577.0" y="284.9" width="44" height="67.1" rx="6" fill="#9aa7b6" />
-<text x="549.0" y="287.7" text-anchor="middle" class="value-accent">2.16</text>
-<text x="599.0" y="278.9" text-anchor="middle" class="value">2.49</text>
+<rect x="527.0" y="294.7" width="44" height="57.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="577.0" y="286.1" width="44" height="65.9" rx="6" fill="#9aa7b6" />
+<text x="549.0" y="288.7" text-anchor="middle" class="value-accent">2.12</text>
+<text x="599.0" y="280.1" text-anchor="middle" class="value">2.44</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="723.0" y="242.0" width="44" height="110.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="773.0" y="216.7" width="44" height="135.3" rx="6" fill="#9aa7b6" />
-<text x="745.0" y="236.0" text-anchor="middle" class="value-accent">4.07</text>
-<text x="795.0" y="210.7" text-anchor="middle" class="value">5.01</text>
+<rect x="723.0" y="244.9" width="44" height="107.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="773.0" y="219.0" width="44" height="133.0" rx="6" fill="#9aa7b6" />
+<text x="745.0" y="238.9" text-anchor="middle" class="value-accent">3.97</text>
+<text x="795.0" y="213.0" text-anchor="middle" class="value">4.92</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">ms / query</text>

--- a/docs/x86_speed_mt.svg
+++ b/docs/x86_speed_mt.svg
@@ -30,27 +30,27 @@
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Multi-threaded</text>
 <rect x="135.0" y="297.3" width="44" height="54.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="185.0" y="298.7" width="44" height="53.3" rx="6" fill="#9aa7b6" />
+<rect x="185.0" y="298.9" width="44" height="53.1" rx="6" fill="#9aa7b6" />
 <text x="157.0" y="291.3" text-anchor="middle" class="value-accent">0.304</text>
-<text x="207.0" y="292.7" text-anchor="middle" class="value">0.296</text>
+<text x="207.0" y="292.9" text-anchor="middle" class="value">0.295</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="331.0" y="248.1" width="44" height="103.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="331.0" y="248.3" width="44" height="103.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
 <rect x="381.0" y="245.8" width="44" height="106.2" rx="6" fill="#9aa7b6" />
-<text x="353.0" y="242.1" text-anchor="middle" class="value-accent">0.577</text>
+<text x="353.0" y="242.3" text-anchor="middle" class="value-accent">0.576</text>
 <text x="403.0" y="239.8" text-anchor="middle" class="value">0.590</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="527.0" y="240.4" width="44" height="111.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="577.0" y="246.0" width="44" height="106.0" rx="6" fill="#9aa7b6" />
-<text x="549.0" y="234.4" text-anchor="middle" class="value-accent">0.620</text>
-<text x="599.0" y="240.0" text-anchor="middle" class="value">0.589</text>
+<rect x="527.0" y="239.3" width="44" height="112.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="577.0" y="245.8" width="44" height="106.2" rx="6" fill="#9aa7b6" />
+<text x="549.0" y="233.3" text-anchor="middle" class="value-accent">0.626</text>
+<text x="599.0" y="239.8" text-anchor="middle" class="value">0.590</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="723.0" y="144.8" width="44" height="207.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="773.0" y="142.1" width="44" height="209.9" rx="6" fill="#9aa7b6" />
-<text x="745.0" y="138.8" text-anchor="middle" class="value-accent">1.151</text>
-<text x="795.0" y="136.1" text-anchor="middle" class="value">1.166</text>
+<rect x="723.0" y="140.1" width="44" height="211.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="773.0" y="140.1" width="44" height="211.9" rx="6" fill="#9aa7b6" />
+<text x="745.0" y="134.1" text-anchor="middle" class="value-accent">1.177</text>
+<text x="795.0" y="134.1" text-anchor="middle" class="value">1.177</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">ms / query</text>

--- a/docs/x86_speed_st.svg
+++ b/docs/x86_speed_st.svg
@@ -29,28 +29,28 @@
 <text x="74" y="86.0" text-anchor="end" class="tick">10.0</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Single-threaded</text>
-<rect x="135.0" y="317.6" width="44" height="34.4" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="185.0" y="318.9" width="44" height="33.1" rx="6" fill="#9aa7b6" />
-<text x="157.0" y="311.6" text-anchor="middle" class="value-accent">1.27</text>
-<text x="207.0" y="312.9" text-anchor="middle" class="value">1.23</text>
+<rect x="135.0" y="317.7" width="44" height="34.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="185.0" y="320.4" width="44" height="31.6" rx="6" fill="#9aa7b6" />
+<text x="157.0" y="311.7" text-anchor="middle" class="value-accent">1.27</text>
+<text x="207.0" y="314.4" text-anchor="middle" class="value">1.17</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="331.0" y="284.8" width="44" height="67.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="381.0" y="284.0" width="44" height="68.0" rx="6" fill="#9aa7b6" />
-<text x="353.0" y="278.8" text-anchor="middle" class="value-accent">2.49</text>
-<text x="403.0" y="278.0" text-anchor="middle" class="value">2.52</text>
+<rect x="331.0" y="286.1" width="44" height="65.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="381.0" y="282.9" width="44" height="69.1" rx="6" fill="#9aa7b6" />
+<text x="353.0" y="280.1" text-anchor="middle" class="value-accent">2.44</text>
+<text x="403.0" y="276.9" text-anchor="middle" class="value">2.56</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <rect x="527.0" y="280.3" width="44" height="71.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="577.0" y="282.2" width="44" height="69.8" rx="6" fill="#9aa7b6" />
+<rect x="577.0" y="282.3" width="44" height="69.7" rx="6" fill="#9aa7b6" />
 <text x="549.0" y="274.3" text-anchor="middle" class="value-accent">2.66</text>
-<text x="599.0" y="276.2" text-anchor="middle" class="value">2.59</text>
+<text x="599.0" y="276.3" text-anchor="middle" class="value">2.58</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="723.0" y="215.2" width="44" height="136.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="773.0" y="214.2" width="44" height="137.8" rx="6" fill="#9aa7b6" />
-<text x="745.0" y="209.2" text-anchor="middle" class="value-accent">5.07</text>
-<text x="795.0" y="208.2" text-anchor="middle" class="value">5.10</text>
+<rect x="723.0" y="207.8" width="44" height="144.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="773.0" y="204.2" width="44" height="147.8" rx="6" fill="#9aa7b6" />
+<text x="745.0" y="201.8" text-anchor="middle" class="value-accent">5.34</text>
+<text x="795.0" y="198.2" text-anchor="middle" class="value">5.47</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">ms / query</text>


### PR DESCRIPTION
## Summary

Follow-up to #74 — picks up the post-flush x86 speed numbers in the SVGs that #74 explicitly left for a separate PR (so the kernel review there could focus on the code).

- `docs/x86_speed_{st,mt}.svg` — now reflects the post-kernel-fix JSONs landed in #74 (e.g. d=1536/4bit ST: 2.49 → 2.44 vs FAISS 2.56)
- `docs/arm_speed_{st,mt}.svg` — small noise updates from the post-TQ+ ARM rerun in #71 (e.g. d=1536/4bit ST: 2.03 → 1.99)

No code, no data, no methodology change — purely regenerating SVGs from JSONs already on main via `python3 benchmarks/create_diagrams.py`.

## Test plan

- [x] `git diff` limited to the 4 speed SVGs; all numeric values match `benchmarks/results/speed_*.json` on main
- [ ] Eyeball the rendered SVGs in the README preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)