### PR TITLE
Fix upsert deleting old data before validating new data (#89)

### DIFF
--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -393,9 +393,18 @@ class TurboQuantVectorDb(VectorDb):
         # Match LanceDb's semantic: replace all documents previously
         # stored under this content_hash with the incoming batch. Not
         # "replace by derived doc_id" — that's a different contract.
-        if self.content_hash_exists(content_hash):
-            self._delete_by_content_hash(content_hash)
+        #
+        # Capture the existing generation's handles, run the insert, and
+        # only then drop the old vectors — so a failed insert (dim
+        # mismatch, non-finite embeddings) never destroys the data being
+        # replaced (issue #89). We delete by captured handle rather than
+        # re-querying by content_hash, because insert() re-derives ids
+        # under the SAME content_hash and would otherwise clobber the
+        # just-inserted rows.
+        old_handles = self._handles_for_content_hash(content_hash)
         self.insert(content_hash, documents, filters)
+        for handle in old_handles:
+            self._remove_handle(handle)
 
     async def async_upsert(
         self,
@@ -403,24 +412,51 @@ class TurboQuantVectorDb(VectorDb):
         documents: List[Document],
         filters: Optional[Dict[str, Any]] = None,
     ) -> None:
-        if self.content_hash_exists(content_hash):
-            self._delete_by_content_hash(content_hash)
+        old_handles = self._handles_for_content_hash(content_hash)
         await self.async_insert(content_hash, documents, filters)
+        for handle in old_handles:
+            self._remove_handle(handle)
 
-    def _delete_by_content_hash(self, content_hash: str) -> bool:
-        """Internal helper matching LanceDb's same-named method: delete
-        every document whose ``content_hash`` matches. Returns True if at
-        least one document was deleted."""
-        if self._index is None:
-            return False
-        to_delete = [
-            data["id"]
-            for data in self._u64_to_doc.values()
+    def _handles_for_content_hash(self, content_hash: str) -> List[int]:
+        """Internal handles of every document currently stored under this
+        content_hash. Used by upsert to defer removal of the previous
+        generation until the replacement add has succeeded (issue #89)."""
+        return [
+            handle
+            for handle, data in self._u64_to_doc.items()
             if data.get("content_hash") == content_hash
         ]
-        for doc_id in to_delete:
-            self.delete_by_id(doc_id)
-        return bool(to_delete)
+
+    def _remove_handle(self, handle: int) -> None:
+        """Remove a single vector by its internal handle, leaving other
+        handles intact — including ones that share this document's derived
+        id (two distinct documents can map to the same doc_id, matching
+        LanceDb). Cleans the id, name, and content_hash side-indexes only
+        where no surviving handle still needs them."""
+        if self._index is None:
+            return
+        data = self._u64_to_doc.pop(handle, None)
+        if data is None:
+            return
+        self._index.remove(handle)
+        doc_id = data.get("id")
+        # Only clear the id->handle mapping if it still points at this
+        # handle; a re-inserted doc may have repointed it to a new handle.
+        if doc_id is not None and self._str_to_u64.get(doc_id) == handle:
+            self._str_to_u64.pop(doc_id, None)
+        # Drop the name->id link only if no surviving handle keeps that id.
+        name = data.get("name")
+        if name and name in self._name_to_ids:
+            if not any(d.get("id") == doc_id for d in self._u64_to_doc.values()):
+                self._name_to_ids[name].discard(doc_id)
+                if not self._name_to_ids[name]:
+                    del self._name_to_ids[name]
+        # Drop the content_hash only if no surviving doc carries it.
+        ch = data.get("content_hash")
+        if ch and not any(
+            d.get("content_hash") == ch for d in self._u64_to_doc.values()
+        ):
+            self._content_hashes.discard(ch)
 
     # ---- VectorDb protocol: search ----------------------------------------
 

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -185,6 +185,7 @@ class TurboQuantDocumentStore:
         # keeps only the last handle, orphaning the earlier vectors.
         to_write: List[Document] = []
         batch_pos: Dict[str, int] = {}  # doc.id -> index into to_write
+        to_remove: List[str] = []  # existing ids to drop, deferred past add
         written = len(documents)
         for doc in documents:
             if doc.embedding is None:
@@ -204,7 +205,10 @@ class TurboQuantDocumentStore:
                     continue
             if policy == DuplicatePolicy.OVERWRITE:
                 if doc.id in self._str_to_u64:
-                    self._remove_one(doc.id)
+                    # Defer the removal until after the add succeeds so a
+                    # failed validation/add never destroys existing data
+                    # (issue #89).
+                    to_remove.append(doc.id)
                 if doc.id in batch_pos:
                     # Last write wins: replace the earlier queued document
                     # in place rather than appending a second vector.
@@ -238,6 +242,12 @@ class TurboQuantDocumentStore:
             [self._issue_handle() for _ in to_write], dtype=np.uint64
         )
         self._index.add_with_ids(vectors, handles)
+
+        # The add succeeded — now it's safe to drop the old vectors for any
+        # overwritten ids. Done before the mapping loop below so _remove_one
+        # resolves the old handle, not the one we're about to assign.
+        for doc_id in to_remove:
+            self._remove_one(doc_id)
 
         for doc, handle in zip(to_write, handles):
             h = int(handle)

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -191,16 +191,10 @@ class TurboQuantVectorStore(VectorStore):
             metadatas = [metadatas[i] for i in keep]
             vectors = vectors[keep]
 
-        # Upsert: any id that already exists is removed so the re-added
-        # vector wins. Matches LangChain user expectation that `add_texts`
-        # with an existing id updates in place.
-        duplicates = [i for i in ids if i in self._str_to_u64]
-        if duplicates:
-            self.delete(duplicates)
-
-        # IdMapIndex.add_with_ids handles both eager (dim must match) and
-        # lazy (locks dim on first call) cases. Pre-check the eager case
-        # so we surface a clean ValueError rather than a Rust panic.
+        # Validate before mutating any existing data. IdMapIndex.add_with_ids
+        # handles both eager (dim must match) and lazy (locks dim on first
+        # call) cases. Pre-check the eager case so we surface a clean
+        # ValueError rather than a Rust panic.
         existing_dim = self._index.dim
         if existing_dim is not None and vectors.shape[1] != existing_dim:
             raise ValueError(
@@ -212,7 +206,19 @@ class TurboQuantVectorStore(VectorStore):
         handles = np.array(
             [self._issue_handle() for _ in texts_list], dtype=np.uint64
         )
+        # Add first; if encoding rejects the batch (e.g. non-finite values)
+        # this raises before any existing data is touched. Only once the add
+        # has succeeded do we remove the old vectors for colliding ids, so a
+        # failed upsert never destroys existing data (issue #89). Handles are
+        # freshly issued, so the old and new vectors coexist until the delete.
         self._index.add_with_ids(vectors, handles)
+
+        # Upsert: any id that already existed is removed so the re-added
+        # vector wins. Matches LangChain user expectation that `add_texts`
+        # with an existing id updates in place.
+        duplicates = [i for i in ids if i in self._str_to_u64]
+        if duplicates:
+            self.delete(duplicates)
 
         for id_, text, meta, handle in zip(ids, texts_list, metadatas, handles):
             h = int(handle)

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -152,12 +152,6 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
                 )
             seen.add(n.node_id)
 
-        # Upsert-like: if a node_id is already present in the STORE, remove
-        # the old entry before re-adding so the new embedding wins.
-        duplicates = [n.node_id for n in nodes if n.node_id in self._node_id_to_u64]
-        for node_id in duplicates:
-            self._remove_node_by_id(node_id)
-
         embeddings = [node.get_embedding() for node in nodes]
         vectors = np.asarray(embeddings, dtype=np.float32)
         if vectors.ndim != 2:
@@ -176,7 +170,19 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
             vectors = np.ascontiguousarray(vectors)
 
         handles = np.array([self._issue_handle() for _ in nodes], dtype=np.uint64)
+        # Add first; if validation above or encoding here (e.g. non-finite
+        # values) rejects the batch, it raises before any existing data is
+        # touched. Only after the add succeeds do we remove the old entries
+        # for colliding node_ids, so a failed upsert never destroys existing
+        # data (issue #89). Handles are freshly issued, so the old and new
+        # vectors coexist until the delete.
         self._index.add_with_ids(vectors, handles)
+
+        # Upsert-like: if a node_id is already present in the STORE, remove
+        # the old entry so the new embedding wins.
+        duplicates = [n.node_id for n in nodes if n.node_id in self._node_id_to_u64]
+        for node_id in duplicates:
+            self._remove_node_by_id(node_id)
 
         ids: list[str] = []
         for node, handle in zip(nodes, handles):

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -256,6 +256,39 @@ def test_search_does_not_dedupe_distinct_documents_with_identical_content():
     assert {d.content_id for d in results} == {"cid-1", "cid-2"}
 
 
+def test_upsert_replaces_previous_generation():
+    # A valid upsert under the same content_hash replaces the previous
+    # generation entirely (deferred handle-based removal after the add).
+    db = TurboQuantVectorDb(embedder=StubEmbedder(DIM))
+    db.create()
+    db.upsert("h1", [_doc("v1", content_id="cid-1")])
+    db.upsert("h1", [_doc("v2", content_id="cid-1")])
+
+    assert len(db._u64_to_doc) == 1
+    contents = [r.content for r in db.search("v2", limit=10)]
+    assert "v2" in contents
+    assert "v1" not in contents
+
+
+def test_upsert_dim_mismatch_preserves_existing():
+    # An upsert whose new embeddings fail validation must not destroy the
+    # data being replaced: the old generation is removed only after the
+    # insert succeeds (issue #89).
+    db = TurboQuantVectorDb(embedder=StubEmbedder(DIM))
+    db.create()
+    db.upsert("h1", [_doc("orig", content_id="cid-1")])
+
+    bad = Document(content="new", meta_data={}, content_id="cid-1",
+                   embedding=[0.1] * 32)
+    with pytest.raises(ValueError):
+        db.upsert("h1", [bad])  # dim 32 != index dim 64
+
+    results = db.search("orig", limit=5)
+    assert len(results) == 1
+    assert results[0].content == "orig"
+    assert len(db._u64_to_doc) == 1
+
+
 def test_constructor_requires_embedder():
     with pytest.raises(ValueError, match="embedder.*required"):
         TurboQuantVectorDb()

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -492,6 +492,21 @@ def test_intra_batch_duplicate_skip_keeps_first():
     assert store.filter_documents()[0].content == "first"
 
 
+def test_overwrite_upsert_dim_mismatch_preserves_existing():
+    # An OVERWRITE write whose new embedding fails validation must not
+    # destroy the existing document: the delete is deferred past the add.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(
+        [Document(id="d1", content="orig", embedding=unit_vector(0))]
+    )
+    bad = Document(id="d1", content="new", embedding=unit_vector(1)[:32])
+    with pytest.raises(ValueError):
+        store.write_documents([bad], policy=DuplicatePolicy.OVERWRITE)
+
+    assert store.count_documents() == 1
+    assert store.filter_documents()[0].content == "orig"
+
+
 def test_write_document_without_embedding_raises():
     store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
     with pytest.raises(ValueError, match="no embedding"):

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -194,6 +194,33 @@ def test_add_texts_intra_batch_duplicate_ids_keep_last():
     assert store._docs["dup"][0] == "beta"
 
 
+def test_upsert_dim_mismatch_preserves_existing_data():
+    # An upsert whose new embeddings fail validation must not destroy the
+    # existing entry: the delete is deferred until the add succeeds.
+    class VarDimEmbeddings(Embeddings):
+        def __init__(self):
+            self.call = 0
+
+        def embed_documents(self, texts):
+            self.call += 1
+            dim = 64 if self.call == 1 else 32
+            return [[float(i + 1)] * dim for i in range(len(texts))]
+
+        def embed_query(self, t):
+            return [1.0] * 64
+
+    store = TurboQuantVectorStore(VarDimEmbeddings())
+    store.add_texts(["hello"], ids=["my-id"])      # dim=64, OK
+    with pytest.raises(ValueError):
+        store.add_texts(["world"], ids=["my-id"])  # dim=32, must reject
+
+    # Original data survives the failed upsert.
+    assert "my-id" in store._docs
+    assert store._docs["my-id"][0] == "hello"
+    assert len(store._index) == 1
+    assert len(store._u64_to_str) == 1
+
+
 def test_get_by_ids_empty_input_and_order_preserved():
     # Two contract points the reference makes that our existing tests
     # don't pin: (1) empty input returns [] without erroring; (2) output

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -242,6 +242,24 @@ def test_add_upsert_replaces_same_node_id():
     assert result.nodes[0].get_content() == "v2"
 
 
+def test_add_upsert_dim_mismatch_preserves_existing_node():
+    # An upsert whose new embedding fails validation must not destroy the
+    # existing node: the delete is deferred until the add succeeds.
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    first = TextNode(text="v1", embedding=_unit_vec(1, 64))
+    bad = TextNode(text="v2", id_=first.node_id, embedding=_unit_vec(2, 32))
+    store.add([first])
+    with pytest.raises(ValueError):
+        store.add([bad])  # dim 32 != index dim 64
+
+    assert len(store._index) == 1
+    assert first.node_id in store._node_id_to_u64
+    result = store.query(
+        VectorStoreQuery(query_embedding=_unit_vec(1, 64), similarity_top_k=1)
+    )
+    assert result.nodes[0].get_content() == "v1"
+
+
 # ------------------- Filtered query -------------------
 
 def _store_with_tiered_nodes() -> TurboQuantVectorStore:


### PR DESCRIPTION
Closes #89.

## Problem

All four integrations' upsert paths **deleted the old data before validating/encoding the new batch**. If the new embeddings failed validation (a dimension change between calls, or non-finite values rejected by `add_with_ids`), the old data was already gone — silent data loss on a failed re-ingest.

| Integration | Method | Deleted before validating |
|---|---|---|
| langchain | `_store_texts_and_vectors` | dim check + `add_with_ids` |
| llama_index | `add` | everything (ndim, dim, add) |
| haystack | `write_documents` (OVERWRITE) | ndim, dim, add |
| agno | `upsert` / `async_upsert` | `insert()`'s dim check + add |

## Fix

**Defer the delete until after the add succeeds**, so a failed validation/encode never destroys existing data:

- **langchain / llama_index / haystack** — validate, add the new vectors (fresh handles, old + new coexist briefly), *then* remove the old duplicates. For haystack the OVERWRITE removals are collected during the policy pass and executed after the add (before the new mappings are written, so removal still resolves the old handle).
- **agno** — defer-by-content_hash is unsafe here because `insert()` re-derives ids under the *same* content_hash and would clobber the just-inserted rows. Instead capture the old generation's internal **handles** up front, run `insert()`, then remove those specific handles. New `_remove_handle` helper cleans the id/name/content_hash side-indexes only where no surviving handle still needs them; removes the now-unused `_delete_by_content_hash`.

## Tests

One regression test per integration asserting the original data survives a failed (dim-mismatch) upsert, plus an agno test that a valid upsert still fully replaces the previous generation. Full suite: **340 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)