### PR TITLE
Audit-driven integration + Rust core fidelity work (7 waves)

### DIFF
--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -495,6 +495,12 @@ class TurboQuantVectorDb(VectorDb):
         limit: int = 5,
         filters: Optional[Union[Dict[str, Any], List[Any]]] = None,
     ) -> List[Document]:
+        # An empty query string usually indicates an upstream bug
+        # (uninitialised variable, failed prompt construction). LanceDb
+        # short-circuits this to [] rather than searching with a hash-
+        # derived embedding of "", which would return arbitrary garbage.
+        if not query:
+            return []
         if self._index is None or len(self._index) == 0:
             return []
 
@@ -529,6 +535,8 @@ class TurboQuantVectorDb(VectorDb):
         limit: int = 5,
         filters: Optional[Union[Dict[str, Any], List[Any]]] = None,
     ) -> List[Document]:
+        if not query:
+            return []
         if self._index is None or len(self._index) == 0:
             return []
 

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -478,6 +478,13 @@ class TurboQuantVectorDb(VectorDb):
                     meta_data=dict(doc_data.get("meta_data") or {}),
                     usage=doc_data.get("usage"),
                     content_id=doc_data.get("content_id"),
+                    # Match LanceDb._build_search_results: thread the
+                    # store's embedder through so downstream code can call
+                    # `doc.embed()` / `doc.async_embed()` on a retrieved
+                    # hit without explicitly passing the embedder back in.
+                    # Without this, `doc.embed()` raises
+                    # "No embedder provided".
+                    embedder=self.embedder,
                 )
             )
         return results

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -2,11 +2,15 @@
 
 Install with: ``pip install turbovec[haystack]``.
 
-Implements the Haystack 2.x ``DocumentStore`` protocol and matches the
-public surface of ``InMemoryDocumentStore`` so this store can be swapped
-in wherever the in-memory store is used. The quantized index discards
-full-precision embeddings after compression — callers that rely on
-``Document.embedding`` after retrieval will see ``None``.
+Implements the Haystack 2.x ``DocumentStore`` protocol and mirrors most
+of ``InMemoryDocumentStore``'s public surface (write/filter/delete,
+``embedding_retrieval``, ``save_to_disk``/``load_from_disk``, pipeline
+``to_dict``/``from_dict``). BM25 (sparse-text) retrieval is not
+implemented — wire an ``InMemoryBM25Retriever`` against a separate
+store if you need keyword search alongside vector search. The
+quantized index discards full-precision embeddings after compression —
+callers that rely on ``Document.embedding`` after retrieval will see
+``None``.
 """
 
 from __future__ import annotations
@@ -24,6 +28,8 @@ from ._turbovec import IdMapIndex
 
 try:
     from haystack import Document
+    from haystack.dataclasses import ByteStream
+    from haystack.dataclasses.sparse_embedding import SparseEmbedding
     from haystack.document_stores.errors import DuplicateDocumentError
     from haystack.document_stores.types import DuplicatePolicy
     from haystack.utils.filters import document_matches_filter
@@ -224,6 +230,8 @@ class TurboQuantDocumentStore:
                 "id": doc.id,
                 "content": doc.content,
                 "meta": dict(doc.meta),
+                "blob": doc.blob,
+                "sparse_embedding": doc.sparse_embedding,
             }
         return len(to_write)
 
@@ -362,11 +370,14 @@ class TurboQuantDocumentStore:
 
     @staticmethod
     def _validate_filters(filters: Optional[Dict[str, Any]]) -> None:
+        # Match InMemoryDocumentStore (document_store.py:504-509): a
+        # filter dict must have a top-level "operator" (simple comparison
+        # or logical) or "conditions" (compound). A bare "field" without
+        # an operator is malformed and the reference rejects it; we do too.
         if (
             filters
             and "operator" not in filters
             and "conditions" not in filters
-            and "field" not in filters
         ):
             raise ValueError(
                 "Invalid filter syntax. See https://docs.haystack.deepset.ai/docs/metadata-filtering for details."
@@ -556,8 +567,12 @@ class TurboQuantDocumentStore:
     # ---- Persistence -------------------------------------------------
 
     # Side-car schema. Bump when the on-disk shape changes; loader
-    # checks it and refuses to deserialize unknown versions.
-    _DOCSTORE_SCHEMA_VERSION = 1
+    # accepts the current version plus any older versions whose missing
+    # fields we know how to reconstruct (currently v1, written before
+    # blob / sparse_embedding round-trip was added — both default to None
+    # on load).
+    _DOCSTORE_SCHEMA_VERSION = 2
+    _DOCSTORE_SCHEMA_COMPAT = (1, 2)
 
     def save_to_disk(self, folder_path: str | Path) -> None:
         """Persist the quantized index plus the Haystack side-car to disk.
@@ -579,7 +594,9 @@ class TurboQuantDocumentStore:
         # so we don't lose type fidelity on the round-trip.
         payload = {
             "schema_version": self._DOCSTORE_SCHEMA_VERSION,
-            "u64_to_doc": [[h, d] for h, d in self._u64_to_doc.items()],
+            "u64_to_doc": [
+                [h, self._serialize_doc_data(d)] for h, d in self._u64_to_doc.items()
+            ],
             "next_u64": self._next_u64,
             "bit_width": self._bit_width,
             "embedding_similarity_function": self.embedding_similarity_function,
@@ -601,10 +618,10 @@ class TurboQuantDocumentStore:
         with open(folder / "docstore.json") as f:
             state = json.load(f)
         version = state.get("schema_version", 0)
-        if version != cls._DOCSTORE_SCHEMA_VERSION:
+        if version not in cls._DOCSTORE_SCHEMA_COMPAT:
             raise ValueError(
                 f"docstore.json has schema version {version}; "
-                f"this turbovec expects version {cls._DOCSTORE_SCHEMA_VERSION}"
+                f"this turbovec accepts versions {list(cls._DOCSTORE_SCHEMA_COMPAT)}"
             )
         store = cls(
             bit_width=state["bit_width"],
@@ -617,7 +634,12 @@ class TurboQuantDocumentStore:
         # uncommitted, int otherwise).
         store._index = IdMapIndex.load(str(folder / "index.tvim"))
         # Reconstruct {int handle: doc data} from the list-of-pairs form.
-        store._u64_to_doc = {int(h): d for h, d in state["u64_to_doc"]}
+        # `_deserialize_doc_data` is shape-tolerant: v1 entries lack the
+        # `blob` / `sparse_embedding` keys and come back with both set to
+        # None, which matches their original on-write state.
+        store._u64_to_doc = {
+            int(h): cls._deserialize_doc_data(d) for h, d in state["u64_to_doc"]
+        }
         store._next_u64 = state["next_u64"]
         # Rebuild str_to_u64 from the reloaded doc table.
         store._str_to_u64 = {
@@ -660,8 +682,38 @@ class TurboQuantDocumentStore:
             id=data["id"],
             content=data["content"],
             meta=dict(data["meta"]),
+            blob=data.get("blob"),
+            sparse_embedding=data.get("sparse_embedding"),
             score=score,
         )
+
+    @staticmethod
+    def _serialize_doc_data(data: Dict[str, Any]) -> Dict[str, Any]:
+        # blob is a ByteStream; sparse_embedding is a SparseEmbedding.
+        # Both have a JSON-safe to_dict() form.
+        blob = data.get("blob")
+        sparse = data.get("sparse_embedding")
+        return {
+            "id": data["id"],
+            "content": data["content"],
+            "meta": data["meta"],
+            "blob": blob.to_dict() if blob is not None else None,
+            "sparse_embedding": sparse.to_dict() if sparse is not None else None,
+        }
+
+    @staticmethod
+    def _deserialize_doc_data(d: Dict[str, Any]) -> Dict[str, Any]:
+        blob = d.get("blob")
+        sparse = d.get("sparse_embedding")
+        return {
+            "id": d["id"],
+            "content": d["content"],
+            "meta": d["meta"],
+            "blob": ByteStream.from_dict(blob) if blob is not None else None,
+            "sparse_embedding": (
+                SparseEmbedding.from_dict(sparse) if sparse is not None else None
+            ),
+        }
 
 
 __all__ = ["TurboQuantDocumentStore"]

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -301,7 +301,7 @@ class TurboQuantVectorStore(VectorStore):
             allowed_handles = [
                 self._str_to_u64[sid]
                 for sid, (text, meta) in self._docs.items()
-                if predicate(Document(page_content=text, metadata=dict(meta)))
+                if predicate(Document(id=sid, page_content=text, metadata=dict(meta)))
             ]
             if not allowed_handles:
                 return []
@@ -312,7 +312,9 @@ class TurboQuantVectorStore(VectorStore):
         for score, handle in zip(scores[0], handles[0]):
             sid = self._u64_to_str[int(handle)]
             text, meta = self._docs[sid]
-            results.append((Document(page_content=text, metadata=dict(meta)), float(score)))
+            results.append(
+                (Document(id=sid, page_content=text, metadata=dict(meta)), float(score))
+            )
         return results
 
     @staticmethod

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -18,7 +18,6 @@ try:
     from llama_index.core.bridge.pydantic import PrivateAttr
     from llama_index.core.schema import (
         BaseNode,
-        MetadataMode,
         NodeRelationship,
         RelatedNodeInfo,
         TextNode,
@@ -30,7 +29,12 @@ try:
         MetadataFilter,
         MetadataFilters,
         VectorStoreQuery,
+        VectorStoreQueryMode,
         VectorStoreQueryResult,
+    )
+    from llama_index.core.vector_stores.utils import (
+        metadata_dict_to_node,
+        node_to_metadata_dict,
     )
 except ImportError as exc:
     raise ImportError(
@@ -51,9 +55,14 @@ _STORE_EXT = ".nodes.json"
 _NAMESPACE_SEP = "__"
 _DEFAULT_PERSIST_FNAME = "vector_store.json"
 _DEFAULT_VECTOR_STORE = "default"
-# Bump when the nodes.json shape changes; loader refuses to deserialize
-# unknown versions.
-_NODES_SCHEMA_VERSION = 1
+# Bump when the nodes.json shape changes; loader accepts the current
+# version plus any older versions whose missing fields we know how to
+# reconstruct (currently v1, written before full-node round-trip was
+# added — v1 entries are reconstructed as bare TextNodes with only
+# text + metadata + SOURCE relationship, matching the original
+# lossy behaviour rather than failing to load).
+_NODES_SCHEMA_VERSION = 2
+_NODES_SCHEMA_COMPAT = (1, 2)
 
 
 def _split_persist_base(persist_path: str | Path) -> Path:
@@ -160,10 +169,23 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
             nid = node.node_id
             self._node_id_to_u64[nid] = h
             self._u64_to_node_id[h] = nid
+            # `metadata` and `ref_doc_id` are kept at top level for fast
+            # filter / doc-id lookup (queries hit these on every hit;
+            # parsing _node_content per hit would be wasteful). `node_dict`
+            # is the framework's canonical metadata representation
+            # (`_node_content` + `_node_type` + original metadata keys),
+            # which `metadata_dict_to_node` reconstructs into a full
+            # BaseNode — preserving relationships (PREVIOUS / NEXT /
+            # PARENT / CHILD), excluded_*_metadata_keys, template fields,
+            # start/end_char_idx and mimetype on retrieval. The narrow
+            # `{text, metadata, ref_doc_id}` schema we used to keep lost
+            # all of those silently.
             self._nodes[nid] = {
-                "text": node.get_content(metadata_mode=MetadataMode.NONE),
                 "metadata": dict(node.metadata),
                 "ref_doc_id": node.ref_doc_id,
+                "node_dict": node_to_metadata_dict(
+                    node, remove_text=False, flat_metadata=False
+                ),
             }
             ids.append(nid)
         return ids
@@ -254,7 +276,16 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         return [self._reconstruct_node(nid, data) for nid, data in candidates]
 
     @staticmethod
-    def _reconstruct_node(nid: str, data: dict[str, Any]) -> TextNode:
+    def _reconstruct_node(nid: str, data: dict[str, Any]) -> BaseNode:
+        # v2 entries carry `node_dict` — round-trip via the framework's
+        # own helper so we get the full BaseNode subclass back
+        # (TextNode / IndexNode / ImageNode) with every field populated.
+        if "node_dict" in data:
+            return metadata_dict_to_node(data["node_dict"])
+        # v1 fallback: stores that were persisted before the full-node
+        # round-trip landed only have {text, metadata, ref_doc_id}.
+        # Reconstruct the minimum-fidelity TextNode they used to produce
+        # so old on-disk stores keep loading without manual migration.
         node = TextNode(
             id_=nid,
             text=data["text"],
@@ -329,9 +360,13 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
             return all(results) if results else True
         if condition == FilterCondition.OR:
             return any(results) if results else True
+        if condition == FilterCondition.NOT:
+            # Reference semantics (`build_metadata_filter_fn`,
+            # `utils.py:187-189`): NOT matches when none of the inner
+            # filters match. Empty inner list trivially satisfies NOT.
+            return not any(results)
         raise NotImplementedError(
-            f"filter condition {condition!r} not supported by TurboQuantVectorStore "
-            "(supported: AND, OR)"
+            f"filter condition {condition!r} not supported by TurboQuantVectorStore"
         )
 
     @staticmethod
@@ -369,16 +404,55 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
             return value in target
         if op == FilterOperator.NIN:
             return value not in target
-        if op == FilterOperator.TEXT_MATCH:
-            # Case-insensitive, like the reference impl.
-            return str(target).lower() in str(value).lower()
         if op == FilterOperator.CONTAINS:
             return target in value
+        if op == FilterOperator.TEXT_MATCH:
+            # Reference (`utils.py:138-144`): case-SENSITIVE substring,
+            # both sides must be strings. Previous turbovec impl
+            # lowercased both sides — a silent semantic divergence that
+            # caused our results to disagree with SimpleVectorStore on
+            # mixed-case keys.
+            if isinstance(target, str) and isinstance(value, str):
+                return target in value
+            raise TypeError(
+                "Both metadata value and filter value must be strings "
+                "for the TEXT_MATCH operator"
+            )
+        if op == FilterOperator.TEXT_MATCH_INSENSITIVE:
+            if isinstance(target, str) and isinstance(value, str):
+                return target.lower() in value.lower()
+            raise TypeError(
+                "Both metadata value and filter value must be strings "
+                "for the TEXT_MATCH_INSENSITIVE operator"
+            )
+        if op == FilterOperator.ALL:
+            # Reference (`utils.py:152-153`): every element of `target`
+            # must be present in the metadata value (which is typically
+            # a list — tag-set matching).
+            return all(t in value for t in target)
+        if op == FilterOperator.ANY:
+            return any(t in value for t in target)
         raise NotImplementedError(
             f"filter operator {op!r} not supported by TurboQuantVectorStore"
         )
 
     def query(self, query: VectorStoreQuery, **_: Any) -> VectorStoreQueryResult:
+        # MMR / SVM / LINEAR_REGRESSION / HYBRID etc. all need access to
+        # full-precision vectors (for pairwise diversity, learned scoring,
+        # or sparse-dense fusion). turbovec discards full precision after
+        # quantization, so any non-DEFAULT mode is unsupportable here.
+        # Raise loudly instead of silently treating it as DEFAULT, which
+        # the previous impl did and which let callers think they were
+        # getting e.g. MMR diversity when they were not.
+        if query.mode != VectorStoreQueryMode.DEFAULT:
+            raise NotImplementedError(
+                f"TurboQuantVectorStore does not support query mode "
+                f"{query.mode!r}. Only VectorStoreQueryMode.DEFAULT is "
+                "supported — MMR / SVM / hybrid modes need access to "
+                "full-precision vectors which turbovec discards after "
+                "quantization. Maintain a parallel store with full vectors "
+                "if you need a non-default scoring mode."
+            )
         if query.query_embedding is None:
             raise ValueError(
                 "TurboQuantVectorStore requires a pre-computed query_embedding "
@@ -538,12 +612,16 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         with open(base.with_suffix(_STORE_EXT)) as f:
             state = json.load(f)
         version = state.get("schema_version", 0)
-        if version != _NODES_SCHEMA_VERSION:
+        if version not in _NODES_SCHEMA_COMPAT:
             raise ValueError(
                 f"{_STORE_EXT.lstrip('.')} has schema version {version}; "
-                f"this turbovec expects version {_NODES_SCHEMA_VERSION}"
+                f"this turbovec accepts versions {list(_NODES_SCHEMA_COMPAT)}"
             )
         store = cls(index=index)
+        # v1 entries lack `node_dict` and reconstruct as narrow TextNodes;
+        # v2 entries carry it and reconstruct with full BaseNode fidelity.
+        # `_reconstruct_node` dispatches on shape, so we just load the
+        # dict as-is.
         store._nodes = state["nodes"]
         # Reconstruct {node_id: int handle} from the list-of-pairs form.
         store._node_id_to_u64 = {nid: int(h) for nid, h in state["node_id_to_u64"]}

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -137,8 +137,23 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         if not nodes:
             return []
 
-        # Upsert-like: if a node_id is already present, remove the old
-        # entry before re-adding so the new embedding wins.
+        # Reject intra-batch duplicates loudly. Letting them through would
+        # leave the index with N vectors but only the last node_id mapped
+        # back to one of them — the earlier handles become orphans that
+        # `query` later resolves through the duplicate node_id, returning
+        # the second node's payload attached to the first node's vector.
+        # Caller's job to deduplicate before calling add.
+        seen: set[str] = set()
+        for n in nodes:
+            if n.node_id in seen:
+                raise ValueError(
+                    f"duplicate node_id {n.node_id!r} appears multiple times "
+                    "in the input batch; deduplicate before calling add()"
+                )
+            seen.add(n.node_id)
+
+        # Upsert-like: if a node_id is already present in the STORE, remove
+        # the old entry before re-adding so the new embedding wins.
         duplicates = [n.node_id for n in nodes if n.node_id in self._node_id_to_u64]
         for node_id in duplicates:
             self._remove_node_by_id(node_id)

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -283,11 +283,20 @@ impl IdMapIndex {
 
         let (scores, ids) = self.inner.search_with_allowlist(q_slice, k, allow_slice);
         // For empty queries (nq=0), match TurboQuantIndex's shape
-        // contract: effective_k is `min(k, n_vectors, n_allowed)`, not
-        // raw `k`. Previously these two index types returned divergent
-        // shapes for the same `k` on the same data.
+        // contract: effective_k is `min(k, n_vectors, n_allowed)`. The
+        // kernel dedups the allowlist via a packed bool mask for nq>0,
+        // so we have to dedup here too — otherwise `allowlist=[1, 1, 1]`
+        // returns shape `(0, 3)` for empty queries but `(N, 1)` for
+        // non-empty queries, a silent shape divergence.
         let effective_k = if nq == 0 {
-            let n_allowed = allow_slice.map_or(self.inner.len(), |s| s.len());
+            let n_allowed = match allow_slice {
+                Some(s) => {
+                    let mut seen: std::collections::HashSet<u64> =
+                        std::collections::HashSet::with_capacity(s.len());
+                    s.iter().filter(|id| seen.insert(**id)).count()
+                }
+                None => self.inner.len(),
+            };
             k.min(self.inner.len()).min(n_allowed)
         } else {
             scores.len() / nq

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -2,6 +2,12 @@ use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::prelude::*;
 use pyo3::types::PyType;
 
+fn not_contiguous_err(kind: &str) -> PyErr {
+    pyo3::exceptions::PyValueError::new_err(format!(
+        "{kind} must be C-contiguous; call np.ascontiguousarray(...) first",
+    ))
+}
+
 #[pyclass]
 struct TurboQuantIndex {
     inner: turbovec_core::TurboQuantIndex,
@@ -27,7 +33,7 @@ impl TurboQuantIndex {
     fn add(&mut self, vectors: PyReadonlyArray2<f32>) -> PyResult<()> {
         let arr = vectors.as_array();
         let dim = arr.ncols();
-        let slice = arr.as_slice().expect("vectors must be contiguous");
+        let slice = arr.as_slice().ok_or_else(|| not_contiguous_err("vectors"))?;
         // `add_2d` handles both eager (dim must match) and lazy (locks
         // dim on first call) cases.
         self.inner
@@ -50,7 +56,20 @@ impl TurboQuantIndex {
     ) -> PyResult<(Bound<'py, PyArray2<f32>>, Bound<'py, PyArray2<i64>>)> {
         let arr = queries.as_array();
         let nq = arr.nrows();
-        let q_slice = arr.as_slice().expect("queries must be contiguous");
+        let q_slice = arr.as_slice().ok_or_else(|| not_contiguous_err("queries"))?;
+        // Reject wrong-dim queries cleanly. Previously the inner
+        // `assert_eq!(queries.len(), nq * dim)` would fire as a Rust
+        // panic and surface to Python as a PanicException, not the
+        // ValueError users expect for input-shape mismatch.
+        if let Some(idx_dim) = self.inner.dim_opt() {
+            if arr.ncols() != idx_dim {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "query dim {} does not match index dim {}",
+                    arr.ncols(),
+                    idx_dim,
+                )));
+            }
+        }
 
         let mask_arr = mask.as_ref().map(|m| m.as_array());
         let mask_slice: Option<&[bool]> = match mask_arr.as_ref() {
@@ -63,7 +82,7 @@ impl TurboQuantIndex {
                         expected,
                     )));
                 }
-                Some(m_arr.as_slice().expect("mask must be contiguous"))
+                Some(m_arr.as_slice().ok_or_else(|| not_contiguous_err("mask"))?)
             }
             None => None,
         };
@@ -107,8 +126,16 @@ impl TurboQuantIndex {
     /// The last vector moves into the deleted slot — order is not
     /// preserved. Returns the old index of the moved vector; equals `idx`
     /// when `idx` was already the last element.
-    fn swap_remove(&mut self, idx: usize) -> usize {
-        self.inner.swap_remove(idx)
+    ///
+    /// Raises ``IndexError`` if ``idx`` is out of range.
+    fn swap_remove(&mut self, idx: usize) -> PyResult<usize> {
+        let len = self.inner.len();
+        if idx >= len {
+            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                "index {idx} out of range for index of length {len}",
+            )));
+        }
+        Ok(self.inner.swap_remove(idx))
     }
 
     fn __len__(&self) -> usize {
@@ -176,9 +203,9 @@ impl IdMapIndex {
     ) -> PyResult<()> {
         let v = vectors.as_array();
         let dim = v.ncols();
-        let v_slice = v.as_slice().expect("vectors must be contiguous");
+        let v_slice = v.as_slice().ok_or_else(|| not_contiguous_err("vectors"))?;
         let i = ids.as_array();
-        let i_slice = i.as_slice().expect("ids must be contiguous");
+        let i_slice = i.as_slice().ok_or_else(|| not_contiguous_err("ids"))?;
         self.inner
             .add_with_ids_2d(v_slice, dim, i_slice)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
@@ -210,7 +237,16 @@ impl IdMapIndex {
     ) -> PyResult<(Bound<'py, PyArray2<f32>>, Bound<'py, PyArray2<u64>>)> {
         let arr = queries.as_array();
         let nq = arr.nrows();
-        let q_slice = arr.as_slice().expect("queries must be contiguous");
+        let q_slice = arr.as_slice().ok_or_else(|| not_contiguous_err("queries"))?;
+        if let Some(idx_dim) = self.inner.dim_opt() {
+            if arr.ncols() != idx_dim {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "query dim {} does not match index dim {}",
+                    arr.ncols(),
+                    idx_dim,
+                )));
+            }
+        }
 
         let allow_arr = allowlist.as_ref().map(|a| a.as_array());
         let allow_slice: Option<&[u64]> = match allow_arr.as_ref() {
@@ -220,7 +256,7 @@ impl IdMapIndex {
                         "allowlist is empty",
                     ));
                 }
-                let slice = a_arr.as_slice().expect("allowlist must be contiguous");
+                let slice = a_arr.as_slice().ok_or_else(|| not_contiguous_err("allowlist"))?;
                 let mut unknown: Vec<u64> = Vec::new();
                 for &id in slice {
                     if !self.inner.contains(id) {
@@ -246,7 +282,16 @@ impl IdMapIndex {
         };
 
         let (scores, ids) = self.inner.search_with_allowlist(q_slice, k, allow_slice);
-        let effective_k = if nq == 0 { k } else { scores.len() / nq };
+        // For empty queries (nq=0), match TurboQuantIndex's shape
+        // contract: effective_k is `min(k, n_vectors, n_allowed)`, not
+        // raw `k`. Previously these two index types returned divergent
+        // shapes for the same `k` on the same data.
+        let effective_k = if nq == 0 {
+            let n_allowed = allow_slice.map_or(self.inner.len(), |s| s.len());
+            k.min(self.inner.len()).min(n_allowed)
+        } else {
+            scores.len() / nq
+        };
 
         let scores_arr = numpy::ndarray::Array2::from_shape_vec((nq, effective_k), scores)
             .unwrap()

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -991,3 +991,100 @@ def test_update_metadata_unknown_content_id_is_noop():
     # Nothing changed on the known doc.
     docs = list(db._u64_to_doc.values())
     assert docs[0]["meta_data"] == {"k": 1}
+
+
+# ---- Tier-2 field-completeness tests. Each pins behaviour around
+# Document fields that are populated, omitted, or diverged from LanceDb.
+# Without these, a refactor could silently change the contract. ----
+
+def test_search_results_content_origin_divergence_from_lancedb():
+    # `Document.content_origin` is an agno field set by some Reader
+    # pipelines. LanceDb drops it on insert (stores `payload` as opaque
+    # JSON of {id, name, meta_data, content_id, usage} only); turbovec
+    # mirrors that. Pin the divergence so a future caller doesn't quietly
+    # start relying on the field surviving — and so a future preservation
+    # change (turbovec preserving it where LanceDb doesn't) is a
+    # deliberate decision.
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    doc = Document(
+        id="d-1",
+        content="hello",
+        embedding=embedder._embed("hello"),
+        content_origin="pdf",
+    )
+    db.insert("h", [doc])
+    [result] = db.search("hello", limit=1)
+    # Matches LanceDb behaviour: content_origin is not preserved.
+    assert result.content_origin is None
+
+
+def test_search_results_size_divergence_from_lancedb():
+    # Same divergence pin for `Document.size`.
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    doc = Document(
+        id="d-1",
+        content="hello",
+        embedding=embedder._embed("hello"),
+        size=42,
+    )
+    db.insert("h", [doc])
+    [result] = db.search("hello", limit=1)
+    assert result.size is None
+
+
+def test_search_results_embedding_is_none_divergence_from_lancedb():
+    # LanceDb's `_build_search_results` sets `embedding=item["vector"]`
+    # so callers can read the original vector off a returned hit.
+    # turbovec quantizes vectors to 2-4 bits per dim and discards the
+    # full-precision form — the original vector is unrecoverable, so
+    # we return `embedding=None`. Pin this so a caller who depends on
+    # `result.embedding` after retrieval (e.g. for rerank-by-similarity)
+    # gets a clear contract from the test suite, not a runtime surprise.
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    db.insert("h", [_doc("a", doc_id="d-1")])
+    [result] = db.search("a", limit=1)
+    assert result.embedding is None
+
+
+def test_reranker_output_documents_carry_reranking_score():
+    # When the reranker sets `reranking_score`, it must survive the
+    # post-rerank result list. Existing reranker tests only check the
+    # order; a refactor that re-threads `embedder` could drop other
+    # fields the reranker mutated.
+    from agno.knowledge.reranker.base import Reranker as _AgnoReranker
+
+    class ScoringReranker(_AgnoReranker):
+        def rerank(self, query: str, documents):
+            for i, d in enumerate(documents):
+                d.reranking_score = float(len(documents) - i)
+            return documents
+
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder, reranker=ScoringReranker())
+    db.create()
+    db.insert("h", [_doc(f"doc-{i}") for i in range(3)])
+
+    results = db.search("doc-0", limit=3)
+    assert all(r.reranking_score is not None for r in results)
+    assert all(isinstance(r.reranking_score, float) for r in results)
+
+
+def test_delete_by_metadata_returns_false_when_no_match():
+    # `delete_by_*` methods return bool — True when at least one doc
+    # matched (and was deleted), False otherwise. Other delete tests
+    # cover the True branch; this pins the False branch so a regression
+    # always returning True can't silently mask "I expected to delete
+    # something and nothing matched" upstream.
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    db.insert("h", [_doc("a", meta_data={"tag": "x"})])
+    assert db.delete_by_metadata({"tag": "no-such-value"}) is False
+    # Original doc still present.
+    assert db.get_count() == 1

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -123,6 +123,139 @@ def test_async_search_results_also_carry_embedder():
     asyncio.run(_async_search_embedder_body())
 
 
+# ---- Reference-parity tests against agno's LanceDb test suite. Each
+# pins behaviour the in-tree LanceDb unit tests exercise. ----
+
+def test_update_metadata_updates_all_docs_sharing_content_id():
+    # `content_id` is intentionally many-to-one — `update_metadata(cid, m)`
+    # must update every doc with that cid, not just the first match. The
+    # LanceDb reference covers this; our existing test only inserts one
+    # doc per content_id and wouldn't have caught a "first-match only" bug.
+    # Identify docs by a `label` in meta_data since agno's _derive_doc_id
+    # rewrites doc.id at insert time.
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    db.insert("h", [
+        _doc("a", content_id="shared", meta_data={"label": "first"}),
+        _doc("b", content_id="shared", meta_data={"label": "second"}),
+        _doc("c", content_id="other", meta_data={"label": "third"}),
+    ])
+    db.update_metadata("shared", {"updated": True})
+
+    results = db.search("a", limit=10)
+    by_label = {d.meta_data["label"]: d for d in results}
+    assert by_label["first"].meta_data.get("updated") is True
+    assert by_label["second"].meta_data.get("updated") is True
+    assert by_label["third"].meta_data.get("updated") is None
+
+
+def test_update_metadata_preserves_quantized_codes():
+    # `update_metadata` must not re-derive codes — codes are precious
+    # (cost an embed + a quantise) and a silent re-embed would also
+    # break determinism. Behaviour-level check: search results are
+    # bit-identical before and after a metadata update.
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    db.insert("h", [
+        _doc(f"doc-{i}", doc_id=f"d-{i}", content_id=f"cid-{i}") for i in range(3)
+    ])
+
+    before = db.search("doc-0", limit=3)
+    db.update_metadata("cid-0", {"updated": True})
+    after = db.search("doc-0", limit=3)
+    assert [d.id for d in before] == [d.id for d in after]
+
+
+def test_insert_reembeds_document_with_empty_list_embedding():
+    # In agno's async pipeline, failed embeds surface as `embedding=[]`
+    # (an empty list, distinct path from None). The integration must
+    # re-embed those rather than silently skipping or shipping the
+    # zero-length vector to the kernel. Uses BatchEmbedder so we have
+    # an embedder with the batch path the re-embed code prefers.
+    embedder = BatchEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    doc = Document(id="d-1", content="hello", embedding=[], meta_data={})
+    db.insert("h", [doc])
+    assert db.get_count() == 1
+
+
+def test_insert_empty_document_list_is_noop():
+    # Drop-in safety: callers passing an empty list (e.g. a Knowledge
+    # batch where every doc was filtered out upstream) must not raise
+    # and must not change store state.
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    db.insert("h", [])
+    assert db.get_count() == 0
+
+
+def test_search_with_empty_query_returns_empty():
+    # LanceDb short-circuits `search("")` to []. Without this, a hash-
+    # derived embedding of "" would return arbitrary near-match garbage.
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    db.insert("h", [_doc("a", doc_id="d-1")])
+    assert db.search("", limit=5) == []
+    # None also short-circuits (defensive against upstream un-init).
+    assert db.search(None, limit=5) == []  # type: ignore[arg-type]
+
+
+def test_delete_by_metadata_handles_non_string_values():
+    # `delete_by_metadata` matches on equality across heterogeneous
+    # value types — bools, floats, ints. JSON round-trip during persist
+    # could coerce types (`True` → `"true"`); the in-memory path must
+    # at minimum work natively. Identify docs by `label` since agno's
+    # _derive_doc_id rewrites doc.id at insert time.
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    db.insert("h", [
+        _doc("a", meta_data={"active": True, "score": 0.9, "label": "x"}),
+        _doc("b", meta_data={"active": False, "score": 0.9, "label": "y"}),
+        _doc("c", meta_data={"active": True, "score": 0.5, "label": "z"}),
+    ])
+    db.delete_by_metadata({"active": True})
+    labels = {d.meta_data["label"] for d in db.search("a", limit=10)}
+    assert labels == {"y"}
+
+
+def test_update_metadata_with_empty_dict_is_noop():
+    # `update_metadata(cid, {})` must not raise and must not strip the
+    # existing metadata — empty dict is a real edge case (e.g. a caller
+    # built `metadata` from filtered keys and ended up with no updates).
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    db.insert("h", [_doc("a", doc_id="d-1", content_id="cid-1", meta_data={"k": "v"})])
+    db.update_metadata("cid-1", {})
+
+    results = db.search("a", limit=1)
+    assert results[0].meta_data == {"k": "v"}
+
+
+def test_search_does_not_dedupe_distinct_documents_with_identical_content():
+    # LanceDb dedupes search results by content string; turbovec
+    # intentionally does NOT — each insert produces a distinct quantized
+    # vector + id, and we return both as separate hits so callers can
+    # tell them apart via content_id. Pin this deliberate divergence so
+    # a future refactor doesn't silently start matching LanceDb.
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    db.insert("h", [
+        _doc("identical text", content_id="cid-1"),
+        _doc("identical text", content_id="cid-2"),
+    ])
+    results = db.search("identical text", limit=10)
+    assert len(results) == 2
+    assert {d.content_id for d in results} == {"cid-1", "cid-2"}
+
+
 def test_constructor_requires_embedder():
     with pytest.raises(ValueError, match="embedder.*required"):
         TurboQuantVectorDb()

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -96,6 +96,33 @@ class ReverseReranker(_AgnoReranker):
 # ---- Constructor validation -----------------------------------------------
 
 
+def test_search_results_carry_embedder():
+    # Match LanceDb._build_search_results — returned Documents must have
+    # `embedder` set to the store's embedder so downstream code can call
+    # `doc.embed()` / `doc.async_embed()` on a retrieved hit. Without
+    # the field set, `Document.embed` raises "No embedder provided".
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    db.insert("h", [_doc("hello", doc_id="d-1")])
+    [result] = db.search(query="hello", limit=1)
+    assert result.embedder is embedder
+
+
+async def _async_search_embedder_body():
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    db.insert("h", [_doc("hello", doc_id="d-1")])
+    [result] = await db.async_search(query="hello", limit=1)
+    assert result.embedder is embedder
+
+
+def test_async_search_results_also_carry_embedder():
+    import asyncio
+    asyncio.run(_async_search_embedder_body())
+
+
 def test_constructor_requires_embedder():
     with pytest.raises(ValueError, match="embedder.*required"):
         TurboQuantVectorDb()

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -7,6 +7,8 @@ import pytest
 pytest.importorskip("haystack")
 
 from haystack import Document
+from haystack.dataclasses import ByteStream
+from haystack.dataclasses.sparse_embedding import SparseEmbedding
 from haystack.document_stores.errors import DuplicateDocumentError
 from haystack.document_stores.types import DuplicatePolicy
 
@@ -38,6 +40,141 @@ def make_docs(n: int, seed_offset: int = 0) -> list[Document]:
 def test_count_documents_starts_at_zero():
     store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
     assert store.count_documents() == 0
+
+
+# ---- Field-fidelity round-trip tests (covers the langchain-class bug
+# pattern: returned Documents must populate every field the reference
+# would, not just id/content/meta). ----
+
+def test_blob_field_round_trips_through_filter_and_retrieval():
+    # Writing a Document with `blob=` must survive write -> filter_documents
+    # AND write -> embedding_retrieval AND write -> storage. The reference
+    # InMemoryDocumentStore preserves blob; we used to drop it silently.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    payload = b"binary-payload-bytes"
+    blob = ByteStream(data=payload, meta={"origin": "test"}, mime_type="application/octet-stream")
+    doc = Document(
+        id="doc-blob",
+        content="text",
+        embedding=unit_vector(0),
+        blob=blob,
+        meta={"k": 1},
+    )
+    store.write_documents([doc])
+
+    [filtered] = store.filter_documents(filters={"field": "meta.k", "operator": "==", "value": 1})
+    assert filtered.blob is not None
+    assert filtered.blob.data == payload
+    assert filtered.blob.mime_type == "application/octet-stream"
+    assert filtered.blob.meta == {"origin": "test"}
+
+    [retrieved] = store.embedding_retrieval(query_embedding=doc.embedding, top_k=1)
+    assert retrieved.blob is not None
+    assert retrieved.blob.data == payload
+
+    assert store.storage["doc-blob"].blob is not None
+    assert store.storage["doc-blob"].blob.data == payload
+
+
+def test_sparse_embedding_field_round_trips_through_filter_and_retrieval():
+    # Same shape of test for sparse_embedding — hybrid-search pipelines
+    # rely on this surviving the round-trip.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    sparse = SparseEmbedding(indices=[0, 7, 42], values=[0.1, 0.5, 0.9])
+    doc = Document(
+        id="doc-sparse",
+        content="text",
+        embedding=unit_vector(0),
+        sparse_embedding=sparse,
+    )
+    store.write_documents([doc])
+
+    [filtered] = store.filter_documents()
+    assert filtered.sparse_embedding is not None
+    assert filtered.sparse_embedding.indices == [0, 7, 42]
+    assert filtered.sparse_embedding.values == [0.1, 0.5, 0.9]
+
+    [retrieved] = store.embedding_retrieval(query_embedding=doc.embedding, top_k=1)
+    assert retrieved.sparse_embedding is not None
+    assert retrieved.sparse_embedding.indices == [0, 7, 42]
+
+
+def test_blob_and_sparse_embedding_survive_save_load_roundtrip(tmp_path):
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    blob = ByteStream(data=b"abc", mime_type="text/plain")
+    sparse = SparseEmbedding(indices=[1, 2], values=[0.25, 0.75])
+    store.write_documents([
+        Document(
+            id="doc-rich",
+            content="text",
+            embedding=unit_vector(0),
+            blob=blob,
+            sparse_embedding=sparse,
+        )
+    ])
+    store.save_to_disk(tmp_path)
+
+    restored = TurboQuantDocumentStore.load_from_disk(tmp_path)
+    rebuilt = restored.storage["doc-rich"]
+    assert rebuilt.blob is not None
+    assert rebuilt.blob.data == b"abc"
+    assert rebuilt.blob.mime_type == "text/plain"
+    assert rebuilt.sparse_embedding is not None
+    assert rebuilt.sparse_embedding.indices == [1, 2]
+    assert rebuilt.sparse_embedding.values == [0.25, 0.75]
+
+
+def test_documents_without_blob_or_sparse_embedding_round_trip_as_none():
+    # Documents that were written WITHOUT blob/sparse_embedding must come
+    # back with those fields as None, not missing-attribute or KeyError.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents([
+        Document(id="plain", content="text", embedding=unit_vector(0))
+    ])
+    [doc] = store.filter_documents()
+    assert doc.blob is None
+    assert doc.sparse_embedding is None
+
+
+def test_load_accepts_v1_schema_with_no_blob_or_sparse_fields(tmp_path):
+    # v1 docstore.json predates blob/sparse round-trip. Reading it back
+    # should succeed and leave both fields as None — not raise.
+    import json
+
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents([
+        Document(id="doc-v1", content="text", embedding=unit_vector(0), meta={"x": 1})
+    ])
+    store.save_to_disk(tmp_path)
+
+    with open(tmp_path / "docstore.json") as f:
+        state = json.load(f)
+    state["schema_version"] = 1
+    # Strip the v2-only fields from each doc entry so the file shape
+    # matches what a v1 save would have produced.
+    for _h, d in state["u64_to_doc"]:
+        d.pop("blob", None)
+        d.pop("sparse_embedding", None)
+    with open(tmp_path / "docstore.json", "w") as f:
+        json.dump(state, f)
+
+    restored = TurboQuantDocumentStore.load_from_disk(tmp_path)
+    [doc] = restored.filter_documents()
+    assert doc.id == "doc-v1"
+    assert doc.blob is None
+    assert doc.sparse_embedding is None
+
+
+# ---- Filter validation parity ----
+
+def test_filter_documents_rejects_field_without_operator():
+    # InMemoryDocumentStore rejects a filter dict that has neither
+    # `operator` nor `conditions` at the top level — even if a stray
+    # `field` key is present. We do too.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(3))
+    with pytest.raises(ValueError, match="Invalid filter syntax"):
+        store.filter_documents(filters={"field": "meta.idx", "value": 1})
 
 
 def test_write_returns_written_count():

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -1006,3 +1006,112 @@ def test_to_dict_from_dict_round_trip():
     assert restored.count_documents() == 0
     # (to_dict/from_dict serializes the component config, not the data —
     # this matches Haystack's InMemoryDocumentStore contract.)
+
+
+# ---- Tier-2 field-completeness tests. Each pins a value that a future
+# refactor could silently drop. ----
+
+def test_filter_documents_returns_documents_with_score_none():
+    # `_reconstruct` is called without `score=` from filter_documents,
+    # so score must be None on every returned doc. A future cache leak
+    # between read paths could carry a stale score from a prior
+    # embedding_retrieval — pin this so the invariant doesn't drift.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(3))
+    for doc in store.filter_documents():
+        assert doc.score is None
+
+
+def test_storage_property_documents_have_no_blob_sparse_or_score_when_unset():
+    # The `storage` property mirrors filter_documents semantics. For
+    # docs written without blob / sparse_embedding / score, those
+    # fields must come back as None (not a default ByteStream /
+    # SparseEmbedding / 0.0).
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents([
+        Document(id="plain", content="text", embedding=unit_vector(0), meta={"k": "v"})
+    ])
+    doc = store.storage["plain"]
+    assert doc.score is None
+    assert doc.blob is None
+    assert doc.sparse_embedding is None
+    assert doc.embedding is None  # always None — quantization-justified
+
+
+def test_embedding_retrieval_preserves_content_and_meta():
+    # Every existing retrieval test asserts `.id` / `.score` / `.meta` keys
+    # but no test checks that `Document.content` survives the round-trip.
+    # If `_reconstruct` ever stopped copying content, only the blob /
+    # sparse-embedding tests would notice — and only indirectly.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents([
+        Document(
+            id="doc-c",
+            content="distinctive content string",
+            embedding=unit_vector(0),
+            meta={"key1": "value1", "key2": 42, "key3": [1, 2, 3]},
+        )
+    ])
+    [doc] = store.embedding_retrieval(query_embedding=unit_vector(0), top_k=1)
+    assert doc.content == "distinctive content string"
+    assert doc.meta == {"key1": "value1", "key2": 42, "key3": [1, 2, 3]}
+
+
+def test_to_dict_includes_all_init_params_and_type_key():
+    # `to_dict` returns four init_parameters: dim, bit_width,
+    # embedding_similarity_function, return_embedding. A single test
+    # must pin all four plus the outer `type` key (which Haystack's
+    # pipeline serialization uses to resolve the class for from_dict).
+    store = TurboQuantDocumentStore(
+        dim=DIM,
+        bit_width=2,
+        embedding_similarity_function="dot_product",
+        return_embedding=True,
+    )
+    serialized = store.to_dict()
+
+    assert serialized["type"] == "turbovec.haystack.TurboQuantDocumentStore"
+    assert set(serialized["init_parameters"]) == {
+        "dim",
+        "bit_width",
+        "embedding_similarity_function",
+        "return_embedding",
+    }
+    assert serialized["init_parameters"]["dim"] == DIM
+    assert serialized["init_parameters"]["bit_width"] == 2
+    assert serialized["init_parameters"]["embedding_similarity_function"] == "dot_product"
+    assert serialized["init_parameters"]["return_embedding"] is True
+
+
+def test_save_load_preserves_similarity_function_and_return_embedding(tmp_path):
+    # `load_from_disk` uses `.get()` with defaults for the two non-bit_width
+    # init params. If `save_to_disk` ever stopped writing them, the load
+    # would silently fall back to defaults — undetected. Pin both fields
+    # explicitly through a save / load round-trip.
+    store = TurboQuantDocumentStore(
+        dim=DIM,
+        bit_width=4,
+        embedding_similarity_function="dot_product",
+        return_embedding=True,
+    )
+    store.write_documents(make_docs(1))
+    store.save_to_disk(tmp_path)
+
+    restored = TurboQuantDocumentStore.load_from_disk(tmp_path)
+    assert restored.embedding_similarity_function == "dot_product"
+    assert restored.return_embedding is True
+
+
+def test_embedding_retrieval_all_results_have_finite_float_scores():
+    # The existing `top_k` test asserts `results[0].score is not None`
+    # but not for the tail hits — a kernel regression producing NaN /
+    # None on non-top-1 results would slip through.
+    import math
+
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(10))
+    results = store.embedding_retrieval(query_embedding=unit_vector(0), top_k=10)
+    assert len(results) == 10
+    for r in results:
+        assert isinstance(r.score, float)
+        assert math.isfinite(r.score)

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -177,6 +177,212 @@ def test_filter_documents_rejects_field_without_operator():
         store.filter_documents(filters={"field": "meta.idx", "value": 1})
 
 
+# ---- Reference-parity tests against InMemoryDocumentStore. Each one
+# pins behaviour the haystack in-tree DocumentStoreBaseTests suite
+# tests; the bug class is "drop-in regression that only shows up when
+# users compare turbovec's store against InMemoryDocumentStore". ----
+
+@pytest.mark.parametrize(
+    "bad_filter",
+    [
+        {"field": "meta.x"},                       # no operator / conditions
+        {"operator": "AND"},                       # missing conditions
+        {"operator": "==", "value": 1},            # comparison missing field
+    ],
+)
+def test_filter_documents_rejects_malformed_filter_shapes(bad_filter):
+    # Distinct from `field_without_operator` above: each of these is a
+    # different malformed shape the InMemoryDocumentStore reference
+    # rejects. Either our outer `_validate_filters` catches it (raising
+    # ValueError) or haystack's `document_matches_filter` does (raising
+    # `haystack.errors.FilterError`) — either way, the store must not
+    # silently match everything / nothing.
+    from haystack.errors import FilterError
+
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(3))
+    with pytest.raises((ValueError, FilterError)):
+        store.filter_documents(filters=bad_filter)
+
+
+def test_filter_documents_with_and_or_not_operators():
+    # Compound filter dicts (AND / OR / NOT joining sub-conditions) are
+    # the standard production filter shape — pipelines build them via
+    # haystack's filter DSL, not the bare single-comparison form. We
+    # only delegate to `document_matches_filter`, but proving the
+    # delegation works end-to-end through `filter_documents` and
+    # `embedding_retrieval` is what catches a regression where (say) we
+    # forget to forward compound filters to the kernel allowlist path.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents([
+        Document(id="a", content="x", embedding=unit_vector(0), meta={"tier": "pro", "n": 1}),
+        Document(id="b", content="y", embedding=unit_vector(1), meta={"tier": "free", "n": 2}),
+        Document(id="c", content="z", embedding=unit_vector(2), meta={"tier": "pro", "n": 3}),
+    ])
+
+    and_filter = {
+        "operator": "AND",
+        "conditions": [
+            {"field": "meta.tier", "operator": "==", "value": "pro"},
+            {"field": "meta.n", "operator": ">", "value": 1},
+        ],
+    }
+    assert {d.id for d in store.filter_documents(filters=and_filter)} == {"c"}
+    # embedding_retrieval must apply the same compound filter as an allowlist.
+    hits = store.embedding_retrieval(
+        query_embedding=unit_vector(0), top_k=10, filters=and_filter
+    )
+    assert {d.id for d in hits} == {"c"}
+
+    or_filter = {
+        "operator": "OR",
+        "conditions": [
+            {"field": "meta.tier", "operator": "==", "value": "free"},
+            {"field": "meta.n", "operator": ">=", "value": 3},
+        ],
+    }
+    assert {d.id for d in store.filter_documents(filters=or_filter)} == {"b", "c"}
+
+    not_filter = {
+        "operator": "NOT",
+        "conditions": [
+            {"field": "meta.tier", "operator": "==", "value": "pro"},
+        ],
+    }
+    assert {d.id for d in store.filter_documents(filters=not_filter)} == {"b"}
+
+
+def test_embedding_retrieval_rejects_empty_query_embedding():
+    # An empty list is degenerate input — the index's dim is non-zero,
+    # so the dim-mismatch check raises. Pins that "no query at all"
+    # surfaces as a clean error, not a kernel-side panic or empty hit list.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(3))
+    with pytest.raises(ValueError):
+        store.embedding_retrieval(query_embedding=[], top_k=3)
+
+
+def test_filter_documents_equality_with_missing_meta_key():
+    # `field == None` should match docs where the field is absent.
+    # Reference behaviour; an easy regression where we accidentally
+    # normalise missing keys to empty string / sentinel.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents([
+        Document(id="has-tag", content="x", embedding=unit_vector(0), meta={"tag": "free"}),
+        Document(id="no-tag", content="y", embedding=unit_vector(1), meta={}),
+    ])
+    filters = {"field": "meta.tag", "operator": "==", "value": None}
+    assert [d.id for d in store.filter_documents(filters=filters)] == ["no-tag"]
+
+
+def test_delete_documents_on_lazy_empty_store_is_noop():
+    # A lazy-uncommitted store has no committed index dim. Deleting from
+    # it must not blow up — even if every requested id is unknown.
+    store = TurboQuantDocumentStore(bit_width=4)  # dim=None (lazy)
+    store.delete_documents(["nonexistent-1", "nonexistent-2"])
+    assert store.count_documents() == 0
+
+
+def test_get_metadata_field_min_max_handles_float_meta_prefix_and_single_value():
+    # The reference covers (a) float-valued fields, (b) the "meta."
+    # prefix on the field name, and (c) a single-value collection
+    # (min==max). Our existing test only covers int + missing field, so
+    # all three branches are uncovered.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents([
+        Document(id="a", content="x", embedding=unit_vector(0), meta={"price": 9.99}),
+        Document(id="b", content="y", embedding=unit_vector(1), meta={"price": 19.99}),
+        Document(id="c", content="z", embedding=unit_vector(2), meta={"price": 4.50}),
+    ])
+    # Float values.
+    assert store.get_metadata_field_min_max("price") == {"min": 4.50, "max": 19.99}
+    # "meta." prefix on the field name.
+    assert store.get_metadata_field_min_max("meta.price") == {"min": 4.50, "max": 19.99}
+
+    # Single-value collection — min == max.
+    single = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    single.write_documents([
+        Document(id="d", content="x", embedding=unit_vector(0), meta={"price": 5.0}),
+    ])
+    assert single.get_metadata_field_min_max("price") == {"min": 5.0, "max": 5.0}
+
+
+def test_two_stores_have_independent_state():
+    # Refactor canary against accidental class-level mutable state
+    # (sets/dicts at class scope are a recurring footgun). Mutating one
+    # store must never be visible in another.
+    s1 = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    s2 = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    s1.write_documents([Document(id="a", content="x", embedding=unit_vector(0))])
+    assert s2.count_documents() == 0
+    s2.write_documents([Document(id="b", content="y", embedding=unit_vector(1))])
+    assert s1.count_documents() == 1
+    assert s2.count_documents() == 1
+    assert "a" not in s2._str_to_u64
+    assert "b" not in s1._str_to_u64
+
+
+def test_async_concurrent_embedding_retrievals_are_consistent():
+    # The async methods are `to_thread`-style wrappers around the sync
+    # ones. Concurrent reads against the IdMapIndex are documented as
+    # safe; pin it with a consistency test (every concurrent call
+    # produces the same top-k as a single sync call).
+    import asyncio
+
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    docs = make_docs(20)
+    store.write_documents(docs)
+
+    sync_ids = [d.id for d in store.embedding_retrieval(
+        query_embedding=docs[0].embedding, top_k=3
+    )]
+
+    async def run() -> list[list[str]]:
+        results = await asyncio.gather(*[
+            store.embedding_retrieval_async(
+                query_embedding=docs[0].embedding, top_k=3
+            )
+            for _ in range(10)
+        ])
+        return [[d.id for d in r] for r in results]
+
+    all_ids = asyncio.run(run())
+    for ids in all_ids:
+        assert ids == sync_ids
+
+
+def test_return_embedding_flag_is_inert_for_turbovec():
+    # Quantization discards full-precision embeddings — the flag is
+    # accepted for `InMemoryDocumentStore` parity but Documents always
+    # come back with `embedding=None` regardless of the flag (both
+    # store-level and per-call). Pin the deliberate divergence so a
+    # future caller doesn't quietly start relying on it.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4, return_embedding=True)
+    docs = make_docs(2)
+    store.write_documents(docs)
+
+    for d in store.filter_documents():
+        assert d.embedding is None
+    for d in store.embedding_retrieval(query_embedding=docs[0].embedding, top_k=2):
+        assert d.embedding is None
+    # Per-call override (force True) is also inert.
+    for d in store.embedding_retrieval(
+        query_embedding=docs[0].embedding, top_k=2, return_embedding=True
+    ):
+        assert d.embedding is None
+
+
+def test_shutdown_closes_async_executor():
+    # After `shutdown()`, the owned executor must not accept new tasks.
+    # Catches a regression where we silently leak the executor by
+    # marking it shut down without actually calling shutdown.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    executor = store.executor
+    store.shutdown()
+    with pytest.raises(RuntimeError):
+        executor.submit(lambda: None)
+
+
 def test_write_returns_written_count():
     store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
     assert store.write_documents(make_docs(5)) == 5

--- a/turbovec-python/tests/test_id_map.py
+++ b/turbovec-python/tests/test_id_map.py
@@ -181,3 +181,31 @@ def test_add_with_ids_rejects_nan_with_value_error():
     data[0, 5] = np.nan
     with pytest.raises(ValueError, match="invalid input value"):
         idx.add_with_ids(data, np.array([1], dtype=np.uint64))
+
+
+def test_search_empty_queries_dedups_allowlist_for_effective_k():
+    # Wave-6 fix for a bug introduced in wave-5: the `effective_k`
+    # computation for `nq == 0` counted the raw allowlist length, but
+    # the kernel dedups the allowlist via a packed-bool mask for
+    # `nq > 0`. So `allowlist=[1, 1, 1]` returned shape `(0, 3)` for
+    # empty queries but `(N, 1)` for non-empty — silent divergence.
+    idx = IdMapIndex(dim=64, bit_width=4)
+    idx.add_with_ids(
+        unit_vectors(3, 64),
+        np.array([10, 20, 30], dtype=np.uint64),
+    )
+
+    # Allowlist with three copies of the same id. Effective n_allowed
+    # is 1 (after dedup), not 3.
+    allowlist_with_dupes = np.array([10, 10, 10], dtype=np.uint64)
+    empty_queries = np.empty((0, 64), dtype=np.float32)
+    real_query = unit_vectors(1, 64)
+
+    _, empty_ids = idx.search(empty_queries, k=5, allowlist=allowlist_with_dupes)
+    _, real_ids = idx.search(real_query, k=5, allowlist=allowlist_with_dupes)
+
+    # Both should have effective_k = 1 (only one unique id in the
+    # allowlist), differing only in the leading dimension.
+    assert empty_ids.shape[1] == real_ids.shape[1]
+    assert empty_ids.shape == (0, 1)
+    assert real_ids.shape == (1, 1)

--- a/turbovec-python/tests/test_id_map.py
+++ b/turbovec-python/tests/test_id_map.py
@@ -131,3 +131,53 @@ def test_search_on_empty_eager_index_returns_zero_effective_k():
     q = unit_vectors(1, 128)
     _, ids = idx.search(q, k=3)
     assert ids.shape == (1, 0)
+
+
+# ---- Wave 5: typed-exception hygiene + cross-class consistency ----
+
+def test_search_empty_queries_returns_consistent_shape_across_index_types():
+    # Cross-class invariant: passing an empty queries array with k>n
+    # must produce the same shape on both index types. Previously,
+    # IdMapIndex returned (0, k) (raw k) while TurboQuantIndex returned
+    # (0, min(k, n_vectors)) — a silent divergence in result shape.
+    from turbovec import TurboQuantIndex
+
+    tq = TurboQuantIndex(dim=64, bit_width=4)
+    im = IdMapIndex(dim=64, bit_width=4)
+    tq.add(unit_vectors(3, 64))
+    im.add_with_ids(unit_vectors(3, 64), np.array([1, 2, 3], dtype=np.uint64))
+
+    empty_queries = np.empty((0, 64), dtype=np.float32)
+
+    tq_scores, tq_indices = tq.search(empty_queries, k=5)
+    im_scores, im_ids = im.search(empty_queries, k=5)
+
+    assert tq_scores.shape == im_scores.shape
+    assert tq_indices.shape == im_ids.shape
+    # effective_k should be min(k=5, n_vectors=3) = 3.
+    assert tq_scores.shape == (0, 3)
+
+
+def test_search_query_dim_mismatch_raises_value_error():
+    idx = IdMapIndex(dim=128, bit_width=4)
+    idx.add_with_ids(unit_vectors(3, 128), np.array([1, 2, 3], dtype=np.uint64))
+    wrong = unit_vectors(1, 64)
+    with pytest.raises(ValueError, match="query dim"):
+        idx.search(wrong, k=1)
+
+
+def test_add_with_ids_noncontiguous_vectors_raises_value_error():
+    idx = IdMapIndex(dim=128, bit_width=4)
+    full = unit_vectors(2, 256)
+    sliced = full[:, ::2]
+    assert not sliced.flags["C_CONTIGUOUS"]
+    with pytest.raises(ValueError, match="contiguous"):
+        idx.add_with_ids(sliced, np.array([1, 2], dtype=np.uint64))
+
+
+def test_add_with_ids_rejects_nan_with_value_error():
+    idx = IdMapIndex(dim=64, bit_width=4)
+    data = unit_vectors(1, 64).copy()
+    data[0, 5] = np.nan
+    with pytest.raises(ValueError, match="invalid input value"):
+        idx.add_with_ids(data, np.array([1], dtype=np.uint64))

--- a/turbovec-python/tests/test_index.py
+++ b/turbovec-python/tests/test_index.py
@@ -190,3 +190,83 @@ def test_search_on_empty_eager_index_returns_zero_effective_k():
     scores, indices = idx.search(q, k=3)
     assert scores.shape == (1, 0)
     assert indices.shape == (1, 0)
+
+
+# ---- Wave 5: typed-exception hygiene at the binding layer ----
+
+def test_add_noncontiguous_vectors_raises_value_error():
+    # A non-C-contiguous numpy view used to surface as a Rust panic via
+    # `as_slice().expect("vectors must be contiguous")`. The binding now
+    # converts that to a clean ValueError pointing at the caller-side
+    # fix (`np.ascontiguousarray`).
+    idx = TurboQuantIndex(dim=128, bit_width=4)
+    full = unit_vectors(4, 256)  # 256 cols
+    sliced = full[:, ::2]  # take every other column → non-contiguous, 128 cols
+    assert not sliced.flags["C_CONTIGUOUS"]
+    with pytest.raises(ValueError, match="contiguous"):
+        idx.add(sliced)
+
+
+def test_search_query_dim_mismatch_raises_value_error():
+    # A query with the wrong number of columns previously panicked
+    # inside the core's `assert_eq!(queries.len(), nq * dim)` — pyo3
+    # surfaces that as a PanicException, not the ValueError users
+    # naturally try to catch. The binding now validates ncols against
+    # the index dim before forwarding.
+    idx = TurboQuantIndex(dim=128, bit_width=4)
+    idx.add(unit_vectors(5, 128))
+    wrong_dim_query = unit_vectors(1, 64)
+    with pytest.raises(ValueError, match="query dim"):
+        idx.search(wrong_dim_query, k=1)
+
+
+def test_search_noncontiguous_query_raises_value_error():
+    idx = TurboQuantIndex(dim=128, bit_width=4)
+    idx.add(unit_vectors(3, 128))
+    full = unit_vectors(2, 256)
+    sliced = full[:, ::2]
+    assert not sliced.flags["C_CONTIGUOUS"]
+    with pytest.raises(ValueError, match="contiguous"):
+        idx.search(sliced, k=1)
+
+
+def test_swap_remove_out_of_bounds_raises_index_error():
+    # Previously panicked in core's `assert!(idx < n_vectors)`. The
+    # binding now raises a clean IndexError before the inner call.
+    idx = TurboQuantIndex(dim=128, bit_width=4)
+    idx.add(unit_vectors(3, 128))
+    with pytest.raises(IndexError, match="out of range"):
+        idx.swap_remove(99)
+
+
+# ---- Wave 5: input validation surfaces from the Rust core ----
+
+def test_add_rejects_nan_with_value_error():
+    # The Rust core's `AddError::InvalidInputValue` is mapped through
+    # the binding's `add_2d` Result → PyValueError path.
+    idx = TurboQuantIndex(dim=64, bit_width=4)
+    data = unit_vectors(1, 64).copy()
+    data[0, 5] = np.nan
+    with pytest.raises(ValueError, match="invalid input value"):
+        idx.add(data)
+
+
+def test_add_rejects_huge_magnitude_with_value_error():
+    idx = TurboQuantIndex(dim=64, bit_width=4)
+    data = unit_vectors(1, 64).copy()
+    data[0, 5] = 1e20
+    with pytest.raises(ValueError, match="invalid input value"):
+        idx.add(data)
+
+
+def test_search_with_nan_query_raises():
+    # NaN in the query reaches the core via search_with_mask, which
+    # now panics with a clear message; pyo3 maps Rust panics to
+    # PanicException → BaseException, so the test catches broadly but
+    # asserts on the message substring.
+    idx = TurboQuantIndex(dim=64, bit_width=4)
+    idx.add(unit_vectors(3, 64))
+    q = unit_vectors(1, 64).copy()
+    q[0, 0] = np.nan
+    with pytest.raises(BaseException, match="invalid query value"):
+        idx.search(q, k=1)

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -88,6 +88,110 @@ def test_similarity_search_callable_filter_receives_document_id():
     assert {r.id for r in results} == {"keep-1", "keep-2"}
 
 
+# ---- Reference-parity tests against InMemoryVectorStore. Each pins a
+# behaviour the langchain-core in-tree suite tests; the bug class is
+# "drop-in regression that only shows up when users compare against
+# InMemoryVectorStore". ----
+
+def test_async_methods_await_aembed_functions():
+    # If our async paths silently fall back to sync embedding, callers
+    # with a real async embedder (e.g. OpenAI async client) end up
+    # blocking the event loop. AsyncMock makes the side-effect visible:
+    # if aembed_documents / aembed_query weren't awaited, await_count
+    # stays zero.
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    class AsyncStub(StubEmbeddings):
+        def __init__(self, dim: int = 64) -> None:
+            super().__init__(dim)
+            self.aembed_documents = AsyncMock(
+                side_effect=lambda texts: [self._embed(t) for t in texts]
+            )
+            self.aembed_query = AsyncMock(
+                side_effect=lambda text: self._embed(text)
+            )
+
+    emb = AsyncStub(dim=64)
+    store = TurboQuantVectorStore(embedding=emb)
+
+    async def run() -> None:
+        await store.aadd_texts(["a", "b"])
+        await store.asimilarity_search("a", k=1)
+
+    asyncio.run(run())
+
+    assert emb.aembed_documents.await_count >= 1
+    assert emb.aembed_query.await_count >= 1
+
+
+def test_add_documents_upsert_replaces_metadata():
+    # Re-adding a Document with the same id and new metadata must let
+    # the new metadata win — not silently retain the old one. Reference
+    # `InMemoryVectorStore.add_documents` overwrites on duplicate id.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts([], emb, bit_width=4)
+    store.add_documents([Document(id="x", page_content="v1", metadata={"tag": "old"})])
+    store.add_documents([Document(id="x", page_content="v2", metadata={"tag": "new"})])
+
+    [doc] = store.get_by_ids(["x"])
+    assert doc.metadata == {"tag": "new"}
+    assert doc.page_content == "v2"
+
+
+def test_add_documents_does_not_mutate_inputs():
+    # Caller-passed Documents must not be mutated by add_documents — no
+    # in-place .id assignment, no metadata mutation. Reference behaviour;
+    # easy regression target when refactoring the add path.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts([], emb, bit_width=4)
+    docs = [
+        Document(page_content="a", metadata={"k": 1}),
+        Document(id="explicit", page_content="b", metadata={"k": 2}),
+    ]
+    original_meta_ids = [id(d.metadata) for d in docs]
+    store.add_documents(docs)
+
+    assert docs[0].id is None
+    assert docs[1].id == "explicit"
+    assert docs[0].metadata == {"k": 1}
+    assert docs[1].metadata == {"k": 2}
+    # Same dict objects — we didn't replace caller-provided metadata dicts.
+    assert [id(d.metadata) for d in docs] == original_meta_ids
+
+
+def test_add_documents_with_ids_is_idempotent():
+    # Re-running ingestion on an unchanged corpus must not accrete
+    # duplicates. Reference upserts on same id; size stays constant.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts([], emb, bit_width=4)
+    docs = [
+        Document(id="a", page_content="hello"),
+        Document(id="b", page_content="world"),
+    ]
+    store.add_documents(docs)
+    store.add_documents(docs)
+
+    assert len(store._docs) == 2
+    assert set(store._docs.keys()) == {"a", "b"}
+
+
+def test_get_by_ids_empty_input_and_order_preserved():
+    # Two contract points the reference makes that our existing tests
+    # don't pin: (1) empty input returns [] without erroring; (2) output
+    # is in the order of input ids so callers can zip with parallel
+    # arrays (e.g. scores from a separate retriever).
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["a", "b", "c"], emb, bit_width=4, ids=["id-a", "id-b", "id-c"]
+    )
+
+    assert store.get_by_ids([]) == []
+
+    docs = store.get_by_ids(["id-c", "id-a", "id-b"])
+    assert [d.id for d in docs] == ["id-c", "id-a", "id-b"]
+
+
 def test_similarity_search_with_dict_filter():
     emb = StubEmbeddings(dim=64)
     store = TurboQuantVectorStore.from_texts(

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -645,3 +645,70 @@ def test_dump_and_load_empty_store(tmp_path):
     assert loaded.similarity_search("anything", k=1) == []
     loaded.add_texts(["new"])
     assert loaded._index.dim == 64
+
+
+# ---- Tier-2 field-completeness tests. Each pins a value that a future
+# refactor could silently drop (the #81 family: populated but
+# unasserted). ----
+
+def test_similarity_search_with_score_returns_descending_scores_and_self_match():
+    # Pins the actual semantics of the float in (Document, float) — that
+    # it's a real similarity score, that the self-match wins, and that
+    # results are monotonically non-increasing. Without this, the tuple
+    # position 1 could silently regress to a constant or get swapped
+    # with `handle` and only `isinstance(score, float)` would still pass.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["alpha", "beta", "gamma"], emb, bit_width=4
+    )
+    scored = store.similarity_search_with_score("alpha", k=3)
+    assert scored[0][0].page_content == "alpha"
+    scores = [s for _, s in scored]
+    assert all(a >= b for a, b in zip(scores, scores[1:]))
+
+
+def test_load_then_add_assigns_fresh_handles_without_collision(tmp_path):
+    # `_next_u64` is persisted across dump/load; if it were silently
+    # dropped (back to 0 on load), a fresh add would reuse a handle
+    # that's still mapped to an old doc, corrupting search results.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["a", "b", "c"], emb, bit_width=4, ids=["id-a", "id-b", "id-c"]
+    )
+    store.dump(tmp_path)
+    loaded = TurboQuantVectorStore.load(tmp_path, emb)
+    loaded.add_texts(["d"], ids=["id-d"])
+
+    # All four ids reachable; all four handles distinct.
+    docs = loaded.get_by_ids(["id-a", "id-b", "id-c", "id-d"])
+    assert [d.id for d in docs] == ["id-a", "id-b", "id-c", "id-d"]
+    handles = list(loaded._str_to_u64.values())
+    assert len(set(handles)) == len(handles)
+
+
+def test_embeddings_property_returns_supplied_embedder():
+    # Pins the `embeddings` property override. A refactor dropping it
+    # would silently make the base class return None, breaking
+    # `similarity_search_with_relevance_scores` discovery and some
+    # retriever wiring.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore(emb)
+    assert store.embeddings is emb
+
+
+def test_aget_by_ids_preserves_order_and_returns_documents_with_id():
+    # Async mirror of `test_get_by_ids_empty_input_and_order_preserved`.
+    import asyncio
+
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["a", "b", "c"], emb, bit_width=4, ids=["id-a", "id-b", "id-c"]
+    )
+
+    async def run() -> list[Document]:
+        empty = await store.aget_by_ids([])
+        assert empty == []
+        return await store.aget_by_ids(["id-c", "id-a", "id-b"])
+
+    docs = asyncio.run(run())
+    assert [d.id for d in docs] == ["id-c", "id-a", "id-b"]

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -55,6 +55,39 @@ def test_similarity_search_returns_documents():
     assert all(isinstance(r, Document) for r in results)
 
 
+def test_similarity_search_results_carry_document_id():
+    # Returned Documents must have `.id` populated — both the explicit ids
+    # callers pass to `add_texts` and the UUIDs the store generates by
+    # default. Matches the InMemoryVectorStore reference behaviour and what
+    # downstream LangChain callers (retrievers, chains) expect.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["a", "b", "c"], emb, bit_width=4, ids=["id-a", "id-b", "id-c"]
+    )
+
+    results = store.similarity_search("a", k=3)
+    assert {r.id for r in results} == {"id-a", "id-b", "id-c"}
+
+    scored = store.similarity_search_with_score("a", k=3)
+    assert {doc.id for doc, _ in scored} == {"id-a", "id-b", "id-c"}
+
+    by_vec = store.similarity_search_by_vector(emb._embed("a"), k=3)
+    assert {r.id for r in by_vec} == {"id-a", "id-b", "id-c"}
+
+
+def test_similarity_search_callable_filter_receives_document_id():
+    # Predicate Document must carry `.id` so callers can filter on it,
+    # not just on page_content / metadata.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["a", "b", "c"], emb, bit_width=4, ids=["keep-1", "drop", "keep-2"]
+    )
+    results = store.similarity_search(
+        "a", k=10, filter=lambda doc: doc.id.startswith("keep")
+    )
+    assert {r.id for r in results} == {"keep-1", "keep-2"}
+
+
 def test_similarity_search_with_dict_filter():
     emb = StubEmbeddings(dim=64)
     store = TurboQuantVectorStore.from_texts(

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -439,7 +439,46 @@ def test_query_ne_filter_treats_missing_key_as_no_match():
     assert result.nodes[0].metadata.get("tier") == "free"
 
 
-def test_query_text_match_is_case_insensitive():
+def test_query_text_match_is_case_sensitive():
+    # Matches the reference (`utils.py:138-144`): TEXT_MATCH is a case-
+    # SENSITIVE substring check. An earlier turbovec impl lowercased both
+    # sides — we no longer do that (TEXT_MATCH_INSENSITIVE is the
+    # opt-in case-folding variant; see below).
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [
+        _make_node("a", seed=0, metadata={"title": "The Lord of the Rings"}),
+        _make_node("b", seed=1, metadata={"title": "Lord of Light"}),
+        _make_node("c", seed=2, metadata={"title": "The Hobbit"}),
+    ]
+    store.add(nodes)
+
+    # Case-correct query: matches the two "Lord" titles.
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="title", value="Lord", operator=FilterOperator.TEXT_MATCH)
+        ]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    titles = {n.metadata["title"] for n in store.query(q).nodes}
+    assert titles == {"The Lord of the Rings", "Lord of Light"}
+
+    # Wrong-case query: no match (used to match under the lowercasing bug).
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="title", value="LORD", operator=FilterOperator.TEXT_MATCH)
+        ]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    assert store.query(q).nodes == []
+
+
+def test_query_text_match_insensitive_folds_case():
+    # TEXT_MATCH_INSENSITIVE is the explicit opt-in for case-folding,
+    # matching `utils.py:145-151`.
     store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
     nodes = [
         _make_node("a", seed=0, metadata={"title": "The Lord of the Rings"}),
@@ -449,28 +488,97 @@ def test_query_text_match_is_case_insensitive():
     store.add(nodes)
     filters = MetadataFilters(
         filters=[
-            MetadataFilter(key="title", value="LORD", operator=FilterOperator.TEXT_MATCH)
+            MetadataFilter(
+                key="title",
+                value="LORD",
+                operator=FilterOperator.TEXT_MATCH_INSENSITIVE,
+            )
         ]
     )
     q = VectorStoreQuery(
         query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
     )
-    result = store.query(q)
-    titles = {n.metadata["title"] for n in result.nodes}
+    titles = {n.metadata["title"] for n in store.query(q).nodes}
     assert titles == {"The Lord of the Rings", "Lord of Light"}
 
 
-def test_query_unsupported_filter_operator_raises():
-    store = _store_with_tiered_nodes()
-    # ANY is intentionally not in our supported list.
+def test_query_text_match_raises_type_error_on_non_string_operands():
+    # Reference rejects non-string operands with a TypeError so the caller
+    # can't silently fall through to string-coerced behaviour.
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([_make_node("a", seed=0, metadata={"page": 7})])
     filters = MetadataFilters(
-        filters=[MetadataFilter(key="tier", value=["pro"], operator=FilterOperator.ANY)]
+        filters=[
+            MetadataFilter(key="page", value="7", operator=FilterOperator.TEXT_MATCH)
+        ]
     )
     q = VectorStoreQuery(
-        query_embedding=_unit_vec(0, 64), similarity_top_k=3, filters=filters
+        query_embedding=_unit_vec(0, 64), similarity_top_k=1, filters=filters
     )
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(TypeError, match="TEXT_MATCH"):
         store.query(q)
+
+
+def test_query_all_operator_matches_set_subset():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [
+        _make_node("a", seed=0, metadata={"tags": ["python", "rust", "go"]}),
+        _make_node("b", seed=1, metadata={"tags": ["python", "rust"]}),
+        _make_node("c", seed=2, metadata={"tags": ["python"]}),
+    ]
+    store.add(nodes)
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(
+                key="tags", value=["python", "rust"], operator=FilterOperator.ALL
+            )
+        ]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    contents = {n.get_content() for n in store.query(q).nodes}
+    assert contents == {"a", "b"}
+
+
+def test_query_any_operator_matches_set_intersection():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [
+        _make_node("a", seed=0, metadata={"tags": ["python"]}),
+        _make_node("b", seed=1, metadata={"tags": ["rust"]}),
+        _make_node("c", seed=2, metadata={"tags": ["go"]}),
+    ]
+    store.add(nodes)
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(
+                key="tags", value=["python", "rust"], operator=FilterOperator.ANY
+            )
+        ]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    contents = {n.get_content() for n in store.query(q).nodes}
+    assert contents == {"a", "b"}
+
+
+def test_query_filter_condition_not_negates_inner_match():
+    # Reference (`utils.py:187-189`): NOT matches when NONE of the inner
+    # filters match. With a single inner EQ filter, NOT is just negation.
+    store = _store_with_tiered_nodes()
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="tier", value="pro", operator=FilterOperator.EQ)
+        ],
+        condition=FilterCondition.NOT,
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    tiers = {n.metadata["tier"] for n in store.query(q).nodes}
+    assert "pro" not in tiers
+    assert tiers == {"free", "enterprise"}
 
 
 # ------------------- Tier 1: protocol completeness -----------------------
@@ -698,3 +806,221 @@ def test_storage_context_persist_and_load_roundtrip(tmp_path):
     retriever = index.as_retriever(similarity_top_k=2)
     results = retriever.retrieve("one")
     assert len(results) == 2
+
+
+# ---- Full-node fidelity round-trip (covers the langchain-class bug
+# pattern at the structural level: every field SimpleVectorStore would
+# preserve through write -> query / get_nodes / persist+load must come
+# back populated, not a bare {id, text, metadata} TextNode shell). ----
+
+def _make_rich_node(
+    text: str,
+    seed: int,
+    *,
+    node_id: str | None = None,
+    metadata: dict | None = None,
+    excluded_embed_metadata_keys: list[str] | None = None,
+    excluded_llm_metadata_keys: list[str] | None = None,
+    relationships: dict | None = None,
+    start_char_idx: int | None = None,
+    end_char_idx: int | None = None,
+    metadata_template: str | None = None,
+    metadata_separator: str | None = None,
+    text_template: str | None = None,
+    mimetype: str | None = None,
+) -> TextNode:
+    """A TextNode with every framework field set to a non-default value so
+    we can assert each one survives the write -> retrieve round-trip."""
+    kwargs: dict = {
+        "text": text,
+        "metadata": metadata or {},
+        "embedding": _unit_vec(seed, 64),
+        "excluded_embed_metadata_keys": excluded_embed_metadata_keys or [],
+        "excluded_llm_metadata_keys": excluded_llm_metadata_keys or [],
+        "relationships": relationships or {},
+    }
+    if node_id is not None:
+        kwargs["id_"] = node_id
+    if start_char_idx is not None:
+        kwargs["start_char_idx"] = start_char_idx
+    if end_char_idx is not None:
+        kwargs["end_char_idx"] = end_char_idx
+    if metadata_template is not None:
+        kwargs["metadata_template"] = metadata_template
+    if metadata_separator is not None:
+        kwargs["metadata_separator"] = metadata_separator
+    if text_template is not None:
+        kwargs["text_template"] = text_template
+    if mimetype is not None:
+        kwargs["mimetype"] = mimetype
+    return TextNode(**kwargs)
+
+
+def test_query_returns_node_with_full_field_fidelity():
+    # Every field SimpleVectorStore preserves through query must survive
+    # turbovec's write -> query round-trip. The previous narrow side-car
+    # schema lost relationships (PREVIOUS/NEXT/PARENT/CHILD),
+    # excluded_*_metadata_keys, template fields, char_idx, and mimetype.
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    node = _make_rich_node(
+        "chunk text",
+        seed=1,
+        node_id="node-rich-1",
+        metadata={"page": 7, "section": "intro"},
+        excluded_embed_metadata_keys=["section"],
+        excluded_llm_metadata_keys=["page"],
+        relationships={
+            NodeRelationship.SOURCE: RelatedNodeInfo(node_id="doc-1"),
+            NodeRelationship.PREVIOUS: RelatedNodeInfo(node_id="node-prev"),
+            NodeRelationship.NEXT: RelatedNodeInfo(node_id="node-next"),
+            NodeRelationship.PARENT: RelatedNodeInfo(node_id="node-parent"),
+        },
+        start_char_idx=100,
+        end_char_idx=200,
+        metadata_template="<<{key}::{value}>>",
+        metadata_separator=" | ",
+        text_template="META:{metadata_str}\nBODY:{content}",
+        mimetype="text/markdown",
+    )
+    store.add([node])
+
+    result = store.query(
+        VectorStoreQuery(query_embedding=_unit_vec(1, 64), similarity_top_k=1)
+    )
+    [returned] = result.nodes
+
+    assert returned.node_id == "node-rich-1"
+    assert returned.get_content() == "chunk text"
+    assert returned.metadata == {"page": 7, "section": "intro"}
+    assert returned.excluded_embed_metadata_keys == ["section"]
+    assert returned.excluded_llm_metadata_keys == ["page"]
+    assert returned.start_char_idx == 100
+    assert returned.end_char_idx == 200
+    assert returned.metadata_template == "<<{key}::{value}>>"
+    assert returned.metadata_separator == " | "
+    assert returned.text_template == "META:{metadata_str}\nBODY:{content}"
+    assert returned.mimetype == "text/markdown"
+    # All four relationships should be present, not just SOURCE.
+    assert returned.relationships[NodeRelationship.SOURCE].node_id == "doc-1"
+    assert returned.relationships[NodeRelationship.PREVIOUS].node_id == "node-prev"
+    assert returned.relationships[NodeRelationship.NEXT].node_id == "node-next"
+    assert returned.relationships[NodeRelationship.PARENT].node_id == "node-parent"
+
+
+def test_get_nodes_returns_full_field_fidelity():
+    # Same fidelity contract for get_nodes (not just query).
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    node = _make_rich_node(
+        "chunk",
+        seed=2,
+        node_id="g-1",
+        metadata={"k": "v"},
+        excluded_embed_metadata_keys=["k"],
+        relationships={
+            NodeRelationship.SOURCE: RelatedNodeInfo(node_id="doc"),
+            NodeRelationship.NEXT: RelatedNodeInfo(node_id="g-2"),
+        },
+        start_char_idx=0,
+        end_char_idx=5,
+        mimetype="application/json",
+    )
+    store.add([node])
+
+    [fetched] = store.get_nodes(node_ids=["g-1"])
+    assert fetched.relationships[NodeRelationship.NEXT].node_id == "g-2"
+    assert fetched.excluded_embed_metadata_keys == ["k"]
+    assert fetched.mimetype == "application/json"
+    assert fetched.start_char_idx == 0
+    assert fetched.end_char_idx == 5
+
+
+def test_persist_round_trip_preserves_full_node_fidelity(tmp_path):
+    # Save + load should not be lossier than query — the on-disk schema
+    # must carry the full _node_content blob (v2+).
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    node = _make_rich_node(
+        "persisted chunk",
+        seed=3,
+        node_id="p-1",
+        metadata={"k": "v"},
+        relationships={
+            NodeRelationship.SOURCE: RelatedNodeInfo(node_id="doc"),
+            NodeRelationship.PREVIOUS: RelatedNodeInfo(node_id="p-0"),
+        },
+        excluded_llm_metadata_keys=["k"],
+        text_template="T:{content}",
+    )
+    store.add([node])
+    persist_path = tmp_path / "store.json"
+    store.persist(str(persist_path))
+
+    loaded = TurboQuantVectorStore.from_persist_path(str(persist_path))
+    [restored] = loaded.get_nodes(node_ids=["p-1"])
+    assert restored.relationships[NodeRelationship.PREVIOUS].node_id == "p-0"
+    assert restored.excluded_llm_metadata_keys == ["k"]
+    assert restored.text_template == "T:{content}"
+
+
+def test_persist_v1_schema_still_loads_with_narrow_fidelity(tmp_path):
+    # A nodes.json written by an older turbovec (schema_version=1, narrow
+    # `{text, metadata, ref_doc_id}` per entry) must still load — relationships
+    # other than SOURCE will be missing (the data wasn't there), but the
+    # text + metadata + SOURCE relationship round-trip as they always did.
+    import json
+
+    # Build a v1-shaped side-car by hand. We still need the binary index
+    # file alongside it, so write a v2 store first and overwrite just
+    # the JSON.
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    node = TextNode(
+        id_="v1-node",
+        text="legacy text",
+        metadata={"k": "v"},
+        embedding=_unit_vec(0, 64),
+        relationships={
+            NodeRelationship.SOURCE: RelatedNodeInfo(node_id="legacy-doc"),
+        },
+    )
+    store.add([node])
+    persist_path = tmp_path / "store.json"
+    store.persist(str(persist_path))
+
+    nodes_path = persist_path.with_suffix(".nodes.json")
+    with open(nodes_path) as f:
+        state = json.load(f)
+    state["schema_version"] = 1
+    # Rewrite each entry in the v1 shape: {text, metadata, ref_doc_id} only.
+    state["nodes"] = {
+        nid: {
+            "text": "legacy text",
+            "metadata": {"k": "v"},
+            "ref_doc_id": "legacy-doc",
+        }
+        for nid in state["nodes"]
+    }
+    with open(nodes_path, "w") as f:
+        json.dump(state, f)
+
+    loaded = TurboQuantVectorStore.from_persist_path(str(persist_path))
+    [restored] = loaded.get_nodes(node_ids=["v1-node"])
+    assert restored.get_content() == "legacy text"
+    assert restored.metadata == {"k": "v"}
+    assert restored.ref_doc_id == "legacy-doc"
+
+
+def test_query_rejects_non_default_mode():
+    # MMR / SVM / hybrid all need full-precision vectors which turbovec
+    # discards. Raise loudly instead of silently treating as DEFAULT
+    # (which the previous impl did, masking that the requested mode
+    # wasn't honoured).
+    from llama_index.core.vector_stores.types import VectorStoreQueryMode
+
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([_make_node("a", seed=0)])
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64),
+        similarity_top_k=1,
+        mode=VectorStoreQueryMode.MMR,
+    )
+    with pytest.raises(NotImplementedError, match="query mode"):
+        store.query(q)

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -1158,3 +1158,99 @@ def test_query_rejects_non_default_mode():
     )
     with pytest.raises(NotImplementedError, match="query mode"):
         store.query(q)
+
+
+# ---- Tier-2 field-completeness tests. ----
+
+def test_add_raises_on_intra_batch_duplicate_node_id():
+    # If a single add() call contains two nodes with the same node_id,
+    # the prior impl would leave the index with both vectors but only
+    # the last node_id mapped back to one — orphaning the first handle
+    # and silently returning the second node's payload attached to the
+    # first node's vector on later queries. Now raises loudly.
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    n1 = TextNode(id_="dup", text="first", embedding=_unit_vec(1, 64))
+    n2 = TextNode(id_="dup", text="second", embedding=_unit_vec(2, 64))
+    with pytest.raises(ValueError, match="duplicate node_id"):
+        store.add([n1, n2])
+    # And the store is left in a clean state — no half-written index.
+    assert len(store._index) == 0
+    assert store._nodes == {}
+
+
+def test_query_round_trips_image_node_subtype():
+    # PR #83 covered TextNode field fidelity exhaustively, but every
+    # test uses TextNode. node_to_metadata_dict / metadata_dict_to_node
+    # also handle ImageNode — pin that explicitly so a regression in
+    # the helper dispatch (or a switch back to bare TextNode
+    # reconstruction) gets caught.
+    from llama_index.core.schema import ImageNode
+
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    image_node = ImageNode(
+        id_="img-1",
+        text="caption",
+        image_url="https://example.com/img.png",
+        image_mimetype="image/png",
+        embedding=_unit_vec(1, 64),
+        metadata={"source": "test"},
+    )
+    store.add([image_node])
+
+    result = store.query(
+        VectorStoreQuery(query_embedding=_unit_vec(1, 64), similarity_top_k=1)
+    )
+    [returned] = result.nodes
+    assert isinstance(returned, ImageNode)
+    assert returned.id_ == "img-1"
+    assert returned.image_url == "https://example.com/img.png"
+    assert returned.image_mimetype == "image/png"
+    assert returned.metadata == {"source": "test"}
+
+
+def test_query_round_trips_index_node_subtype():
+    # Same fidelity check for IndexNode (used by composable indexes /
+    # routers / sub-question pipelines).
+    from llama_index.core.schema import IndexNode
+
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    index_node = IndexNode(
+        id_="idx-1",
+        text="sub-index pointer",
+        index_id="child-index-uuid",
+        embedding=_unit_vec(1, 64),
+        metadata={"router": "yes"},
+    )
+    store.add([index_node])
+
+    result = store.query(
+        VectorStoreQuery(query_embedding=_unit_vec(1, 64), similarity_top_k=1)
+    )
+    [returned] = result.nodes
+    assert isinstance(returned, IndexNode)
+    assert returned.id_ == "idx-1"
+    assert returned.index_id == "child-index-uuid"
+    assert returned.metadata == {"router": "yes"}
+
+
+def test_query_returned_node_always_has_none_embedding():
+    # turbovec discards full-precision embeddings after quantization.
+    # `get()` raises NotImplementedError to communicate this; `query`
+    # and `get_nodes` honour the same contract by returning nodes with
+    # `embedding=None` even when the input node had an embedding set.
+    # Pin this so a future refactor doesn't silently start round-
+    # tripping the raw float list and contradict the `get()` story.
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([
+        _make_node("a", seed=1, metadata={"k": "v"}),
+        _make_node("b", seed=2, metadata={"k": "w"}),
+    ])
+
+    qresult = store.query(
+        VectorStoreQuery(query_embedding=_unit_vec(1, 64), similarity_top_k=2)
+    )
+    for node in qresult.nodes:
+        assert node.embedding is None
+
+    for node in store.get_nodes():
+        assert node.embedding is None

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -563,6 +563,140 @@ def test_query_any_operator_matches_set_intersection():
     assert contents == {"a", "b"}
 
 
+def test_query_is_empty_treats_missing_key_as_match():
+    # Reference (`utils.py:168-173`): IS_EMPTY matches when the key is
+    # absent OR the value is empty string / empty list. Trickiest branch
+    # because it's the only operator where a missing key is a hit.
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([
+        _make_node("a", seed=0, metadata={"note": "x"}),
+        _make_node("b", seed=1, metadata={}),
+        _make_node("c", seed=2, metadata={"note": ""}),
+        _make_node("d", seed=3, metadata={"note": []}),
+    ])
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="note", value=None, operator=FilterOperator.IS_EMPTY)]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    contents = {n.get_content() for n in store.query(q).nodes}
+    # All three "empty-ish" rows match; the populated one does not.
+    assert contents == {"b", "c", "d"}
+
+
+def test_query_contains_operator_matches_list_membership():
+    # CONTAINS — the canonical "scalar value in list-valued metadata"
+    # predicate. Distinct from ALL/ANY (which take list-valued targets).
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([
+        _make_node("a", seed=0, metadata={"tags": ["python", "rust"]}),
+        _make_node("b", seed=1, metadata={"tags": ["go"]}),
+        _make_node("c", seed=2, metadata={"tags": ["python"]}),
+    ])
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="tags", value="python", operator=FilterOperator.CONTAINS)]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    contents = {n.get_content() for n in store.query(q).nodes}
+    assert contents == {"a", "c"}
+
+
+def _store_with_scored_nodes() -> TurboQuantVectorStore:
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([
+        _make_node(f"doc-{i}", seed=i, metadata={"score": i})
+        for i in range(5)
+    ])
+    return store
+
+
+def test_query_with_lt_filter():
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="score", value=2, operator=FilterOperator.LT)]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    scores = {n.metadata["score"] for n in _store_with_scored_nodes().query(q).nodes}
+    assert scores == {0, 1}
+
+
+def test_query_with_lte_filter():
+    # Boundary case: LTE must include the threshold value (where LT excludes it).
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="score", value=2, operator=FilterOperator.LTE)]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    scores = {n.metadata["score"] for n in _store_with_scored_nodes().query(q).nodes}
+    assert scores == {0, 1, 2}
+
+
+def test_query_with_gte_filter():
+    # Boundary case: GTE must include the threshold value (where GT excludes it).
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="score", value=3, operator=FilterOperator.GTE)]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    scores = {n.metadata["score"] for n in _store_with_scored_nodes().query(q).nodes}
+    assert scores == {3, 4}
+
+
+def test_query_with_nin_filter():
+    # NIN — values NOT in the supplied list. Distinct branch from IN.
+    store = _store_with_tiered_nodes()
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="tier", value=["pro"], operator=FilterOperator.NIN)]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    tiers = {n.metadata["tier"] for n in store.query(q).nodes}
+    assert tiers == {"free", "enterprise"}
+
+
+def test_query_contradictive_same_key_and_returns_empty():
+    # Two EQ filters on the same key with different values, joined by
+    # AND, must return zero matches. Confirms AND is genuinely
+    # conjunctive over same-key duplicates rather than accidentally
+    # last-wins / OR.
+    store = _store_with_tiered_nodes()
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="tier", value="pro", operator=FilterOperator.EQ),
+            MetadataFilter(key="tier", value="free", operator=FilterOperator.EQ),
+        ],
+        condition=FilterCondition.AND,
+    )
+    q = VectorStoreQuery(
+        query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
+    )
+    assert store.query(q).nodes == []
+
+
+def test_query_returns_results_sorted_by_similarity():
+    # Top-1 of a self-query (query embedding == one of the stored
+    # embeddings) must be that exact node. Quantization noise is small
+    # enough that the self-match wins, and this is the only guard
+    # against a regression that returns hits in insertion order.
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [_make_node(f"doc-{i}", seed=i) for i in range(5)]
+    ids = store.add(nodes)
+    # Query with the embedding of node index 3.
+    q = VectorStoreQuery(query_embedding=_unit_vec(3, 64), similarity_top_k=5)
+    result = store.query(q)
+    assert result.ids[0] == ids[3]
+    # Similarities must be monotonically non-increasing (top-k contract).
+    sims = result.similarities
+    assert all(a >= b for a, b in zip(sims, sims[1:]))
+
+
 def test_query_filter_condition_not_negates_inner_match():
     # Reference (`utils.py:187-189`): NOT matches when NONE of the inner
     # filters match. With a single inner EQ filter, NOT is just negation.

--- a/turbovec/src/error.rs
+++ b/turbovec/src/error.rs
@@ -89,10 +89,6 @@ impl fmt::Display for AddError {
 
 impl Error for AddError {}
 
-// AddError is constructed via PartialEq derive. Manual impl needed
-// because of the `f32` field on InvalidInputValue (which would
-// otherwise force the derive to require Eq, blocking PartialEq).
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConstructError {
     /// `bit_width` must be 2, 3, or 4.

--- a/turbovec/src/error.rs
+++ b/turbovec/src/error.rs
@@ -20,7 +20,10 @@
 use std::error::Error;
 use std::fmt;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+// Eq dropped from the derive because `InvalidInputValue` carries an f32,
+// which is not `Eq` (NaN != NaN). PartialEq still works for the
+// finite-input cases tests assert against.
+#[derive(Debug, Clone, PartialEq)]
 pub enum AddError {
     /// Batch dim does not match the index's already-locked dim.
     DimMismatch { existing: usize, got: usize },
@@ -36,6 +39,20 @@ pub enum AddError {
 
     /// External id was already present in the index.
     IdAlreadyPresent(u64),
+
+    /// A coordinate in the input vectors is not finite (NaN, +Inf, -Inf)
+    /// or has magnitude `>= 1e16`. Either silently corrupts the index:
+    ///   - NaN/Inf: poisons the per-vector scale via `0 * NaN = NaN`,
+    ///     making the slot exist in `len()` but never reachable through
+    ///     `search`.
+    ///   - Huge magnitude: overflows the f32 sum-of-squares in the norm
+    ///     computation to `+Inf`, so `scale[i] = Inf` and the slot
+    ///     incorrectly wins top-k against every query.
+    InvalidInputValue {
+        vector_index: usize,
+        coord_index: usize,
+        value: f32,
+    },
 }
 
 impl fmt::Display for AddError {
@@ -57,11 +74,24 @@ impl fmt::Display for AddError {
             Self::IdAlreadyPresent(id) => {
                 write!(f, "id {id} already present in index")
             }
+            Self::InvalidInputValue {
+                vector_index,
+                coord_index,
+                value,
+            } => write!(
+                f,
+                "invalid input value at vector {vector_index}, coord {coord_index}: {value} \
+                 (must be finite and |value| < 1e16 to avoid f32 norm overflow)",
+            ),
         }
     }
 }
 
 impl Error for AddError {}
+
+// AddError is constructed via PartialEq derive. Manual impl needed
+// because of the `f32` field on InvalidInputValue (which would
+// otherwise force the derive to require Eq, blocking PartialEq).
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConstructError {

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -135,16 +135,23 @@ impl IdMapIndex {
             }
         }
 
+        // Capture the slot the first new vector will occupy BEFORE we
+        // touch the inner index, then run the inner add first. If `add_2d`
+        // returns Err (e.g. DimMismatch on a committed-dim index) the ID
+        // tables stay untouched — otherwise we'd leave `n` ghost entries
+        // pointing at slots that don't exist in the inner index, and the
+        // next search_with_allowlist / remove would corrupt further.
+        let base_slot = self.inner.len();
+        self.inner.add_2d(vectors, dim)?;
+
         self.id_to_slot.reserve(n);
         self.slot_to_id.reserve(n);
-
-        let base_slot = self.inner.len();
         for (i, &id) in ids.iter().enumerate() {
             self.id_to_slot.insert(id, base_slot + i);
         }
         self.slot_to_id.extend_from_slice(ids);
 
-        self.inner.add_2d(vectors, dim)
+        Ok(())
     }
 
     /// Remove the vector with the given external id.

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -7,10 +7,10 @@
 //! vectors by a stable `u64` ID that doesn't change when other vectors
 //! are inserted or removed.
 //!
-//! Roughly analogous to FAISS's `IndexIDMap2` (hash-table backed). The
-//! wrapper delegates all vector storage, rotation, scoring and
-//! serialization questions to the inner [`TurboQuantIndex`] and only
-//! owns the ID table.
+//! A bidirectional hash-table-backed `u64 ↔ slot` mapping layered over
+//! the inner [`TurboQuantIndex`]. The wrapper delegates all vector
+//! storage, rotation, scoring and serialization questions to the inner
+//! index and only owns the ID table.
 //!
 //! ```no_run
 //! use turbovec::IdMapIndex;

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -204,12 +204,20 @@ impl TurboQuantIndex {
     }
 
     /// Add a flat batch of vectors. `dim` must be set (either eagerly at
-    /// construction or by a prior [`Self::add_2d`] call). Panics otherwise.
+    /// construction or by a prior [`Self::add_2d`] call).
     ///
-    /// Panics if any coordinate is non-finite (NaN, +Inf, -Inf) or has
-    /// magnitude `>= 1e16`. Callers handling untrusted input should
-    /// prefer [`Self::add_2d`], which returns a typed
-    /// [`AddError::InvalidInputValue`] instead.
+    /// `vectors.len()` must be a multiple of `dim`; an empty input is a
+    /// no-op.
+    ///
+    /// # Panics
+    ///
+    /// - If `dim` is not set (call [`Self::new_lazy`] then [`Self::add_2d`]
+    ///   instead).
+    /// - If `vectors.len()` is not a multiple of `dim`.
+    /// - If any coordinate is non-finite (NaN, +Inf, -Inf) or has
+    ///   magnitude `>= 1e16`. Callers handling untrusted input should
+    ///   prefer [`Self::add_2d`], which returns a typed
+    ///   [`AddError::InvalidInputValue`] instead.
     pub fn add(&mut self, vectors: &[f32]) {
         let dim = self.dim.expect(
             "TurboQuantIndex dim is not set; use add_2d(vectors, dim) on the \
@@ -221,6 +229,17 @@ impl TurboQuantIndex {
             n * dim,
             "vectors length must be a multiple of dim"
         );
+        // Empty add is a true no-op — return before touching calibration
+        // or caches. Previously, an empty first add hit the
+        // `n < TQPLUS_MIN_SAMPLES` branch in `encode`, returned identity
+        // calibration, and locked `tqplus_shift` to that identity for the
+        // lifetime of the index. Every subsequent add — even a million
+        // vectors — then saw `Some(identity)` and silently skipped
+        // fitting fresh calibration. The user lost TQ+ entirely with no
+        // warning.
+        if n == 0 {
+            return;
+        }
         if let Some((vi, ci, v)) = first_invalid_coord(vectors, dim) {
             panic!(
                 "invalid input value at vector {vi}, coord {ci}: {v} \
@@ -290,9 +309,19 @@ impl TurboQuantIndex {
     /// Python binding receiving a 2D numpy array) should use, since a
     /// flat `&[f32]` alone is ambiguous about its shape.
     ///
-    /// Returns [`AddError::DimMismatch`] if `dim` does not match the
-    /// already-locked dim, and [`AddError::DimNotMultipleOf8`] when
-    /// committing a lazy index to a dim that is not a multiple of 8.
+    /// Returns:
+    /// - [`AddError::DimMismatch`] if `dim` does not match the
+    ///   already-locked dim.
+    /// - [`AddError::DimNotMultipleOf8`] when committing a lazy index
+    ///   to a dim that is not a multiple of 8.
+    /// - [`AddError::InvalidInputValue`] if any coordinate is non-finite
+    ///   or has magnitude `>= 1e16`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `vectors.len()` is not a multiple of `dim`. (This
+    /// indicates a caller-side bug rather than recoverable bad data, so
+    /// it isn't returned as a typed error.)
     pub fn add_2d(&mut self, vectors: &[f32], dim: usize) -> Result<(), AddError> {
         match self.dim {
             Some(existing) if existing != dim => {
@@ -336,6 +365,13 @@ impl TurboQuantIndex {
     /// Call [`TurboQuantIndex::prepare`] once after `add`/`load` to
     /// pay that cost up front if you want deterministic first-query
     /// latency.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `queries.len()` is not a multiple of `dim`, or if any
+    /// query coordinate is non-finite (NaN, +Inf, -Inf) or has
+    /// magnitude `>= 1e16`. Validate untrusted input at the caller
+    /// (e.g. the Python binding raises `ValueError`).
     pub fn search(&self, queries: &[f32], k: usize) -> SearchResults {
         self.search_with_mask(queries, k, None)
     }
@@ -348,6 +384,12 @@ impl TurboQuantIndex {
     /// `n_allowed` is the number of `true` entries in `mask`.
     ///
     /// Passing `mask = None` is equivalent to [`Self::search`].
+    ///
+    /// # Panics
+    ///
+    /// - If `mask.len() != self.len()` (when `mask` is `Some`).
+    /// - If `queries.len()` is not a multiple of `dim`.
+    /// - If any query coordinate is non-finite or has magnitude `>= 1e16`.
     pub fn search_with_mask(
         &self,
         queries: &[f32],
@@ -508,6 +550,28 @@ impl TurboQuantIndex {
         tqplus_shift: Vec<f32>,
         tqplus_scale: Vec<f32>,
     ) -> Self {
+        // v2 files (pre-TQ+) load with empty TQ+ vectors and a positive
+        // n_vectors. If we leave `tqplus_shift` empty, the next `add()`
+        // would see `existing = None` (the lazy-first-add signal),
+        // call `encode()` with `existing = None`, get a fresh fitted
+        // calibration back — and then silently drop it because
+        // `n_vectors != 0` takes the else branch that only extends
+        // `packed_codes` / `scales`. The new vectors would be encoded
+        // with that fitted calibration but searched against identity,
+        // producing silently-wrong scores.
+        //
+        // Populate explicit identity here so the "is the calibration
+        // committed?" check always agrees with the actual state of the
+        // stored vectors.
+        let (tqplus_shift, tqplus_scale) = if tqplus_shift.is_empty() && n_vectors > 0 {
+            let d = dim.expect(
+                "from_parts: n_vectors > 0 implies a committed dim — \
+                 mismatch indicates a corrupted side-car or a misuse",
+            );
+            (vec![0.0; d], vec![1.0; d])
+        } else {
+            (tqplus_shift, tqplus_scale)
+        };
         Self {
             dim,
             bit_width,

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -53,6 +53,36 @@ const ROTATION_SEED: u64 = 42;
 const BLOCK: usize = 32;
 const FLUSH_EVERY: usize = 256;
 
+/// Maximum permitted coordinate magnitude. Beyond this, f32 sum-of-
+/// squares in the norm computation can overflow to +Inf for any
+/// reasonable dim (sqrt(f32::MAX / dim) for dim=2^16 is ~7e16; this
+/// bound leaves a 7x safety margin and is still ~16 orders of
+/// magnitude above any realistic embedding value).
+const MAX_INPUT_MAGNITUDE: f32 = 1e16;
+
+/// Reject non-finite (NaN, +Inf, -Inf) or extremely-large input values.
+/// Returns the first offending vector/coord/value tuple, or `None` if
+/// the input is clean.
+///
+/// Called from `add` / `add_2d` / `search` / `search_with_mask`. Without
+/// this check the encode pipeline silently corrupts the index:
+///   - NaN: `0 * NaN = NaN` poisons `vec_scales[slot]`, so the slot
+///     exists in `len()` but is never reachable through search.
+///   - Inf: same path via `1/Inf = 0`.
+///   - Huge magnitude: `simd_norm`'s f32 sum-of-squares overflows to
+///     +Inf, `scale[i] = Inf` gets stored, slot incorrectly wins
+///     top-k against every query.
+fn first_invalid_coord(values: &[f32], dim: usize) -> Option<(usize, usize, f32)> {
+    for (i, x) in values.iter().enumerate() {
+        if !x.is_finite() || x.abs() >= MAX_INPUT_MAGNITUDE {
+            let vector_index = if dim == 0 { 0 } else { i / dim };
+            let coord_index = if dim == 0 { i } else { i % dim };
+            return Some((vector_index, coord_index, *x));
+        }
+    }
+    None
+}
+
 /// SIMD-blocked cache derived from `packed_codes`.
 ///
 /// Materialised lazily by [`TurboQuantIndex::search`] on first call
@@ -175,6 +205,11 @@ impl TurboQuantIndex {
 
     /// Add a flat batch of vectors. `dim` must be set (either eagerly at
     /// construction or by a prior [`Self::add_2d`] call). Panics otherwise.
+    ///
+    /// Panics if any coordinate is non-finite (NaN, +Inf, -Inf) or has
+    /// magnitude `>= 1e16`. Callers handling untrusted input should
+    /// prefer [`Self::add_2d`], which returns a typed
+    /// [`AddError::InvalidInputValue`] instead.
     pub fn add(&mut self, vectors: &[f32]) {
         let dim = self.dim.expect(
             "TurboQuantIndex dim is not set; use add_2d(vectors, dim) on the \
@@ -186,6 +221,12 @@ impl TurboQuantIndex {
             n * dim,
             "vectors length must be a multiple of dim"
         );
+        if let Some((vi, ci, v)) = first_invalid_coord(vectors, dim) {
+            panic!(
+                "invalid input value at vector {vi}, coord {ci}: {v} \
+                 (must be finite and |value| < 1e16 to avoid f32 norm overflow)",
+            );
+        }
 
         let rotation = self
             .rotation
@@ -262,8 +303,23 @@ impl TurboQuantIndex {
                 if dim % 8 != 0 {
                     return Err(AddError::DimNotMultipleOf8(dim));
                 }
-                self.dim = Some(dim);
+                // Don't commit dim until value validation passes — otherwise
+                // a lazy index is left with a committed dim and no vectors,
+                // which would let a follow-up wrong-dim add see a confusing
+                // DimMismatch instead of a fresh start.
             }
+        }
+        if let Some((vi, ci, v)) = first_invalid_coord(vectors, dim) {
+            return Err(AddError::InvalidInputValue {
+                vector_index: vi,
+                coord_index: ci,
+                value: v,
+            });
+        }
+        // Lazy commit happens via add() (which goes through `self.dim.expect`),
+        // so re-do the dim assignment here for the lazy-first-add case.
+        if self.dim.is_none() {
+            self.dim = Some(dim);
         }
         self.add(vectors);
         Ok(())
@@ -312,6 +368,16 @@ impl TurboQuantIndex {
         };
         let nq = queries.len() / dim;
         assert_eq!(queries.len(), nq * dim);
+        // Reject non-finite / huge-magnitude queries. Same rationale as
+        // `add`: NaN / Inf / overflow-magnitude values poison the SIMD
+        // scoring kernel and produce arbitrary indices with NaN scores,
+        // silently rather than as a typed error.
+        if let Some((vi, ci, v)) = first_invalid_coord(queries, dim) {
+            panic!(
+                "invalid query value at query {vi}, coord {ci}: {v} \
+                 (must be finite and |value| < 1e16 to avoid f32 overflow)",
+            );
+        }
 
         let rotation = self
             .rotation

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -550,6 +550,63 @@ impl TurboQuantIndex {
         tqplus_shift: Vec<f32>,
         tqplus_scale: Vec<f32>,
     ) -> Self {
+        // Structural invariants every caller must uphold. `from_parts` is
+        // pub(crate); today the only callers are `io::load` and
+        // `id_map::load`, both of which validate at the read layer — but
+        // pinning the invariants here makes future callers (and refactors
+        // of the existing ones) safe by construction.
+        assert_eq!(
+            tqplus_shift.len(),
+            tqplus_scale.len(),
+            "from_parts: tqplus_shift.len()={} != tqplus_scale.len()={}",
+            tqplus_shift.len(),
+            tqplus_scale.len(),
+        );
+        match dim {
+            Some(d) => {
+                let expected_packed = n_vectors * d * bit_width / 8;
+                assert_eq!(
+                    packed_codes.len(),
+                    expected_packed,
+                    "from_parts: packed_codes.len()={} != n_vectors({}) * dim({}) * bit_width({}) / 8 = {}",
+                    packed_codes.len(),
+                    n_vectors,
+                    d,
+                    bit_width,
+                    expected_packed,
+                );
+                assert_eq!(
+                    scales.len(),
+                    n_vectors,
+                    "from_parts: scales.len()={} != n_vectors={}",
+                    scales.len(),
+                    n_vectors,
+                );
+                if !tqplus_shift.is_empty() {
+                    assert_eq!(
+                        tqplus_shift.len(),
+                        d,
+                        "from_parts: non-empty TQ+ length {} must equal dim {}",
+                        tqplus_shift.len(),
+                        d,
+                    );
+                }
+            }
+            None => {
+                // Lazy uncommitted state — every storage field must be empty.
+                assert_eq!(n_vectors, 0, "from_parts: lazy index must have n_vectors=0");
+                assert!(
+                    packed_codes.is_empty(),
+                    "from_parts: lazy index must have empty packed_codes",
+                );
+                assert!(scales.is_empty(), "from_parts: lazy index must have empty scales");
+                assert!(
+                    tqplus_shift.is_empty(),
+                    "from_parts: lazy index must have empty tqplus_shift",
+                );
+            }
+        }
+
         // v2 files (pre-TQ+) load with empty TQ+ vectors and a positive
         // n_vectors. If we leave `tqplus_shift` empty, the next `add()`
         // would see `existing = None` (the lazy-first-add signal),
@@ -673,5 +730,123 @@ impl TurboQuantIndex {
 
     pub fn bit_width(&self) -> usize {
         self.bit_width
+    }
+}
+
+#[cfg(test)]
+mod from_parts_tests {
+    //! Unit tests for `TurboQuantIndex::from_parts` length-invariant
+    //! checks. `from_parts` is `pub(crate)`, so these live inside the
+    //! crate; the assertions catch any future caller (or refactor of
+    //! the existing `io::load` callers) that hands in a malformed
+    //! tuple of fields.
+
+    use super::TurboQuantIndex;
+
+    #[test]
+    #[should_panic(expected = "packed_codes.len()")]
+    fn from_parts_panics_on_packed_codes_length_mismatch() {
+        // Expected packed_codes length for dim=64, bit_width=4, n=2 is
+        // 2 * 64 * 4 / 8 = 64 bytes. Pass 32 to trigger the assert.
+        let _ = TurboQuantIndex::from_parts(
+            Some(64),
+            4,
+            2,
+            vec![0u8; 32],
+            vec![1.0f32; 2],
+            Vec::new(),
+            Vec::new(),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "scales.len()")]
+    fn from_parts_panics_on_scales_length_mismatch() {
+        let _ = TurboQuantIndex::from_parts(
+            Some(64),
+            4,
+            2,
+            vec![0u8; 64],
+            vec![1.0f32; 5],  // n_vectors says 2; scales has 5
+            Vec::new(),
+            Vec::new(),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "tqplus_shift.len()")]
+    fn from_parts_panics_on_mismatched_tqplus_lengths() {
+        let _ = TurboQuantIndex::from_parts(
+            Some(64),
+            4,
+            2,
+            vec![0u8; 64],
+            vec![1.0f32; 2],
+            vec![0.0f32; 64],   // length 64
+            vec![1.0f32; 32],   // length 32 — mismatch
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "non-empty TQ+ length")]
+    fn from_parts_panics_when_tqplus_length_does_not_equal_dim() {
+        let _ = TurboQuantIndex::from_parts(
+            Some(64),
+            4,
+            2,
+            vec![0u8; 64],
+            vec![1.0f32; 2],
+            vec![0.0f32; 48],   // length 48 != dim 64
+            vec![1.0f32; 48],
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "lazy index must have n_vectors=0")]
+    fn from_parts_panics_on_lazy_with_nonzero_n_vectors() {
+        let _ = TurboQuantIndex::from_parts(
+            None,
+            4,
+            5,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+    }
+
+    #[test]
+    fn from_parts_accepts_lazy_uncommitted() {
+        // Lazy + everything empty + n_vectors=0 is the canonical lazy
+        // state the constructor must accept.
+        let idx = TurboQuantIndex::from_parts(
+            None,
+            4,
+            0,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        assert_eq!(idx.dim_opt(), None);
+        assert_eq!(idx.len(), 0);
+    }
+
+    #[test]
+    fn from_parts_accepts_eager_with_consistent_lengths() {
+        // dim=64, bit_width=4, n=2 → packed=64 bytes, scales=2.
+        // Empty TQ+ vectors are valid input (v2-loaded shape); the
+        // identity-population logic fills them in below.
+        let idx = TurboQuantIndex::from_parts(
+            Some(64),
+            4,
+            2,
+            vec![0u8; 64],
+            vec![1.0f32; 2],
+            Vec::new(),
+            Vec::new(),
+        );
+        assert_eq!(idx.dim(), 64);
+        assert_eq!(idx.len(), 2);
     }
 }

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -1334,6 +1334,88 @@ pub(crate) fn block_pair_has_allowed(mask: Option<&[u64]>, base_vec_pair: usize)
     }
 }
 
+/// Per-query scalar scoring writing into caller-provided heap arrays.
+/// Used by the non-x86_64 / non-aarch64 scalar fallback at the bottom
+/// of `search`, AND as the x86_64 fallback inside the SIMD-dispatch
+/// `unsafe` block when neither AVX-512 BW nor AVX2 is detected at
+/// runtime (e.g. running a turbovec binary built without the cargo
+/// config's `target-cpu=x86-64-v3` on a pre-Haswell CPU, or under a
+/// VM / emulator that doesn't expose AVX2 to userspace). Without this
+/// fallback, pre-AVX2 x86_64 silently returned empty top-k results
+/// instead of falling back to a slower-but-correct kernel.
+#[allow(clippy::too_many_arguments)]
+fn score_query_into_heap(
+    qlut_uint8: &[u8],
+    qlut_scale: f32,
+    qlut_bias: f32,
+    blocked_codes: &[u8],
+    vec_scales: &[f32],
+    n_byte_groups: usize,
+    n_vectors: usize,
+    n_blocks: usize,
+    mask: Option<&[u64]>,
+    k: usize,
+    heap_s: &mut [f32],
+    heap_i: &mut [u32],
+    heap_sz: &mut usize,
+    heap_min: &mut f32,
+    heap_mi: &mut usize,
+) {
+    for b in 0..n_blocks {
+        let base_vec = b * BLOCK;
+        if !block_has_allowed(mask, base_vec) {
+            continue;
+        }
+        let block_offset = b * n_byte_groups * BLOCK;
+        for lane in 0..BLOCK {
+            let vi = base_vec + lane;
+            if vi >= n_vectors {
+                break;
+            }
+            if let Some(m) = mask {
+                if !mask_allows(m, vi) {
+                    continue;
+                }
+            }
+            let mut score = qlut_bias;
+            for g in 0..n_byte_groups {
+                let byte_val = blocked_codes[block_offset + g * BLOCK + lane] as usize;
+                let hi = byte_val >> 4;
+                let lo = byte_val & 0x0F;
+                score += qlut_scale * qlut_uint8[g * 32 + hi] as f32;
+                score += qlut_scale * qlut_uint8[g * 32 + 16 + lo] as f32;
+            }
+            score *= vec_scales[vi];
+            if *heap_sz < k {
+                heap_s[*heap_sz] = score;
+                heap_i[*heap_sz] = vi as u32;
+                *heap_sz += 1;
+                if *heap_sz == k {
+                    *heap_min = heap_s[0];
+                    *heap_mi = 0;
+                    for h in 1..k {
+                        if heap_s[h] < *heap_min {
+                            *heap_min = heap_s[h];
+                            *heap_mi = h;
+                        }
+                    }
+                }
+            } else if score > *heap_min {
+                heap_s[*heap_mi] = score;
+                heap_i[*heap_mi] = vi as u32;
+                *heap_min = heap_s[0];
+                *heap_mi = 0;
+                for h in 1..k {
+                    if heap_s[h] < *heap_min {
+                        *heap_min = heap_s[h];
+                        *heap_mi = h;
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Apply TQ+ per-coord (shift, scale) calibration to a batch of rotated
 /// queries. Returns the calibrated queries and a per-query bias correction
 /// (the search kernel folds this into the per-query bias). When the index
@@ -1639,6 +1721,32 @@ pub fn search(
                             &mut heap_scores, &mut heap_indices,
                             &mut heap_sizes, &mut heap_mins, &mut heap_min_idxs,
                         );
+                    } else {
+                        // Neither AVX-512 BW nor AVX2 detected at runtime on
+                        // this x86_64 CPU. Previously this fell through to
+                        // an empty `unsafe { }` block and `heap_sizes` stayed
+                        // at 0 — `search` then returned empty top-k results
+                        // for every query with no error signal. Fall back to
+                        // per-query scalar scoring instead.
+                        for qo in 0..batch_nq {
+                            score_query_into_heap(
+                                lut_refs[qo],
+                                scale_vals[qo],
+                                bias_vals[qo],
+                                blocked_codes,
+                                vec_scales,
+                                n_byte_groups,
+                                n_vectors,
+                                n_blocks,
+                                mask,
+                                k,
+                                &mut heap_scores[qo],
+                                &mut heap_indices[qo],
+                                &mut heap_sizes[qo],
+                                &mut heap_mins[qo],
+                                &mut heap_min_idxs[qo],
+                            );
+                        }
                     }
                 }
 
@@ -1662,7 +1770,7 @@ pub fn search(
 
     #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
     let results = {
-        // Scalar fallback for other architectures
+        // Scalar fallback for architectures without a SIMD kernel.
         let results: Vec<(Vec<f32>, Vec<i64>)> = (0..nq)
             .into_par_iter()
             .map(|qi| {
@@ -1672,43 +1780,23 @@ pub fn search(
                 let mut heap_sz = 0usize;
                 let mut heap_min = f32::NEG_INFINITY;
                 let mut heap_mi = 0usize;
-
-                for b in 0..n_blocks {
-                    let base_vec = b * BLOCK;
-                    if !block_has_allowed(mask, base_vec) {
-                        continue;
-                    }
-                    let block_offset = b * n_byte_groups * BLOCK;
-                    for lane in 0..BLOCK {
-                        let vi = base_vec + lane;
-                        if vi >= n_vectors { break; }
-                        if let Some(m) = mask {
-                            if !mask_allows(m, vi) { continue; }
-                        }
-                        // Total bias is applied once; per-sub-table zero-points
-                        // are already folded into qlut.bias at LUT build time.
-                        let mut score = qlut.bias;
-                        for g in 0..n_byte_groups {
-                            let byte_val = blocked_codes[block_offset + g * BLOCK + lane] as usize;
-                            let hi = byte_val >> 4;
-                            let lo = byte_val & 0x0F;
-                            score += qlut.scale * qlut.uint8_luts[g * 32 + hi] as f32;
-                            score += qlut.scale * qlut.uint8_luts[g * 32 + 16 + lo] as f32;
-                        }
-                        score *= vec_scales[vi];
-                        if heap_sz < k {
-                            heap_s[heap_sz] = score; heap_i[heap_sz] = vi as u32; heap_sz += 1;
-                            if heap_sz == k {
-                                heap_min = heap_s[0]; heap_mi = 0;
-                                for h in 1..k { if heap_s[h] < heap_min { heap_min = heap_s[h]; heap_mi = h; } }
-                            }
-                        } else if score > heap_min {
-                            heap_s[heap_mi] = score; heap_i[heap_mi] = vi as u32;
-                            heap_min = heap_s[0]; heap_mi = 0;
-                            for h in 1..k { if heap_s[h] < heap_min { heap_min = heap_s[h]; heap_mi = h; } }
-                        }
-                    }
-                }
+                score_query_into_heap(
+                    &qlut.uint8_luts,
+                    qlut.scale,
+                    qlut.bias,
+                    blocked_codes,
+                    vec_scales,
+                    n_byte_groups,
+                    n_vectors,
+                    n_blocks,
+                    mask,
+                    k,
+                    &mut heap_s,
+                    &mut heap_i,
+                    &mut heap_sz,
+                    &mut heap_min,
+                    &mut heap_mi,
+                );
                 let mut pairs: Vec<(f32, u32)> = heap_s[..heap_sz].iter()
                     .zip(heap_i[..heap_sz].iter()).map(|(&s, &i)| (s, i)).collect();
                 pairs.sort_unstable_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));

--- a/turbovec/tests/concurrent_search.rs
+++ b/turbovec/tests/concurrent_search.rs
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 use std::thread;
 
-use turbovec::TurboQuantIndex;
+use turbovec::{IdMapIndex, TurboQuantIndex};
 
 /// Deterministic pseudo-random vector generator so the tests are
 /// reproducible without pulling an extra dev-dependency.
@@ -189,5 +189,124 @@ fn write_load_preserves_concurrent_search_results() {
             after.indices_for_query(qi),
             "roundtrip changed top-k for query {qi}"
         );
+    }
+}
+
+#[test]
+fn concurrent_search_after_load_is_safe() {
+    // The docstring on the `Concurrent search` section explicitly
+    // mentions `load` as a `prepare()`-skip target. A loaded index
+    // starts with empty OnceLock caches (same shape as a freshly-built
+    // one), so the race window is identical — but no test exercised it.
+    let index = build_index();
+    let tmp = std::env::temp_dir().join(format!(
+        "turbovec_concurrent_after_load_{}.tv",
+        std::process::id()
+    ));
+    index.write(&tmp).expect("write");
+    let loaded = Arc::new(TurboQuantIndex::load(&tmp).expect("load"));
+    let _ = std::fs::remove_file(&tmp);
+
+    let queries = make_vectors(3, loaded.dim(), 0xC0C0_5EE1);
+    let k = 8;
+    let reference: Vec<Vec<i64>> = {
+        let r = loaded.search(&queries, k);
+        (0..r.nq).map(|qi| r.indices_for_query(qi).to_vec()).collect()
+    };
+
+    let n_threads = 16;
+    let mut handles = Vec::with_capacity(n_threads);
+    for _ in 0..n_threads {
+        let idx = Arc::clone(&loaded);
+        let qs = queries.clone();
+        handles.push(thread::spawn(move || {
+            let r = idx.search(&qs, k);
+            (0..r.nq)
+                .map(|qi| r.indices_for_query(qi).to_vec())
+                .collect::<Vec<_>>()
+        }));
+    }
+    for h in handles {
+        let result = h.join().unwrap();
+        assert_eq!(result, reference);
+    }
+}
+
+#[test]
+fn id_map_concurrent_search_is_deterministic_across_threads() {
+    // `IdMapIndex::search` takes `&self` and delegates to the inner
+    // index's `&self` search plus a Vec/HashMap read. Previously zero
+    // test coverage at this layer — pin the contract.
+    let dim = 256;
+    let n = 512;
+    let vectors = make_vectors(n, dim, 0xCAFE_F00D);
+    let ids: Vec<u64> = (0..n as u64).collect();
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
+    idx.add_with_ids(&vectors, &ids).unwrap();
+    let idx = Arc::new(idx);
+
+    idx.prepare();
+
+    let queries = make_vectors(4, dim, 0xDEAD_BEEF);
+    let k = 10;
+    let (ref_scores, ref_ids) = idx.search(&queries, k);
+
+    let n_threads = 16;
+    let mut handles = Vec::with_capacity(n_threads);
+    for _ in 0..n_threads {
+        let idx = Arc::clone(&idx);
+        let qs = queries.clone();
+        handles.push(thread::spawn(move || idx.search(&qs, k)));
+    }
+    for h in handles {
+        let (s, i) = h.join().unwrap();
+        assert_eq!(s, ref_scores);
+        assert_eq!(i, ref_ids);
+    }
+}
+
+#[test]
+fn concurrent_prepare_races_with_search_safely() {
+    // Several threads call `prepare()` while others run `search()` on
+    // a fresh index. OnceLock guarantees `get_or_init` runs the closure
+    // exactly once; pin that every search observes consistent state.
+    let queries = make_vectors(2, 256, 0xFAB1_E5);
+    let k = 5;
+
+    let reference_index = build_index();
+    reference_index.prepare();
+    let reference: Vec<Vec<i64>> = {
+        let r = reference_index.search(&queries, k);
+        (0..r.nq).map(|qi| r.indices_for_query(qi).to_vec()).collect()
+    };
+
+    // Fresh copy so the lazy-init race actually exists.
+    let race_index = Arc::new(build_index());
+    let n_prep = 4;
+    let n_search = 8;
+    let mut handles = Vec::with_capacity(n_prep + n_search);
+    for _ in 0..n_prep {
+        let idx = Arc::clone(&race_index);
+        handles.push(thread::spawn(move || {
+            idx.prepare();
+            None
+        }));
+    }
+    for _ in 0..n_search {
+        let idx = Arc::clone(&race_index);
+        let qs = queries.clone();
+        handles.push(thread::spawn(move || {
+            let r = idx.search(&qs, k);
+            Some(
+                (0..r.nq)
+                    .map(|qi| r.indices_for_query(qi).to_vec())
+                    .collect::<Vec<_>>(),
+            )
+        }));
+    }
+    for h in handles {
+        if let Some(result) = h.join().unwrap() {
+            assert_eq!(result, reference);
+        }
     }
 }

--- a/turbovec/tests/encode.rs
+++ b/turbovec/tests/encode.rs
@@ -25,6 +25,27 @@ fn make_vectors(n: usize, dim: usize, seed: u64) -> Vec<f32> {
 }
 
 #[test]
+fn produces_expected_shape_for_bit_width_three() {
+    // 3-bit is its own pack-layout branch (3 planes per row instead of
+    // 2 or 4 per byte). The parametrised `produces_expected_shape` test
+    // only covers 2 and 4 — pin 3 explicitly so a regression in the
+    // 3-bit packing path doesn't slip through.
+    let dim = 128;
+    let n = 17;
+    let rotation = make_rotation_matrix(dim);
+    let (boundaries, centroids) = codebook(3, dim);
+    let vectors = make_vectors(n, dim, 0);
+
+    let (packed, scales, _, _) = encode(
+        &vectors, n, dim, &rotation, &boundaries, &centroids, 3, None,
+    );
+
+    let bytes_per_row = 3 * (dim / 8);
+    assert_eq!(packed.len(), n * bytes_per_row);
+    assert_eq!(scales.len(), n);
+}
+
+#[test]
 fn produces_expected_shape() {
     for &bit_width in &[2usize, 4] {
         let dim = 128;

--- a/turbovec/tests/id_map.rs
+++ b/turbovec/tests/id_map.rs
@@ -246,6 +246,177 @@ fn load_rejects_wrong_magic() {
 }
 
 #[test]
+fn add_with_ids_2d_rolls_back_id_tables_on_inner_dim_mismatch() {
+    // Regression test for an audit-found bug: `add_with_ids_2d` used to
+    // mutate `id_to_slot` / `slot_to_id` BEFORE calling `inner.add_2d`.
+    // If the inner call returned `Err(DimMismatch)` (e.g. caller passed
+    // wrong dim on a committed-dim index), the ID tables retained `n`
+    // ghost entries pointing at slots that don't exist in the inner
+    // index — subsequent `search_with_allowlist` would read those
+    // ghosts and corrupt further.
+    let dim = 128;
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
+    let initial = gaussian_normalized(3, dim, 0xA11D_0DE0);
+    idx.add_with_ids_2d(&initial, dim, &[10, 20, 30]).unwrap();
+    assert_eq!(idx.len(), 3);
+
+    // Now try to add with the wrong dim — must return DimMismatch and
+    // leave ID tables untouched.
+    let wrong = gaussian_normalized(2, 64, 0xA11D_0DE1);
+    let err = idx.add_with_ids_2d(&wrong, 64, &[40, 50]).unwrap_err();
+    assert_eq!(
+        err,
+        turbovec::AddError::DimMismatch {
+            existing: dim,
+            got: 64,
+        },
+    );
+
+    // ID tables must be untouched — len is still 3, the ids 40/50 must
+    // NOT be present (the bug would have left them as ghosts).
+    assert_eq!(idx.len(), 3);
+    assert!(!idx.contains(40));
+    assert!(!idx.contains(50));
+    // Original ids still resolve correctly.
+    assert!(idx.contains(10));
+    assert!(idx.contains(20));
+    assert!(idx.contains(30));
+
+    // And a subsequent correctly-dim'd add still works (no leftover
+    // ghost entries blocking the slots or colliding with the new ids).
+    let extra = gaussian_normalized(2, dim, 0xA11D_0DE2);
+    idx.add_with_ids_2d(&extra, dim, &[40, 50]).unwrap();
+    assert_eq!(idx.len(), 5);
+    assert!(idx.contains(40));
+    assert!(idx.contains(50));
+}
+
+
+// ---- IdMapIndex audit-driven coverage ----
+
+#[test]
+fn add_with_ids_2d_rejects_non_multiple_buffer() {
+    // VectorBufferNotMultipleOfDim — reachable only via `add_with_ids_2d`
+    // (the non-2d entry point panics earlier on the same condition).
+    let mut idx = IdMapIndex::new_lazy(4).unwrap();
+    // 17 floats with dim=8 → 17 % 8 != 0.
+    let err = idx
+        .add_with_ids_2d(&vec![0.0f32; 17], 8, &[1, 2])
+        .unwrap_err();
+    assert!(
+        matches!(err, turbovec::AddError::VectorBufferNotMultipleOfDim { .. }),
+        "expected VectorBufferNotMultipleOfDim, got {err:?}",
+    );
+}
+
+#[test]
+fn add_with_ids_2d_rejects_zero_dim() {
+    // Same error variant, dim=0 sub-branch.
+    let mut idx = IdMapIndex::new_lazy(4).unwrap();
+    let err = idx.add_with_ids_2d(&[], 0, &[]).unwrap_err();
+    assert!(
+        matches!(err, turbovec::AddError::VectorBufferNotMultipleOfDim { .. }),
+        "expected VectorBufferNotMultipleOfDim, got {err:?}",
+    );
+}
+
+#[test]
+fn search_returns_descending_scores_aligned_with_ids() {
+    // Pins (1) scores are returned non-empty, (2) length matches ids,
+    // (3) sorted descending — none of which is asserted in the existing
+    // suite. Same #81-shape regression risk.
+    let dim = 128;
+    let data = gaussian_normalized(20, dim, 0xA11D_5001);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
+    let ids: Vec<u64> = (0..20).map(|i| i as u64 + 1).collect();
+    idx.add_with_ids(&data, &ids).unwrap();
+
+    let q = &data[0..dim];
+    let (scores, got_ids) = idx.search(q, 5);
+
+    assert_eq!(scores.len(), 5);
+    assert_eq!(scores.len(), got_ids.len());
+    assert!(scores.iter().all(|s| s.is_finite()));
+    for w in scores.windows(2) {
+        assert!(w[0] >= w[1], "scores not in descending order: {scores:?}");
+    }
+}
+
+#[test]
+fn search_multi_query_results_are_row_major() {
+    // The docstring promises row-major flattening: result i's results
+    // live in qi*k..(qi+1)*k. All existing IdMap tests use single
+    // queries; multi-query layout is unverified at this layer.
+    let dim = 128;
+    let data = gaussian_normalized(20, dim, 0xA11D_5002);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
+    let ids: Vec<u64> = (0..20).map(|i| i as u64 + 1).collect();
+    idx.add_with_ids(&data, &ids).unwrap();
+
+    // Build two queries: vec0 and vec5. Each should self-match top-1.
+    let k = 3;
+    let mut queries = Vec::with_capacity(2 * dim);
+    queries.extend_from_slice(&data[0..dim]);
+    queries.extend_from_slice(&data[5 * dim..6 * dim]);
+
+    let (scores, got_ids) = idx.search(&queries, k);
+    assert_eq!(scores.len(), 2 * k);
+    assert_eq!(got_ids.len(), 2 * k);
+    // Query 0's results live in indices 0..k; query 1's in k..2k.
+    assert_eq!(got_ids[0], ids[0], "query 0 top-1 should be id of vec 0");
+    assert_eq!(got_ids[k], ids[5], "query 1 top-1 should be id of vec 5");
+}
+
+#[test]
+fn remove_keeps_swapped_id_addressable_in_both_tables() {
+    // After remove(target), the id that was at the last slot moves into
+    // target's slot. Pin that the moved id is still reachable via search
+    // AND via `contains` — i.e. both `slot_to_id` and `id_to_slot`
+    // stayed consistent. A bug updating only one table could mask
+    // itself in self-query and only show up here.
+    let dim = 128;
+    let data = gaussian_normalized(5, dim, 0xA11D_5003);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
+    let ids = [101u64, 202, 303, 404, 505];
+    idx.add_with_ids(&data, &ids).unwrap();
+
+    // Remove the second slot; the last slot's id (505) swaps into slot 1.
+    assert!(idx.remove(202));
+
+    // Both tables must reflect the swap: contains() and search() agree.
+    assert!(idx.contains(505));
+    let q = &data[4 * dim..5 * dim];  // the vector that used to be at slot 4
+    let (_, got_ids) = idx.search(q, 1);
+    assert_eq!(got_ids[0], 505);
+    // The moved id is now at slot 1, and the original slot-1 vector
+    // (id=202) is gone.
+    assert!(!idx.contains(202));
+}
+
+#[test]
+fn prepare_does_not_change_search_results() {
+    // `prepare` is documented as eagerly populating caches; calling it
+    // before search must not change the result.
+    let dim = 128;
+    let data = gaussian_normalized(10, dim, 0xA11D_5004);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
+    let ids: Vec<u64> = (0..10).collect();
+    idx.add_with_ids(&data, &ids).unwrap();
+
+    let q = &data[3 * dim..4 * dim];
+    let (s_before, ids_before) = idx.search(q, 5);
+
+    // Fresh index, same data, but prepare() first.
+    let mut idx2 = IdMapIndex::new(dim, 4).unwrap();
+    idx2.add_with_ids(&data, &ids).unwrap();
+    idx2.prepare();
+    let (s_after, ids_after) = idx2.search(q, 5);
+
+    assert_eq!(ids_before, ids_after);
+    assert_eq!(s_before, s_after);
+}
+
+#[test]
 fn empty_index_round_trip() {
     let dim = 128;
     let idx = IdMapIndex::new(dim, 4).unwrap();

--- a/turbovec/tests/input_validation.rs
+++ b/turbovec/tests/input_validation.rs
@@ -1,0 +1,235 @@
+//! Input-validation tests for `TurboQuantIndex` and `IdMapIndex`.
+//!
+//! Before the validation was added, the encode pipeline silently
+//! corrupted the index on degenerate inputs:
+//!   - NaN coord poisoned `vec_scales[slot]` via `0 * NaN = NaN`,
+//!     so the slot existed in `len()` but was unreachable through
+//!     `search`.
+//!   - +/-Inf coord followed the same NaN-poisoning path.
+//!   - Magnitude `>= 1e16` overflowed the f32 sum-of-squares in the
+//!     norm computation, storing `scale[i] = Inf` and incorrectly
+//!     ranking the slot at the top of every query.
+//!   - NaN/Inf query value produced arbitrary indices with NaN scores
+//!     because the heap's `s > heap_min` comparison is false for NaN.
+//!
+//! These tests pin the typed-error behaviour on the `_2d` paths and
+//! the panic behaviour on the flat / search paths.
+
+use turbovec::{AddError, IdMapIndex, TurboQuantIndex};
+
+const DIM: usize = 64;
+
+fn ok_vector() -> Vec<f32> {
+    let mut v = vec![0.0f32; DIM];
+    v[0] = 1.0;
+    v
+}
+
+// ---- TurboQuantIndex::add_2d returns typed error on bad input ----
+
+#[test]
+fn add_2d_rejects_nan_with_invalid_input_value_error() {
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    let mut data = ok_vector();
+    data[5] = f32::NAN;
+    let err = idx.add_2d(&data, DIM).unwrap_err();
+    match err {
+        AddError::InvalidInputValue {
+            vector_index,
+            coord_index,
+            value,
+        } => {
+            assert_eq!(vector_index, 0);
+            assert_eq!(coord_index, 5);
+            assert!(value.is_nan(), "expected NaN, got {value}");
+        }
+        other => panic!("expected InvalidInputValue, got {other:?}"),
+    }
+    // No vectors were actually added.
+    assert_eq!(idx.len(), 0);
+}
+
+#[test]
+fn add_2d_rejects_positive_infinity() {
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    let mut data = ok_vector();
+    data[10] = f32::INFINITY;
+    let err = idx.add_2d(&data, DIM).unwrap_err();
+    assert!(
+        matches!(err, AddError::InvalidInputValue { coord_index: 10, .. }),
+        "expected InvalidInputValue at coord 10, got {err:?}",
+    );
+}
+
+#[test]
+fn add_2d_rejects_negative_infinity() {
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    let mut data = ok_vector();
+    data[3] = f32::NEG_INFINITY;
+    assert!(matches!(
+        idx.add_2d(&data, DIM).unwrap_err(),
+        AddError::InvalidInputValue { coord_index: 3, .. },
+    ));
+}
+
+#[test]
+fn add_2d_rejects_huge_magnitude_that_would_overflow_norm() {
+    // 1e20 is finite but `(1e20)^2 = 1e40` overflows f32::MAX (~3.4e38)
+    // — the scenario that previously stored `scale[i] = +Inf` and made
+    // the slot incorrectly win every search.
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    let mut data = ok_vector();
+    data[2] = 1e20;
+    let err = idx.add_2d(&data, DIM).unwrap_err();
+    assert!(
+        matches!(err, AddError::InvalidInputValue { coord_index: 2, .. }),
+        "expected InvalidInputValue at coord 2, got {err:?}",
+    );
+}
+
+#[test]
+fn add_2d_accepts_values_just_under_the_magnitude_bound() {
+    // 1e15 is well under 1e16, so it must be accepted. Pins the bound
+    // explicitly so a future tightening doesn't silently break valid
+    // (if unusual) callers.
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    let mut data = ok_vector();
+    data[1] = 1e15;
+    idx.add_2d(&data, DIM).unwrap();
+    assert_eq!(idx.len(), 1);
+}
+
+#[test]
+fn add_2d_rejects_invalid_input_in_second_vector_of_batch() {
+    // Multi-vector batch: the validation must report the *second* (or
+    // later) vector, not just the first.
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    let mut data = vec![0.0f32; 2 * DIM];
+    data[0] = 1.0;
+    data[DIM] = 1.0;
+    data[DIM + 7] = f32::NAN;
+    let err = idx.add_2d(&data, DIM).unwrap_err();
+    match err {
+        AddError::InvalidInputValue {
+            vector_index: 1,
+            coord_index: 7,
+            ..
+        } => {}
+        other => panic!("expected vector 1 / coord 7, got {other:?}"),
+    }
+}
+
+#[test]
+fn add_2d_failure_does_not_commit_dim_on_lazy_index() {
+    // A lazy index that rejects bad input on its first add must stay
+    // uncommitted — otherwise a follow-up correct add at a different
+    // dim would mis-report DimMismatch.
+    let mut idx = TurboQuantIndex::new_lazy(4).unwrap();
+    let mut bad = ok_vector();
+    bad[0] = f32::NAN;
+    assert!(idx.add_2d(&bad, DIM).is_err());
+    assert_eq!(idx.dim_opt(), None, "dim should not have been committed");
+
+    // A subsequent add at a different dim must succeed (no leftover
+    // commitment from the failed call).
+    let other_dim = 32;
+    let mut clean = vec![0.0f32; other_dim];
+    clean[0] = 1.0;
+    idx.add_2d(&clean, other_dim).unwrap();
+    assert_eq!(idx.dim_opt(), Some(other_dim));
+}
+
+// ---- TurboQuantIndex::add panics with a clear message on bad input ----
+
+#[test]
+#[should_panic(expected = "invalid input value")]
+fn add_panics_on_nan_input() {
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    let mut data = ok_vector();
+    data[5] = f32::NAN;
+    idx.add(&data);
+}
+
+#[test]
+#[should_panic(expected = "invalid input value")]
+fn add_panics_on_huge_magnitude_input() {
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    let mut data = ok_vector();
+    data[5] = 5e16;
+    idx.add(&data);
+}
+
+// ---- search panics with a clear message on bad query ----
+
+#[test]
+#[should_panic(expected = "invalid query value")]
+fn search_panics_on_nan_query() {
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.add(&ok_vector());
+
+    let mut query = vec![0.0f32; DIM];
+    query[0] = f32::NAN;
+    let _ = idx.search(&query, 1);
+}
+
+#[test]
+#[should_panic(expected = "invalid query value")]
+fn search_panics_on_infinity_query() {
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.add(&ok_vector());
+
+    let mut query = vec![0.0f32; DIM];
+    query[0] = f32::INFINITY;
+    let _ = idx.search(&query, 1);
+}
+
+#[test]
+#[should_panic(expected = "invalid query value")]
+fn search_panics_on_huge_magnitude_query() {
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.add(&ok_vector());
+
+    let mut query = vec![0.0f32; DIM];
+    query[0] = 1e18;
+    let _ = idx.search(&query, 1);
+}
+
+#[test]
+fn search_on_lazy_uncommitted_skips_query_validation() {
+    // A lazy-uncommitted search returns empty results without ever
+    // looking at the query — so even a NaN-bearing query must not
+    // panic. Pins that the early-return path bypasses validation.
+    let idx = TurboQuantIndex::new_lazy(4).unwrap();
+    let query = vec![f32::NAN; 8];
+    let res = idx.search(&query, 1);
+    assert_eq!(res.scores.len(), 0);
+    assert_eq!(res.indices.len(), 0);
+}
+
+// ---- IdMapIndex inherits validation via the inner index ----
+
+#[test]
+fn id_map_add_with_ids_2d_rejects_nan_input() {
+    let mut idx = IdMapIndex::new(DIM, 4).unwrap();
+    let mut data = ok_vector();
+    data[4] = f32::NAN;
+    let err = idx.add_with_ids_2d(&data, DIM, &[1]).unwrap_err();
+    assert!(
+        matches!(err, AddError::InvalidInputValue { .. }),
+        "expected InvalidInputValue, got {err:?}",
+    );
+    // IdMap tables must be untouched — pin the same partial-mutation
+    // contract the fixed add_with_ids_2d enforces.
+    assert_eq!(idx.len(), 0);
+    assert!(!idx.contains(1));
+}
+
+#[test]
+#[should_panic(expected = "invalid query value")]
+fn id_map_search_panics_on_nan_query() {
+    let mut idx = IdMapIndex::new(DIM, 4).unwrap();
+    idx.add_with_ids(&ok_vector(), &[1]).unwrap();
+    let mut query = vec![0.0f32; DIM];
+    query[0] = f32::NAN;
+    let _ = idx.search(&query, 1);
+}

--- a/turbovec/tests/io_versioning.rs
+++ b/turbovec/tests/io_versioning.rs
@@ -149,6 +149,92 @@ fn tvim_v1_file_is_rejected_with_upgrade_hint() {
 }
 
 #[test]
+fn tv_truncated_payload_errors_cleanly() {
+    // Write a valid v3 .tv file, then truncate it mid-payload. `load`
+    // must surface a clean io::Error (UnexpectedEof) rather than panic
+    // or return malformed state.
+    let path = temp_path("truncated.tv");
+    let bit_width = 4;
+    let dim = 32;
+    let n_vectors = 5;
+    let packed = vec![0xCDu8; (dim / 8) * bit_width * n_vectors];
+    let scales = vec![1.0f32; n_vectors];
+    write(&path, bit_width, dim, n_vectors, &packed, &scales, &[], &[]).unwrap();
+
+    // Truncate the file to half its size.
+    let len = std::fs::metadata(&path).unwrap().len();
+    let f = File::options().write(true).open(&path).unwrap();
+    f.set_len(len / 2).unwrap();
+    drop(f);
+
+    let err = load(&path).unwrap_err();
+    assert_eq!(
+        err.kind(),
+        std::io::ErrorKind::UnexpectedEof,
+        "expected UnexpectedEof on truncated file, got: {err}",
+    );
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn tv_unsupported_version_errors_with_useful_message() {
+    // Hand-construct a .tv file with a recognised magic but a version
+    // byte we don't support. Loader must surface a clean InvalidData
+    // error rather than try to parse with the wrong layout.
+    let path = temp_path("future_version.tv");
+    let mut f = File::create(&path).unwrap();
+    f.write_all(b"TVPI").unwrap();
+    f.write_all(&[99u8]).unwrap();  // version=99 — not 2, not 3
+    // Pad with arbitrary bytes so the read doesn't fail before the
+    // version check.
+    f.write_all(&[0u8; 64]).unwrap();
+    drop(f);
+
+    let err = load(&path).unwrap_err();
+    let msg = err.to_string();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        msg.contains("unsupported"),
+        "expected 'unsupported' in error message, got: {msg}",
+    );
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn tv_v3_invalid_n_calib_errors_cleanly() {
+    // Hand-construct a v3 .tv file whose n_calib is neither 0 nor dim.
+    // Loader must reject with InvalidData per the contract in io.rs.
+    let path = temp_path("bad_n_calib.tv");
+    let bit_width = 4u8;
+    let dim = 32u32;
+    let n_vectors = 1u32;
+
+    let mut f = File::create(&path).unwrap();
+    f.write_all(b"TVPI").unwrap();
+    f.write_all(&[3u8]).unwrap();  // version=3
+    f.write_all(&[bit_width]).unwrap();
+    f.write_all(&dim.to_le_bytes()).unwrap();
+    f.write_all(&n_vectors.to_le_bytes()).unwrap();
+    // Packed codes: (dim/8) * bit_width * n_vectors = 4 * 4 * 1 = 16 bytes.
+    f.write_all(&[0xAAu8; 16]).unwrap();
+    // Scale: 1 f32.
+    f.write_all(&1.0f32.to_le_bytes()).unwrap();
+    // n_calib = 7 — neither 0 nor dim (32). Invalid.
+    f.write_all(&7u32.to_le_bytes()).unwrap();
+    // Pad with junk so the read doesn't fail before the n_calib check.
+    f.write_all(&[0u8; 64]).unwrap();
+    drop(f);
+
+    let err = load(&path).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("n_calib"),
+        "expected 'n_calib' in error message, got: {err}",
+    );
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
 fn tv_garbage_file_rejected_without_upgrade_hint() {
     let path = temp_path("garbage.tv");
     {

--- a/turbovec/tests/lazy_init.rs
+++ b/turbovec/tests/lazy_init.rs
@@ -119,6 +119,63 @@ fn search_on_lazy_uncommitted_returns_empty() {
     assert_eq!(res.scores.len(), 0);
     assert_eq!(res.indices.len(), 0);
     assert_eq!(res.k, 0);
+    // nq is the only `SearchResults` field not pinned elsewhere in this
+    // suite for the lazy-uncommitted path; explicitly assert it.
+    assert_eq!(res.nq, 0);
+}
+
+#[test]
+fn search_single_query_sets_nq_to_one() {
+    // SearchResults.nq is only asserted in multi-query tests; a
+    // regression that dropped nq to 0 in the single-query path would
+    // not have failed any existing test.
+    let dim = 128;
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+    let data = unit_vectors(5, dim, 0xA00D_00A0);
+    idx.add(&data);
+
+    let q = &data[0..dim];
+    let res = idx.search(q, 3);
+    assert_eq!(res.nq, 1);
+    assert_eq!(res.k, 3);
+    assert_eq!(res.scores.len(), 3);
+    assert_eq!(res.indices.len(), 3);
+}
+
+#[test]
+fn is_empty_tracks_len() {
+    // Pins `is_empty()` against `len()`. No existing test calls
+    // `is_empty()` on a TurboQuantIndex, so a regression flipping its
+    // polarity (`self.n_vectors > 0`) would compile and pass the suite.
+    let dim = 64;
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+    assert!(idx.is_empty());
+    assert_eq!(idx.len(), 0);
+
+    let data = unit_vectors(3, dim, 0xA00D_00A1);
+    idx.add(&data);
+    assert!(!idx.is_empty());
+    assert_eq!(idx.len(), 3);
+
+    // After swap_remove down to zero.
+    idx.swap_remove(0);
+    idx.swap_remove(0);
+    idx.swap_remove(0);
+    assert!(idx.is_empty());
+    assert_eq!(idx.len(), 0);
+}
+
+#[test]
+fn add_2d_rejects_non_multiple_of_8_dim_on_lazy_index() {
+    // The `DimNotMultipleOf8` AddError variant is only reachable from a
+    // lazy index whose first `add_2d` commits a non-multiple-of-8 dim.
+    // Previously untested — a regression flipping the branch to Ok or
+    // DimMismatch would not have failed the suite.
+    let mut idx = TurboQuantIndex::new_lazy(4).unwrap();
+    let err = idx.add_2d(&[0.0f32; 14], 7).unwrap_err();
+    assert_eq!(err, turbovec::AddError::DimNotMultipleOf8(7));
+    // Failure must not have committed a dim.
+    assert_eq!(idx.dim_opt(), None);
 }
 
 #[test]

--- a/turbovec/tests/state_sequences.rs
+++ b/turbovec/tests/state_sequences.rs
@@ -1,0 +1,276 @@
+//! Tests for operation sequences across the public API of
+//! `TurboQuantIndex` and `IdMapIndex`.
+//!
+//! Most existing tests exercise operations in isolation; bugs that live
+//! in the transition between two operations (cache invalidation, slot
+//! reuse, persistence round-trip preserving post-mutation state) can
+//! slip past those. The audit that surfaced the LlamaIndex intra-batch
+//! `add()` corruption pointed at the same risk in the Rust core; these
+//! tests pin the operation sequences most likely to harbour it.
+
+use turbovec::{IdMapIndex, TurboQuantIndex};
+
+fn unit_vectors(n: usize, dim: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed | 1;
+    let mut next = || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    let mut uniform = || {
+        let raw = (next() >> 40) as u32 | 1;
+        raw as f32 / (1u32 << 24) as f32
+    };
+    let two_pi = 2.0_f32 * std::f32::consts::PI;
+    let mut data = vec![0.0f32; n * dim];
+    let mut i = 0;
+    while i < data.len() {
+        let u1 = uniform().max(1e-7);
+        let u2 = uniform();
+        let r = (-2.0 * u1.ln()).sqrt();
+        let theta = two_pi * u2;
+        data[i] = r * theta.cos();
+        if i + 1 < data.len() {
+            data[i + 1] = r * theta.sin();
+        }
+        i += 2;
+    }
+    for row in data.chunks_mut(dim) {
+        let norm: f32 = row.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            let inv = 1.0 / norm;
+            for x in row.iter_mut() {
+                *x *= inv;
+            }
+        }
+    }
+    data
+}
+
+#[test]
+fn second_add_after_search_lets_new_vectors_be_found() {
+    // `add -> search -> add -> search`: the second add must invalidate
+    // the blocked cache populated by the first search, so the new
+    // vectors are visible. Existing tests only assert that returned
+    // indices stay in range (idx < len) after the second add — a bug
+    // that excluded the new batch entirely from the blocked layout
+    // would still satisfy that bound but never surface the new vectors.
+    let dim = 128;
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+    let first = unit_vectors(5, dim, 0x5001);
+    idx.add(&first);
+    // First search warms the blocked cache.
+    let _ = idx.search(&first[0..dim], 5);
+
+    // Second add: distinctive vector at known position.
+    let second = unit_vectors(1, dim, 0x5002);
+    idx.add(&second);
+
+    // Self-query the newly added vector — it must be top-1, proving
+    // the second add invalidated the cache and rebuilt it including
+    // the new vector.
+    let res = idx.search(&second, 1);
+    assert_eq!(res.indices.len(), 1);
+    assert_eq!(res.indices[0] as usize, 5, "new vector not findable after second add+search");
+}
+
+#[test]
+fn add_swap_remove_add_then_self_query_finds_all_three_phases() {
+    // Mixed shrink+grow sequence. Tests that swap_remove leaves enough
+    // state intact for a subsequent add (no stale packed_codes length,
+    // no stale n_vectors), and that self-query still works on every
+    // surviving vector across all three phases.
+    let dim = 128;
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+
+    let phase_a = unit_vectors(5, dim, 0x5003);
+    idx.add(&phase_a);
+
+    // Remove the middle vector. The last vector (idx 4) moves into slot 2.
+    idx.swap_remove(2);
+    assert_eq!(idx.len(), 4);
+
+    // Add two more vectors.
+    let phase_c = unit_vectors(2, dim, 0x5004);
+    idx.add(&phase_c);
+    assert_eq!(idx.len(), 6);
+
+    // The two newest vectors must self-query to slots 4 and 5.
+    let r0 = idx.search(&phase_c[0..dim], 1);
+    assert_eq!(r0.indices[0] as usize, 4);
+    let r1 = idx.search(&phase_c[dim..2 * dim], 1);
+    assert_eq!(r1.indices[0] as usize, 5);
+}
+
+#[test]
+fn swap_remove_after_load_produces_correct_search() {
+    // `add -> write -> load -> swap_remove -> search`: a loaded index
+    // has an empty blocked cache, but swap_remove still resets it. The
+    // combined "load then mutate then search" path is untested.
+    let dim = 128;
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+    let data = unit_vectors(5, dim, 0x5005);
+    idx.add(&data);
+
+    let tmp = std::env::temp_dir().join(format!("turbovec_seq_load_swap_{}.tv", std::process::id()));
+    idx.write(&tmp).unwrap();
+
+    let mut loaded = TurboQuantIndex::load(&tmp).unwrap();
+    std::fs::remove_file(&tmp).ok();
+
+    // Remove slot 1 — slot 4 moves into slot 1.
+    let moved = loaded.swap_remove(1);
+    assert_eq!(moved, 4);
+    assert_eq!(loaded.len(), 4);
+
+    // Self-query the surviving 4 vectors via their now-correct slots.
+    // Slot 0 still has vec 0; slot 1 has vec 4 (moved); slot 2,3 unchanged.
+    let r0 = loaded.search(&data[0..dim], 1);
+    assert_eq!(r0.indices[0] as usize, 0);
+    let r4 = loaded.search(&data[4 * dim..5 * dim], 1);
+    assert_eq!(r4.indices[0] as usize, 1, "moved vector should now be at slot 1");
+}
+
+#[test]
+fn swap_remove_then_round_trip_matches_in_memory_search() {
+    // `add -> swap_remove -> write -> load -> search` must match
+    // `add -> swap_remove -> search`. Persistence captures the
+    // post-removal packed_codes / scales, not the pre-removal state.
+    // A regression that wrote stale tail bytes would diverge here.
+    let dim = 128;
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+    let data = unit_vectors(5, dim, 0x5006);
+    idx.add(&data);
+    idx.swap_remove(1);
+    idx.swap_remove(2);
+    let in_memory = idx.search(&data[0..dim], 3);
+
+    let tmp = std::env::temp_dir().join(format!(
+        "turbovec_seq_swap_roundtrip_{}.tv",
+        std::process::id()
+    ));
+    idx.write(&tmp).unwrap();
+    let loaded = TurboQuantIndex::load(&tmp).unwrap();
+    std::fs::remove_file(&tmp).ok();
+
+    let from_disk = loaded.search(&data[0..dim], 3);
+
+    assert_eq!(in_memory.scores, from_disk.scores);
+    assert_eq!(in_memory.indices, from_disk.indices);
+    assert_eq!(in_memory.k, from_disk.k);
+    assert_eq!(in_memory.nq, from_disk.nq);
+}
+
+#[test]
+fn id_map_re_added_id_returns_new_vector_not_old() {
+    // `add({id: 1, vec_a}) -> remove(1) -> add({id: 1, vec_b}) -> search(vec_b)`:
+    // after re-adding the same id with a different vector, search for
+    // the new vector must return id 1 and rank it top. The existing
+    // `remove_then_re_add_same_id_is_allowed` only asserts `contains`.
+    let dim = 128;
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
+    let vec_a = unit_vectors(1, dim, 0x5007);
+    idx.add_with_ids(&vec_a, &[42]).unwrap();
+    assert!(idx.remove(42));
+
+    let vec_b = unit_vectors(1, dim, 0x5008);
+    idx.add_with_ids(&vec_b, &[42]).unwrap();
+
+    let (_, ids) = idx.search(&vec_b, 1);
+    assert_eq!(ids[0], 42, "self-query of re-added vector should return its id");
+}
+
+#[test]
+fn prepare_then_add_invalidates_blocked_cache() {
+    // `prepare -> add -> search`: prepare populates the blocked cache;
+    // the subsequent add must still invalidate it (analogous to the
+    // search -> add -> search path but with the cache pre-warmed via
+    // prepare instead of an actual query).
+    let dim = 128;
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+    let first = unit_vectors(3, dim, 0x5009);
+    idx.add(&first);
+    idx.prepare();
+
+    let second = unit_vectors(1, dim, 0x500A);
+    idx.add(&second);
+
+    let res = idx.search(&second, 1);
+    assert_eq!(res.indices[0] as usize, 3, "new vector not findable after prepare+add");
+}
+
+#[test]
+fn id_map_remove_last_then_add_keeps_slot_tables_consistent() {
+    // `remove(last)` skips the swap branch (no `id_to_slot.insert` for
+    // a moved id). Subsequent add+search must still produce correct
+    // results — pinning that the no-swap branch left no stale
+    // `slot_to_id` tail entry.
+    let dim = 128;
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
+    let data = unit_vectors(3, dim, 0x500B);
+    idx.add_with_ids(&data, &[10, 20, 30]).unwrap();
+
+    // Remove the LAST id; no swap occurs.
+    assert!(idx.remove(30));
+    assert_eq!(idx.len(), 2);
+
+    // Add a fresh id — must land at slot 2 (the now-freed slot).
+    let extra = unit_vectors(1, dim, 0x500C);
+    idx.add_with_ids(&extra, &[40]).unwrap();
+
+    // Self-query the new vector returns id 40.
+    let (_, ids) = idx.search(&extra, 1);
+    assert_eq!(ids[0], 40);
+
+    // The two previously-existing ids still resolve.
+    let (_, ids10) = idx.search(&data[0..dim], 1);
+    assert_eq!(ids10[0], 10);
+    let (_, ids20) = idx.search(&data[dim..2 * dim], 1);
+    assert_eq!(ids20[0], 20);
+}
+
+#[test]
+fn add_after_load_extends_index() {
+    // `add -> write -> load -> add -> search`: a loaded index can be
+    // extended via add and the new vectors join the search results.
+    let dim = 128;
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+    let first = unit_vectors(3, dim, 0x500D);
+    idx.add(&first);
+
+    let tmp = std::env::temp_dir().join(format!(
+        "turbovec_seq_add_after_load_{}.tv",
+        std::process::id()
+    ));
+    idx.write(&tmp).unwrap();
+    let mut loaded = TurboQuantIndex::load(&tmp).unwrap();
+    std::fs::remove_file(&tmp).ok();
+
+    let second = unit_vectors(2, dim, 0x500E);
+    loaded.add(&second);
+    assert_eq!(loaded.len(), 5);
+
+    // Self-query the newly added vector.
+    let res = loaded.search(&second[0..dim], 1);
+    assert_eq!(res.indices[0] as usize, 3, "new vector should be at slot 3 after load+add");
+}
+
+#[test]
+fn prepare_then_swap_remove_invalidates_cache() {
+    // Defensive: `prepare -> swap_remove -> search` must produce a
+    // search that reflects the deletion.
+    let dim = 128;
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+    let data = unit_vectors(5, dim, 0x500F);
+    idx.add(&data);
+    idx.prepare();
+
+    idx.swap_remove(1);  // slot 4 moves into slot 1
+    assert_eq!(idx.len(), 4);
+
+    // Self-query slot-1's old vector (data row 1) — must NOT return
+    // slot 1 anymore (which now has data row 4).
+    let res = idx.search(&data[dim..2 * dim], 1);
+    assert_ne!(res.indices[0] as usize, 1, "deleted vector should not be retrievable after prepare+swap_remove");
+}

--- a/turbovec/tests/tqplus_calibration.rs
+++ b/turbovec/tests/tqplus_calibration.rs
@@ -1,0 +1,171 @@
+//! Wave-6 regression tests for the TQ+ calibration state machine.
+//!
+//! Two bugs surfaced by the audit:
+//!
+//! 1. **Empty first add silently froze identity calibration.** `add(&[])`
+//!    hit the `n < TQPLUS_MIN_SAMPLES` branch in `encode`, returned
+//!    `(zeros, ones)`, and the `n_vectors == 0` branch in `add` copied
+//!    that identity into `self.tqplus_shift` / `self.tqplus_scale`.
+//!    Every subsequent add — even a million-vector batch with rich
+//!    distribution — then saw `existing = Some(identity)` and skipped
+//!    fresh fitting, silently losing the TQ+ recall gain.
+//!
+//! 2. **v2-loaded index + add silently mis-encoded.** A v2 file (pre-TQ+)
+//!    loads with empty `tqplus_shift`; on the next add, `existing` is
+//!    `None`, so `encode` fits fresh calibration and bakes it into the
+//!    packed codes. But the else branch (`n_vectors != 0`) only extends
+//!    `packed_codes` / `scales`, never persisting the fitted shift /
+//!    scale_tq. The new vectors end up encoded with calibration but
+//!    searched with identity — silent score corruption.
+
+use std::fs::File;
+use std::io::Write;
+
+use turbovec::{io, TurboQuantIndex};
+
+fn gaussian_normalized(n: usize, dim: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed | 1;
+    let mut next = || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    let mut uniform = || {
+        let raw = (next() >> 40) as u32 | 1;
+        raw as f32 / (1u32 << 24) as f32
+    };
+    let two_pi = 2.0_f32 * std::f32::consts::PI;
+    let mut data = vec![0.0f32; n * dim];
+    let mut i = 0;
+    while i < data.len() {
+        let u1 = uniform().max(1e-7);
+        let u2 = uniform();
+        let r = (-2.0 * u1.ln()).sqrt();
+        let theta = two_pi * u2;
+        data[i] = r * theta.cos();
+        if i + 1 < data.len() {
+            data[i + 1] = r * theta.sin();
+        }
+        i += 2;
+    }
+    for row in data.chunks_mut(dim) {
+        let norm: f32 = row.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            let inv = 1.0 / norm;
+            for x in row.iter_mut() {
+                *x *= inv;
+            }
+        }
+    }
+    data
+}
+
+#[test]
+fn empty_first_add_does_not_freeze_identity_calibration() {
+    let dim = 128;
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+
+    // Empty add — must be a true no-op, not silently lock identity
+    // calibration on the index.
+    idx.add(&[]);
+    assert_eq!(idx.len(), 0);
+
+    // Add a realistic batch big enough to trigger TQ+ fitting
+    // (>= TQPLUS_MIN_SAMPLES, currently 1000).
+    let data = gaussian_normalized(1500, dim, 0xC0FF_EE01);
+    idx.add(&data);
+    assert_eq!(idx.len(), 1500);
+
+    // After the fix, the second add fits fresh calibration. Verify by
+    // round-tripping through the format and inspecting the persisted
+    // TQ+ trailer — at least one shift or scale value must differ from
+    // identity (shift != 0 or scale != 1). Pre-fix, the trailer would
+    // be exactly `(zeros, ones)` because identity was locked by the
+    // empty add.
+    let tmp = std::env::temp_dir().join(format!(
+        "turbovec_empty_add_freeze_{}.tv",
+        std::process::id()
+    ));
+    idx.write(&tmp).unwrap();
+    let (_, _, _, _, _, shift, scale_tq) = io::load(&tmp).unwrap();
+    let _ = std::fs::remove_file(&tmp);
+
+    assert_eq!(shift.len(), dim);
+    assert_eq!(scale_tq.len(), dim);
+
+    let nontrivial_shift = shift.iter().any(|&x| x.abs() > 1e-6);
+    let nontrivial_scale = scale_tq.iter().any(|&x| (x - 1.0).abs() > 1e-6);
+    assert!(
+        nontrivial_shift || nontrivial_scale,
+        "TQ+ calibration is exactly identity after empty + 1500-vec add — \
+         the empty first add likely locked identity, suppressing fresh \
+         calibration on the real batch.",
+    );
+}
+
+#[test]
+fn v2_loaded_index_populates_identity_calibration() {
+    // Hand-construct a v2 .tv file: TVPI magic + version=2 + header +
+    // packed codes + scales, NO TQ+ trailer (this is the v2 wire format).
+    let path = std::env::temp_dir().join(format!(
+        "turbovec_v2_load_then_add_{}.tv",
+        std::process::id()
+    ));
+    let bit_width = 4u8;
+    let dim = 128u32;
+    let n_vectors = 3u32;
+
+    let mut f = File::create(&path).unwrap();
+    f.write_all(b"TVPI").unwrap();
+    f.write_all(&[2u8]).unwrap();
+    f.write_all(&[bit_width]).unwrap();
+    f.write_all(&dim.to_le_bytes()).unwrap();
+    f.write_all(&n_vectors.to_le_bytes()).unwrap();
+    // packed codes: (dim/8) * bit_width * n_vectors = 16 * 4 * 3 = 192 bytes.
+    f.write_all(&vec![0u8; ((dim / 8) * (bit_width as u32) * n_vectors) as usize])
+        .unwrap();
+    // scales: one f32 per vector.
+    for _ in 0..n_vectors {
+        f.write_all(&1.0f32.to_le_bytes()).unwrap();
+    }
+    // No TQ+ trailer — this is what makes the file v2 rather than v3.
+    drop(f);
+
+    // Load via the public API. After the wave-6 fix, the loaded index
+    // should populate identity TQ+ calibration internally (since
+    // n_vectors > 0 and the file's TQ+ trailer was empty), so the next
+    // `add` will see `existing = Some(identity)` rather than `None` and
+    // encode the new vectors with identity calibration — matching the
+    // already-stored vectors.
+    let mut idx = TurboQuantIndex::load(&path).unwrap();
+    let _ = std::fs::remove_file(&path);
+    assert_eq!(idx.len(), 3);
+    assert_eq!(idx.dim(), dim as usize);
+
+    // Add a fresh batch big enough to make `encode` fit non-trivial
+    // calibration if `existing` were `None` (the pre-fix path). After
+    // the fix, `existing = Some(identity)` so encode does NOT fit, the
+    // new vectors are encoded with identity, and writing back gives an
+    // identity TQ+ trailer — round-trip-stable across the v2->v3 hop.
+    let data = gaussian_normalized(1500, dim as usize, 0x42EE_D101);
+    idx.add(&data);
+    assert_eq!(idx.len(), 1503);
+
+    let tmp = std::env::temp_dir().join(format!(
+        "turbovec_v2_load_then_add_out_{}.tv",
+        std::process::id()
+    ));
+    idx.write(&tmp).unwrap();
+    let (_, _, _, _, _, shift, scale_tq) = io::load(&tmp).unwrap();
+    let _ = std::fs::remove_file(&tmp);
+
+    assert_eq!(shift.len(), dim as usize);
+    assert_eq!(scale_tq.len(), dim as usize);
+    for &s in &shift {
+        assert_eq!(s, 0.0, "v2-loaded + add must keep identity shift");
+    }
+    for &s in &scale_tq {
+        assert_eq!(s, 1.0, "v2-loaded + add must keep identity scale");
+    }
+}


### PR DESCRIPTION
## Summary

Six waves of audit-driven work on the integrations and the Rust core. All in one PR because they share the same investigation thread.

### Wave 1 — Structural fidelity bug fixes in integrations (4 commits)

Follow-up to #81. Audited each integration vs its reference store; found analogous "cherry-picked side-car schema silently drops fields" bugs in haystack, llama-index, agno. Plus the original #81 fix cherry-picked from #82.

### Wave 2 — Reference-parity tests (4 commits, +30 tests)

Audited each library's test surface vs ours; pinned 30 behaviours their in-tree reference store tests but we didn't.

### Wave 3 — Python integration field-completeness (4 commits, 1 fix + 17 tests)

LlamaIndex `add()` was silently corrupting state on intra-batch duplicate node_ids. Plus exhaustive return-field audit on all four integrations.

### Wave 4 — Rust core audit (4 commits, 1 fix + 22 tests)

`IdMapIndex::add_with_ids_2d` was mutating ID tables before delegating to inner add; on `Err` returns the tables retained ghost entries pointing at slots that didn't exist. Plus TurboQuantIndex API gaps, state-sequence tests, internal module gaps.

### Wave 5 — Numerical + bindings + concurrency (3 commits, 8 fixes + 29 tests)

**4 silent data-corruption bugs in the encode/search pipeline:**
- NaN input → vec_scales poisoned, slot exists in `len()` but is silently unreachable.
- Inf input → same NaN-poisoning path.
- Magnitude `>= 1e16` → f32 norm overflows to +Inf, slot wins top-k against every query.
- NaN/Inf query → kernel produces NaN scores, arbitrary indices returned.

Fix: `AddError::InvalidInputValue` + finiteness/magnitude validation at `add` / `add_2d` / `search` / `search_with_mask` entry.

**4 Python binding hygiene fixes:** non-contiguous arrays → typed `ValueError`; wrong query dim → typed `ValueError`; `swap_remove` out-of-bounds → typed `IndexError`; cross-class shape consistency between `TurboQuantIndex.search` and `IdMapIndex.search` for empty queries.

Plus 3 new concurrency tests (`load`+search races, `IdMapIndex` concurrent search, prepare-with-search interleaving).

### Wave 6 — TQ+ calibration + allowlist dedup + doc drift (3 commits, 3 fixes + 3 tests)

**🔴 TQ+ F1 — v2-loaded index + add silently mis-encoded new vectors.** Loading a v2 (pre-TQ+) file left `tqplus_shift` empty; the next `add` saw `existing = None`, encoded vectors with fresh-fitted calibration, but the else branch silently dropped the fitted shift/scale_tq. New vectors were encoded with calibration but searched as identity → silently corrupted scores. Fix in `from_parts`: populate explicit identity when loading a v2-shaped state.

**🔴 TQ+ F2 — Empty first add silently froze identity calibration forever.** `add(&[])` returned identity from `encode`, the `n_vectors == 0` branch wrote it to `self.tqplus_shift`, and every subsequent add (even 1M-vector batches) saw `existing = Some(identity)` and skipped fitting. Fix: `add` short-circuits to a true no-op when `n == 0`.

**🔴 Wave-5 allowlist dedup bug** (in my own wave-5 fix). For `nq == 0`, `effective_k` counted raw allowlist length but the kernel internally dedups via packed-bool mask. So `allowlist=[1,1,1]` returned shape `(0, 3)` for empty queries vs `(N, 1)` for non-empty. Fix: dedup via HashSet in the nq=0 path.

Plus doc updates for the wave-5 panic conditions (rustdoc on `add` / `add_2d` / `search` / `search_with_mask`), a deleted misleading comment in `error.rs`, and dropped the FAISS analogy from `id_map.rs` per the no-faiss-analogues memory entry.

## Verified during the audits

- agno's `VectorDb` ABC only requires `name_exists` / `id_exists` / `content_hash_exists`; an audit flag about missing `content_id_exists` was a false positive.

## Out of scope — follow-ups worth filing

- Full `bm25_retrieval` / `bm25_retrieval_async` for the haystack store.
- agno `Document.content_origin` / `size` / `embedding` preservation (currently pinned as deliberate divergences from LanceDb).
- Direct tests for the `pack` module (currently exercised transitively via `kernel_correctness.rs`).
- Wider encode coverage (TQ+ identity-fallback branch on per-coord degeneracy).
- `TQPLUS_MIN_SAMPLES` threshold could be made discoverable / logged on first-batch-too-small (currently silent).

## Headline totals

- **13 active bugs found and fixed** across waves 1, 3, 4, 5, 6.
- **~125 tests added** across the 6 waves (regression + parity + field-completeness + state-sequence + numerical + concurrency + audit-driven coverage).

## Test plan

- [x] Full Rust test suite locally: 135/135 pass.
- [x] Full Python test suite locally: 331/331 pass.
- [ ] CI on Linux / macOS / Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)