### PR TITLE
Make plain cargo build work on macOS arm64 (#92)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,7 @@ version = "0.7.0"
 dependencies = [
  "numpy",
  "pyo3",
+ "pyo3-build-config",
  "turbovec",
 ]
 

--- a/turbovec-python/Cargo.toml
+++ b/turbovec-python/Cargo.toml
@@ -12,3 +12,6 @@ crate-type = ["cdylib"]
 turbovec-core = { package = "turbovec", path = "../turbovec" }
 pyo3 = { version = "0.27.0", features = ["extension-module", "abi3-py39"] }
 numpy = "0.27.0"
+
+[build-dependencies]
+pyo3-build-config = "0.27.0"

--- a/turbovec-python/build.rs
+++ b/turbovec-python/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    // Emit the platform-correct linker arguments for a Python extension
+    // module. On macOS this passes `-undefined dynamic_lookup` so symbols
+    // from the Python interpreter (e.g. `Py_True`) resolve at load time
+    // instead of failing the link step. Without it, a plain `cargo build`
+    // on macOS fails with "symbol(s) not found for architecture arm64"
+    // (issue #92). Building via maturin already injects these args; this
+    // makes a bare `cargo build` work too.
+    pyo3_build_config::add_extension_module_link_args();
+}

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -61,7 +61,6 @@ unsafe fn score_4bit_block_neon(
     for batch in 0..n_batches {
         let g_start = batch * FLUSH_EVERY;
         let g_end = (g_start + FLUSH_EVERY).min(n_byte_groups);
-        let n_groups = g_end - g_start;
 
         let mut accum = [vdupq_n_u16(0); 4];
 
@@ -1097,7 +1096,6 @@ unsafe fn score_4query_block_neon(
     for batch in 0..n_batches {
         let g_start = batch * FLUSH_EVERY;
         let g_end = (g_start + FLUSH_EVERY).min(n_byte_groups);
-        let n_groups = g_end - g_start;
 
         let mut acc: [[uint16x8_t; 4]; 4] = [[vdupq_n_u16(0); 4]; 4];
 
@@ -1343,6 +1341,10 @@ pub(crate) fn block_pair_has_allowed(mask: Option<&[u64]>, base_vec_pair: usize)
 /// VM / emulator that doesn't expose AVX2 to userspace). Without this
 /// fallback, pre-AVX2 x86_64 silently returned empty top-k results
 /// instead of falling back to a slower-but-correct kernel.
+///
+/// Not compiled on aarch64, where the NEON kernel is always available and
+/// this scalar path is never reached (it would warn as dead code).
+#[cfg(not(target_arch = "aarch64"))]
 #[allow(clippy::too_many_arguments)]
 fn score_query_into_heap(
     qlut_uint8: &[u8],


### PR DESCRIPTION
Closes #92.

## Problem

A bare `cargo build` (or `cargo test`) on macOS Apple Silicon fails to link the `turbovec-python` extension module:

```
ld: symbol(s) not found for architecture arm64
clang: error: linking with `cc` failed: exit status: 1
```

The `cdylib` references Python interpreter symbols (`Py_True`, etc.) that are only present at load time. maturin injects the right linker args (`-undefined dynamic_lookup` on macOS) so the link succeeds, but a plain `cargo build` doesn't — so anyone cloning and running `cargo build` hits a wall. Reproduced locally.

## Fix

Add a `build.rs` for `turbovec-python` that calls `pyo3_build_config::add_extension_module_link_args()` (with the matching `pyo3-build-config` build-dependency). This emits the platform-correct extension-module linker args for a bare cargo build, matching what maturin already does. End-user `pip install` is unaffected (wheels are built by maturin either way).

Also clears the 3 pre-existing build warnings the reporter asked about:
- two unused `n_groups` bindings in the NEON scoring kernels
- the scalar `score_query_into_heap` fallback is `cfg`-gated out of aarch64 builds, where the NEON kernel is always used and it was dead code (still compiled for x86_64, where it's the pre-AVX2 fallback)

## Verification (macOS arm64)

- `cargo build` ✅  ·  `cargo build --release` ✅ — both now link, zero warnings
- `cargo test -p turbovec` ✅ — all suites pass

Approach matches the patch suggested by @yihong0618 in the issue; implemented and verified independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)