### PR TITLE
Add CI workflow that runs tests on every PR (issue #67)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel any in-progress run on the same ref when a new commit lands —
+# saves time when iterating on a PR via force-push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  rust:
+    name: Rust (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install OpenBLAS
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: turbovec test suite
+        run: cargo test -p turbovec --release
+
+      # Standalone cargo project that path-deps turbovec — exercises the same
+      # link path a downstream `cargo add turbovec` user hits. Catches BLAS
+      # link-propagation regressions of the class fixed in #69.
+      - name: Downstream consumer smoke test
+        run: cargo run --release --manifest-path examples/downstream-smoke/Cargo.toml
+
+  python:
+    name: Python (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install OpenBLAS
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev pkg-config
+
+      - name: Install maturin and pytest
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install maturin pytest
+
+      - name: Build turbovec wheel
+        shell: bash
+        working-directory: turbovec-python
+        run: maturin build --release --out dist
+
+      # Install the freshly-built wheel + the four integration extras so the
+      # haystack / langchain / llama-index / agno test files run instead of
+      # being skipped by their `pytest.importorskip(...)` guards.
+      - name: Install wheel + integration extras
+        shell: bash
+        working-directory: turbovec-python
+        run: |
+          python -m pip install dist/*.whl
+          python -m pip install \
+            "langchain-core>=0.3" \
+            "llama-index-core>=0.11" \
+            "haystack-ai>=2.0" \
+            "agno>=2.0"
+
+      - name: Run pytest
+        shell: bash
+        run: pytest turbovec-python/tests/ -v


### PR DESCRIPTION
## Summary

Closes #67.

Adds `.github/workflows/ci.yml` triggered on `pull_request` and `push` to `main`. Two matrixed jobs across `ubuntu-latest`, `macos-14`, and `windows-latest`:

- **`rust`** — `cargo test -p turbovec --release` + the `examples/downstream-smoke/` crate. Covers all three BLAS providers (OpenBLAS / Accelerate / matrixmultiply fallback) and both SIMD ISAs (x86_64 AVX2-AVX512, aarch64 NEON). The smoke-test step replaces the manual pre-release ritual that surfaced #69 — every PR now exercises the downstream `cargo add turbovec` link path automatically.
- **`python`** — `maturin build --release` + install wheel + install the four integration extras + `pytest turbovec-python/tests/`. Catches integration-wrapper regressions (haystack / langchain / llama-index / agno) that `release-pypi.yml` currently misses because it doesn't install the extras — the integration tests silently skip via `pytest.importorskip`.

`concurrency.cancel-in-progress` so force-pushing on a PR doesn't pile up runs. `fail-fast: false` so all six matrix cells report independently.

## Cost

Repo is public, so all three runner OSes (Linux, macOS arm64, Windows) are free with no monthly cap.

## Follow-up — required checks

Once the workflow has run cleanly through one release cycle, mark the `Rust (*)` and `Python (*)` checks as **required** in branch protection on `main`. After that, PRs with failing tests can't reach the merge button.

Out of scope here:
- `paths-ignore` for doc-only changes — interacts badly with required-checks (skipped workflows don't produce a passing check, so doc PRs become unmergeable). Can be addressed later with the "ci-status gate" pattern if it becomes annoying.
- Recall sweeps + speed benchmarks — too slow for per-PR.

## Test plan

This PR itself will be the first run of the workflow. Looking for:
- [ ] All 6 jobs reach a definitive pass/fail (no setup failures)
- [ ] Rust step 2 (downstream-smoke) passes on Linux + macOS + Windows
- [ ] Python step (pytest) runs the integration test files instead of skipping them — visible in `-v` output as `test_haystack.py`, `test_langchain.py`, etc. with passing assertions
- [ ] Total wall time is reasonable (~5-7 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)