### PR TITLE
Docs: correct API-reference drift, stale comments, and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ appears under each surface it touches.
 
 ## [Unreleased]
 
+### turbovec — Python package
+
+#### Fixed
+
+- **Intra-batch duplicate ids no longer orphan vectors** in the LangChain
+  and Haystack integrations. A repeated id within a single `add_texts` /
+  `add_documents` / `write_documents` call previously added one vector per
+  row while the id→handle map kept only the last, leaving the earlier
+  vectors live in search but mapped to the wrong document and unreachable
+  for delete. Both now resolve duplicates the way their reference stores
+  do — LangChain (`InMemoryVectorStore`) keeps the last occurrence;
+  Haystack (`InMemoryDocumentStore`) applies the `DuplicatePolicy` against
+  the batch-so-far. Fixes #90.
+- **Upsert no longer destroys existing data when the new batch fails
+  validation**, across all four integrations (LangChain, LlamaIndex,
+  Haystack, Agno). The old vectors for matching ids were deleted *before*
+  the incoming batch was validated/encoded, so a dimension change or a
+  non-finite embedding left the store with the originals already gone. The
+  delete is now deferred until after the add succeeds (Agno captures the
+  previous generation's handles and removes them after `insert`). Fixes
+  #89.
+
 ## turbovec 0.7.0 (Python package) + turbovec 0.8.0 (Rust crate) — 2026-05-30
 
 Audit-driven correctness pass on every layer (Rust core, Python bindings,
@@ -728,6 +750,6 @@ turbovec 0.4.4 or later.
   `schema_version` field; loaders reject unknown versions instead of
   silently misinterpreting bytes.
 
-[Unreleased]: https://github.com/RyanCodrai/turbovec/compare/py-v0.4.2...HEAD
+[Unreleased]: https://github.com/RyanCodrai/turbovec/compare/v0.8.0...HEAD
 [py-v0.4.2]: https://github.com/RyanCodrai/turbovec/compare/py-v0.4.1...py-v0.4.2
 [py-v0.4.1]: https://github.com/RyanCodrai/turbovec/compare/py-v0.4.0...py-v0.4.1

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ index.add(more_vectors)
 
 scores, indices = index.search(query, k=10)
 
-index.write("my_index.tq")
-loaded = TurboQuantIndex.load("my_index.tq")
+index.write("my_index.tv")
+loaded = TurboQuantIndex.load("my_index.tv")
 ```
 
 Need stable ids that survive deletes? Use `IdMapIndex`:
@@ -100,7 +100,7 @@ cargo add turbovec
 ```rust
 use turbovec::TurboQuantIndex;
 
-let mut index = TurboQuantIndex::new(1536, 4);
+let mut index = TurboQuantIndex::new(1536, 4).unwrap();
 index.add(&vectors);
 let results = index.search(&queries, 10);
 index.write("index.tv").unwrap();
@@ -112,8 +112,8 @@ For stable external ids that survive deletes:
 ```rust
 use turbovec::IdMapIndex;
 
-let mut index = IdMapIndex::new(1536, 4);
-index.add_with_ids(&vectors, &[1001, 1002, 1003]);
+let mut index = IdMapIndex::new(1536, 4).unwrap();
+index.add_with_ids(&vectors, &[1001, 1002, 1003]).unwrap();
 let (scores, ids) = index.search(&queries, 10);
 index.remove(1002);
 index.write("index.tvim").unwrap();

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,7 +40,7 @@ Before the first add, `idx.dim` is `None`, `len(idx)` is `0`, and `search()` ret
 
 | Method | Notes |
 |---|---|
-| `TurboQuantIndex(dim=None, bit_width=4)` | `bit_width ∈ {2, 4}`. `dim` is optional; when omitted it is inferred from the first `add` call. |
+| `TurboQuantIndex(dim=None, bit_width=4)` | `bit_width ∈ {2, 3, 4}`. `dim` is optional; when omitted it is inferred from the first `add` call. |
 | `add(vectors)` | `vectors` is a contiguous float32 array of shape `(n, dim)`. On a lazy index the first call locks `dim`; subsequent calls must match. Raises `ValueError` on dim mismatch. |
 | `search(queries, k, *, mask=None)` | Returns `(scores, indices)`, both shape `(nq, effective_k)`. Indices are `int64` slot positions. `mask` is an optional `bool` array of length `len(idx)`; when given, only slots with `mask[i] == True` contribute. `effective_k = min(k, mask.sum())`. |
 | `swap_remove(idx)` | O(1). Moves the last vector into `idx`; returns the previous position of that moved vector (so external refs can be updated if needed). |
@@ -136,7 +136,10 @@ Common use cases:
 
 ```
 ┌──────────────────────────────────────┐
-│ 9-byte header                         │
+│ magic    "TVPI"  (4 bytes)            │
+│ version  u8    = 3                     │
+├──────────────────────────────────────┤
+│ core header                           │
 │   bit_width  (u8)                     │
 │   dim        (u32 LE)                 │
 │   n_vectors  (u32 LE)                 │
@@ -144,7 +147,13 @@ Common use cases:
 │ packed codes                          │
 │   (dim / 8) * bit_width * n_vectors   │
 ├──────────────────────────────────────┤
-│ norms  (n_vectors × f32 LE)           │
+│ scales  (n_vectors × f32 LE)          │
+│   per-vector length-renormalization   │
+├──────────────────────────────────────┤
+│ TQ+ trailer                           │
+│   n_calib  (u32 LE)  — 0 or dim       │
+│   shift    (n_calib × f32 LE)         │
+│   scale    (n_calib × f32 LE)         │
 └──────────────────────────────────────┘
 ```
 
@@ -152,10 +161,11 @@ Common use cases:
 
 ```
 ┌──────────────────────────────────────┐
-│ magic   "TVIM"  (4 bytes)             │
-│ version  u8   = 1                     │
+│ magic    "TVIM"  (4 bytes)            │
+│ version  u8    = 3                     │
 ├──────────────────────────────────────┤
-│ core payload (same as .tv)            │
+│ core payload (same as .tv:            │
+│   header + codes + scales + TQ+)      │
 ├──────────────────────────────────────┤
 │ slot_to_id  (n_vectors × u64 LE)      │
 └──────────────────────────────────────┘
@@ -163,6 +173,8 @@ Common use cases:
 
 On load, the reverse `id → slot` map is rebuilt in memory. Duplicate ids in the `slot_to_id` table are rejected as corrupt.
 
-`dim = 0` in the header signals a lazy uncommitted index (the constructor asserts `dim ≥ 8` so this value is unambiguous). `dim = 0` is only valid alongside `n_vectors = 0`; on load it produces an index whose `dim` is `None` until the first `add` / `add_with_ids` call.
+`n_calib = 0` in the TQ+ trailer means identity calibration (a lazy index with no `add` yet, or a pre-TQ+ index that was re-saved); otherwise it equals `dim`. Loading a version-2 file (no TQ+ trailer) is still supported and is read as identity calibration; version 1 (headerless, no magic) is rejected.
 
-Both formats are stable across minor versions. Breaking changes bump the file-format version byte (`.tvim`) or the header length (`.tv`).
+`dim = 0` in the core header signals a lazy uncommitted index. It is only valid alongside `n_vectors = 0`; on load it produces an index whose `dim` is `None` until the first `add` / `add_with_ids` call.
+
+Both formats carry a magic + version byte and are stable across minor versions. Breaking changes bump the version byte.

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -131,7 +131,7 @@ Document metadata must be JSON-serializable — same constraint Agno's `LanceDb`
 
 ## Async
 
-Every public method has an async counterpart (`async_create`, `async_insert`, `async_upsert`, `async_search`, `async_drop`, `async_exists`, `async_name_exists`). When the embedder exposes `async_get_embedding` / `async_get_embeddings_batch_and_usage`, the async paths use it for genuine async embedding generation.
+The lifecycle, write, and read methods have async counterparts: `async_create`, `async_drop`, `async_exists`, `async_name_exists`, `async_get_count`, `async_insert`, `async_upsert`, `async_search`. The remaining methods (the `delete_by_*` family, `update_metadata`, `save`, `id_exists`, `content_hash_exists`, `optimize`) are sync-only. When the embedder exposes `async_get_embedding` / `async_get_embeddings_batch_and_usage`, the async paths use it for genuine async embedding generation.
 
 ## Known limitations
 

--- a/docs/integrations/llama_index.md
+++ b/docs/integrations/llama_index.md
@@ -125,9 +125,9 @@ result = vector_store.query(VectorStoreQuery(
 ))
 ```
 
-Supported operators on `MetadataFilter`: `EQ`, `NE`, `GT`, `LT`, `GTE`, `LTE`, `IN`, `NIN`, `TEXT_MATCH`, `CONTAINS`, `IS_EMPTY`. Conditions: `AND`, `OR`. Nested `MetadataFilters` work. `NOT` and the array-membership operators (`ANY`, `ALL`, `TEXT_MATCH_INSENSITIVE`) are not supported and raise `NotImplementedError`.
+Supported operators on `MetadataFilter`: `EQ`, `NE`, `GT`, `LT`, `GTE`, `LTE`, `IN`, `NIN`, `TEXT_MATCH`, `TEXT_MATCH_INSENSITIVE`, `CONTAINS`, `ANY`, `ALL`, `IS_EMPTY`. Conditions: `AND`, `OR`, `NOT`. Nested `MetadataFilters` work.
 
-Filter semantics match `SimpleVectorStore`'s reference implementation — notably, every operator except `IS_EMPTY` returns `False` when the filter key is missing from the document's metadata, and `TEXT_MATCH` is case-insensitive.
+Filter semantics match `SimpleVectorStore`'s reference implementation — notably, every operator except `IS_EMPTY` returns `False` when the filter key is missing from the document's metadata, and `TEXT_MATCH` is case-sensitive (use `TEXT_MATCH_INSENSITIVE` for a case-insensitive substring match).
 
 Filters are resolved to a handle allowlist **before** scoring. Selective filters return up to `similarity_top_k` matches from the filtered set; you never get fewer just because the filter happened to exclude the top-scoring candidates.
 
@@ -144,6 +144,8 @@ Returns a `List[BaseNode]` reconstructed from the side-car. Missing `node_id`s a
 ## Upsert semantics
 
 Calling `add()` with a node whose `node_id` already exists **replaces** the existing entry. Matches LlamaIndex user expectation when re-indexing the same chunks.
+
+A `node_id` repeated **within a single `add()` batch** raises `ValueError` — deduplicate before calling. (This differs from the LangChain and Haystack stores, which silently keep the last occurrence; here it's a hard error so an accidental duplicate doesn't quietly drop a node.)
 
 ```python
 node = TextNode(text="v1", embedding=[...])

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -662,8 +662,8 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         Builds the namespaced filename
         ``{persist_dir}/{namespace}__vector_store.json`` and forwards to
         :meth:`from_persist_path`. The ``.json`` suffix is conventional —
-        our actual on-disk files use ``.tvim`` and ``.pkl`` extensions
-        derived from the same stem.
+        our actual on-disk files use ``.tvim`` and ``.nodes.json``
+        extensions derived from the same stem.
         """
         persist_fname = f"{namespace}{_NAMESPACE_SEP}{_DEFAULT_PERSIST_FNAME}"
         persist_path = os.path.join(persist_dir, persist_fname)

--- a/turbovec/examples/dump_state.rs
+++ b/turbovec/examples/dump_state.rs
@@ -1,9 +1,9 @@
 //! Dump the rotation matrix and Lloyd-Max codebook for a given (dim, bits) to
-//! a raw little-endian f32 file the Python POC can load with np.fromfile.
+//! a raw little-endian f32 file an external tool can load with np.fromfile.
 //!
-//! Used by benchmarks/rabitq_poc/poc_apples_to_apples.py to consume Rust's
-//! exact rotation and codebook so the Python pipeline matches the Rust
-//! pipeline byte-for-byte at the parameter level.
+//! Useful for cross-checking the Rust encode pipeline against a reference
+//! implementation byte-for-byte at the parameter level — feed the dumped
+//! rotation and codebook into the other pipeline and compare outputs.
 //!
 //! Layout per (dim, bits) tuple, written to `<out>/state_d{dim}_b{bits}.bin`:
 //!   - rotation matrix:   dim * dim   f32, row-major

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -3,7 +3,10 @@
 //! Scores queries against quantized database vectors using nibble-split
 //! lookup tables with architecture-specific SIMD kernels:
 //! - NEON on ARM (sequential code layout)
-//! - AVX2 on x86 (FAISS-style perm0-interleaved layout)
+//! - AVX-512BW on x86 when available, with an AVX2 fallback
+//!   (FAISS-style perm0-interleaved layout); selected at runtime via
+//!   `is_x86_feature_detected!`
+//! - a scalar fallback for any other target
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -377,10 +380,12 @@ unsafe fn search_multi_query_avx2(
 // layout and the existing 32-byte LUT format unchanged — the LUT is
 // `_mm512_broadcast_i64x4`'d so both 256-bit halves see the same shuffle table.
 //
-// After the pair loop, the lower 256 bits of each zmm accumulator hold
-// block b's state and the upper 256 bits hold block b+1's, so the epilogue
-// extracts both halves into `__m256i` locals and runs a shared
-// `avx2_block_epilogue` helper twice — once per block in the pair.
+// The lower 256 bits of each zmm accumulator hold block b's state and the
+// upper 256 bits hold block b+1's. Periodically (every FLUSH_EVERY groups,
+// to keep the u16 lane sums from overflowing) both halves are extracted
+// into `__m256i` locals and folded into per-query f32 accumulators via
+// `avx2_batch_flush_to_fa`; after the last batch a final
+// `avx2_post_flush_heap_update` does the top-k heap insertion.
 //
 // Tail (when `n_blocks` is odd) processes the final unpaired block via an
 // inlined AVX2 inner-loop body at the end. Avoids any masked AVX-512 logic.


### PR DESCRIPTION
Addresses #101 (and more found in a full doc sweep). Docs-only / comments-only — no code behavior change.

## User-facing docs

**README.md**
- Python persistence example used the non-existent `.tq` extension → `.tv`.
- Rust snippets called `TurboQuantIndex::new` / `IdMapIndex::new` (both return `Result`) and used the value directly — wouldn't compile. Added `.unwrap()` to match the crate's own doctests.

**docs/api.md**
- `bit_width` documented as `{2, 4}`; the core accepts `{2, 3, 4}`.
- File-format diagrams were stale (described the pre-magic v1 layout). `.tv` now carries a `TVPI` magic + version 3 + per-vector `scales` + a TQ+ trailer; `.tvim` is version 3 (was documented as 1, which the loader now rejects). Updated both diagrams and the surrounding notes.

**docs/integrations/llama_index.md**
- Filter docs were inverted: `NOT`, `ANY`, `ALL`, and `TEXT_MATCH_INSENSITIVE` are all implemented (doc claimed they raise `NotImplementedError`), and `TEXT_MATCH` is case-sensitive (doc said case-insensitive). Corrected the operator/condition lists and the semantics note. Documented that an intra-batch duplicate `node_id` raises (vs the langchain/haystack keep-last behavior).

**docs/integrations/agno.md**
- "Every public method has an async counterpart" was false; listed the methods that actually have async variants and the sync-only ones.

## Code comments

- `search.rs` module doc claimed only "AVX2 on x86"; it actually has an AVX-512BW kernel selected at runtime with an AVX2 fallback (+ scalar fallback). Also corrected an AVX-512 comment that named a never-called `avx2_block_epilogue` helper.
- `llama_index.py` `from_persist_dir` docstring said the side-car uses `.pkl`; it is `.nodes.json`.
- `dump_state.rs` example referenced `benchmarks/rabitq_poc/poc_apples_to_apples.py`, removed in #97; reworded generically.

## CHANGELOG

- Added an `[Unreleased]` entry for the merged #90 / #89 integration fixes.
- Repointed the stale `[Unreleased]` compare link (`py-v0.4.2` → `v0.8.0`).

## Validation

- `cargo test -p turbovec --doc` passes.
- `cargo build -p turbovec --examples` compiles clean.
- All doc links/images resolve; full public-API doc coverage confirmed.

Reported by @gabrielemidulla (#101); remaining items surfaced in a two-pass doc/comment audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)