### PR TITLE
Release: turbovec 0.7.1 (Python) + 0.8.1 (Rust crate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,26 @@ appears under each surface it touches.
 
 ## [Unreleased]
 
-### turbovec — Python package
+## turbovec 0.7.1 (Python package) + turbovec 0.8.1 (Rust crate) — 2026-06-09
+
+Bug-fix release. Two data-safety fixes in the Python integration wrappers'
+add/upsert paths, plus a source-build fix for the Python extension on macOS.
+The Rust crate is functionally unchanged — only non-behavioral cleanups —
+but is re-released to keep crates.io in sync with the source tree. No
+on-disk format change (still `.tv` / `.tvim` v3).
+
+### turbovec — Rust crate (current: 0.8.0 → next: 0.8.1)
+
+#### Changed
+
+- Internal cleanup only, **no behavior change** — the published crate
+  behaves identically to 0.8.0. Cleared three build warnings (two unused
+  bindings in the NEON scoring kernels; the scalar `score_query_into_heap`
+  fallback is now `cfg`-gated out of `aarch64` builds, where the NEON
+  kernel is always used and it was dead code) and corrected stale SIMD
+  module/kernel doc comments.
+
+### turbovec — Python package (current: 0.7.0 → next: 0.7.1)
 
 #### Fixed
 
@@ -32,6 +51,12 @@ appears under each surface it touches.
   delete is now deferred until after the add succeeds (Agno captures the
   previous generation's handles and removes them after `insert`). Fixes
   #89.
+- **Plain `cargo build` of the extension now links on macOS.** Building
+  `turbovec-python` from source failed with "symbol(s) not found for
+  architecture arm64" because nothing emitted the Python extension-module
+  linker args (maturin injects them; a bare `cargo build` did not). Added a
+  `build.rs` calling `pyo3_build_config::add_extension_module_link_args()`.
+  Prebuilt wheels were unaffected. Fixes #92.
 
 ## turbovec 0.7.0 (Python package) + turbovec 0.8.0 (Rust crate) — 2026-05-30
 
@@ -750,6 +775,6 @@ turbovec 0.4.4 or later.
   `schema_version` field; loaders reject unknown versions instead of
   silently misinterpreting bytes.
 
-[Unreleased]: https://github.com/RyanCodrai/turbovec/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/RyanCodrai/turbovec/compare/v0.8.1...HEAD
 [py-v0.4.2]: https://github.com/RyanCodrai/turbovec/compare/py-v0.4.1...py-v0.4.2
 [py-v0.4.1]: https://github.com/RyanCodrai/turbovec/compare/py-v0.4.0...py-v0.4.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "turbovec"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "faer",
  "ndarray",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "turbovec-python"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "numpy",
  "pyo3",

--- a/turbovec-python/Cargo.toml
+++ b/turbovec-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbovec-python"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.70"
 

--- a/turbovec-python/pyproject.toml
+++ b/turbovec-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "turbovec"
-version = "0.7.0"
+version = "0.7.1"
 description = "Fast vector quantization with 2-4 bit compression and SIMD search"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/turbovec/Cargo.toml
+++ b/turbovec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbovec"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.70"
 description = "Fast vector quantization with 2-4 bit compression and SIMD search"


### PR DESCRIPTION
Version bump + CHANGELOG finalization. Mirrors the established release-PR shape (#84): CHANGELOG + the three manifests + Cargo.lock, nothing else.

## What's in this release

**Python 0.7.0 → 0.7.1** — bug-fix release:
- #90 — intra-batch duplicate ids no longer orphan vectors (LangChain, Haystack)
- #89 — upsert no longer destroys existing data when the new batch fails validation (all four integrations)
- #92 — plain `cargo build` of the extension now links on macOS (source-build fix; prebuilt wheels were unaffected)

**Rust crate 0.8.0 → 0.8.1** — no behavior change:
- Non-behavioral cleanup only (cleared 3 warnings, corrected stale SIMD doc comments). The published crate behaves identically to 0.8.0; re-released to keep crates.io in sync with the source tree.

## Publish steps (after merge — maintainer)

Releases are tag-triggered:
- Push `py-v0.7.1` → PyPI workflow
- Push `v0.8.1` → crates.io workflow

I have **not** pushed any tags — that's the irreversible publish step and is left to you.

## Notes
- No on-disk format change (still `.tv` / `.tvim` v3).
- `cargo build -p turbovec -p turbovec-python` compiles clean at the new versions; Cargo.lock updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)