### PR TITLE
Release: turbovec 0.9.0 (Rust crate) + 0.8.0 (Python package)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,81 @@ appears under each surface it touches.
 
 ## [Unreleased]
 
+## turbovec 0.8.0 (Python package) + turbovec 0.9.0 (Rust crate) — 2026-06-10
+
+Security-audit release. Two adversarial audit passes over the core crate,
+the Python binding, and the framework integrations, hardening the
+untrusted-file load path and the Python API surface and fixing several
+data-integrity bugs in the integration wrappers. Resolves #104, #105, and
+#106. No on-disk format change (still `.tv` / `.tvim` v3).
+
+A few fixes change observable behavior — see **Changed** under each surface.
+They turn previously-undefined or silently-wrong situations into clean,
+typed errors, so the bump is minor rather than patch.
+
+### turbovec — Rust crate (current: 0.8.1 → next: 0.9.0)
+
+#### Fixed
+
+- **Untrusted index files are validated before allocation on load.** A
+  crafted `.tv` / `.tvim` could previously trigger an integer-overflow in
+  the packed-size computation, drive a multi-gigabyte allocation from a
+  tiny file, divide-by-zero in the repack step, or load a structurally
+  invalid index that returned silently-wrong scores (a `bit_width` of 5–8
+  passed the old length check). The loader now range-checks `bit_width` and
+  `dim`, computes every size with checked arithmetic, and reads each payload
+  through a length-capped reader. (#105)
+- **x86 scalar fallback returned wrong results.** On pre-AVX2 x86 (or VMs
+  without AVX2), `score_query_into_heap` read the perm0-interleaved code
+  layout as if sequential, producing an incorrect top-k. It now
+  de-interleaves correctly; verified end-to-end against the SIMD kernels on
+  AVX-512 hardware. (#106)
+
+#### Changed
+
+- **`dim` is capped at `MAX_DIM` (65536)** at construction, first add, and
+  load. `search` lazily builds a `dim`×`dim` rotation matrix whose size is
+  not bounded by any file, so an unbounded `dim` was a load-time
+  resource-exhaustion vector. Larger dims now return a typed error.
+- **A zero-`dim` lazy add is rejected** with `AddError` instead of panicking
+  with a divide-by-zero and wedging the index.
+
+#### Removed
+
+- Dead, untested `pack::repack_3bit` (no callers; 3-bit goes through
+  `repack`).
+
+### turbovec — Python package (current: 0.7.1 → next: 0.8.0)
+
+#### Fixed
+
+- **`search()` no longer panics on NaN / Inf / oversized query
+  coordinates.** These previously raised an uncatchable `PanicException`
+  (a `BaseException`); they now raise `ValueError`, matching `add`. (#105)
+- **Loading a malformed `.tv` / `.tvim` raises a clean error** instead of
+  panicking or driving a huge allocation (the Rust load-path hardening
+  above, surfaced through the binding).
+- **agno: duplicate derived `doc_id` no longer orphans vectors.** Two
+  documents that derive the same id (a repeated `doc.id`, or identical
+  content) are both kept and both deletable, matching agno's reference
+  store (LanceDb appends). Previously the earlier vector was counted and
+  searchable but unreachable by id, and leaked on every upsert. (#104)
+- **agno: `delete_by_name` / `delete_by_content_id` / `delete_by_metadata`
+  no longer over-delete.** When distinct documents collided on a
+  content-derived `doc_id`, deleting by one attribute also deleted the
+  id-twin; deletion now targets only the documents matching the predicate.
+- **LangChain / Haystack / LlamaIndex: a persisted JSON side-car that is out
+  of sync with its `.tvim` index now raises a `ValueError` at load** instead
+  of an opaque `KeyError` deep inside a later query.
+- **Internal binding result-shape errors map to `RuntimeError`** rather than
+  an uncatchable panic.
+
+#### Changed
+
+- `search()` and the index constructors now raise `ValueError` for
+  non-finite query values and for `dim` outside the supported range, where
+  some of these inputs previously panicked or were silently accepted.
+
 ## turbovec 0.7.1 (Python package) + turbovec 0.8.1 (Rust crate) — 2026-06-09
 
 Bug-fix release. Two data-safety fixes in the Python integration wrappers'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,12 @@ typed errors, so the bump is minor rather than patch.
   non-finite query values and for `dim` outside the supported range, where
   some of these inputs previously panicked or were silently accepted.
 
+### Docs
+
+- Corrected stale benchmark figures in the README (recall deltas, ARM/x86
+  speed ranges) to match the current `benchmarks/results/`; several had
+  drifted from before the TQ+ calibration step landed.
+
 ## turbovec 0.7.1 (Python package) + turbovec 0.8.1 (Rust crate) — 2026-06-09
 
 Bug-fix release. Two data-safety fixes in the Python integration wrappers'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ typed errors, so the bump is minor rather than patch.
 - Dead, untested `pack::repack_3bit` (no callers; 3-bit goes through
   `repack`).
 
+#### Other
+
+- The crate now fails to compile on non-64-bit targets (a `compile_error!`
+  gated on `target_pointer_width`). The size/offset arithmetic in
+  `encode`/`pack`/`search` assumes 64-bit `usize`; refusing to build on
+  32-bit/wasm avoids shipping a silently-unsafe (potential out-of-bounds)
+  build there.
+
 ### turbovec — Python package (current: 0.7.1 → next: 0.8.0)
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ typed errors, so the bump is minor rather than patch.
 
 #### Changed
 
+- **`AddError` and `ConstructError` are now `#[non_exhaustive]`.** Downstream
+  `match` on these enums must carry a wildcard arm; in exchange, future error
+  variants are no longer breaking changes. (The new `DimTooLarge` variant is
+  why this release is the moment to make the switch.)
 - **`dim` is capped at `MAX_DIM` (65536)** at construction, first add, and
   load. `search` lazily builds a `dim`×`dim` rotation matrix whose size is
   not bounded by any file, so an unbounded `dim` was a load-time

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "turbovec"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "faer",
  "ndarray",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "turbovec-python"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "numpy",
  "pyo3",

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 
 **A 10 million document corpus takes 31 GB of RAM as float32. turbovec fits it in 4 GB - and searches it faster than FAISS.**
 
-turbovec is a Rust vector index with Python bindings, built on Google Research's [**TurboQuant**](https://arxiv.org/abs/2504.19874) algorithm — a data-oblivious quantizer that matches the Shannon lower bound on distortion, with no codebook training and no separate train phase.
+turbovec is a Rust vector index with Python bindings, built on Google Research's [**TurboQuant**](https://arxiv.org/abs/2504.19874) algorithm — a data-oblivious quantizer with near-optimal distortion (within a small constant of the Shannon lower bound), with no codebook training and no separate train phase.
 
 - **Online ingest.** Add vectors, they're indexed — no train step, no parameter tuning, no rebuilds as the corpus grows.
-- **Faster than FAISS.** Hand-written NEON (ARM) and AVX-512BW (x86) kernels beat FAISS IndexPQFastScan by 12–20% on ARM and match-or-beat it on x86.
+- **Fast SIMD search.** Hand-written NEON (ARM) and AVX-512BW (x86) kernels beat FAISS IndexPQFastScan by 10–19% on ARM; on x86 they win the 4-bit configs and trail by a few percent on 2-bit.
 - **Filter at search time.** Pass an id allowlist (or a slot bitmask) to `search()` and the kernel honours it directly. You always get up to `k` results from the allowed set — no over-fetching, no recall hit on selective filters.
 - **Pure local.** No managed service, no data leaving your machine or VPC. Pair with any open-source embedding model for a fully air-gapped RAG stack.
 
@@ -130,7 +130,7 @@ TurboQuant vs FAISS `IndexPQ` (LUT256, nbits=8) — the paper's Section 4.4 base
 
 ![Recall d=3072](docs/recall_d3072.svg)
 
-Across OpenAI d=1536 and d=3072, TurboQuant beats FAISS by 0.4–3.4 points at R@1 across 2-bit and 4-bit, and both converge to 1.0 by k=4. GloVe d=200 is the harder regime — at low dim the asymptotic Beta assumption is looser. TurboQuant beats FAISS by 0.3 points at 4-bit and trails by 1.2 points at 2-bit at R@1, both closing to FAISS by k≈16.
+Across OpenAI d=1536 and d=3072, TurboQuant beats FAISS by 0.2–1.9 points at R@1 across 2-bit and 4-bit, and both reach ~1.0 by k=4. GloVe d=200 is the harder regime — at low dim the asymptotic Beta assumption is looser. TurboQuant beats FAISS by 0.9 points at 4-bit and is effectively tied at 2-bit (within 0.1 points) at R@1, both tracking FAISS closely by k≈16.
 
 **A note on baselines.** We compare against FAISS `IndexPQ` (LUT256, nbits=8, float32 LUT) because it's the default production-grade PQ most users would reach for. This is a stronger baseline than the custom u8-LUT PQ in the [TurboQuant paper](https://arxiv.org/abs/2504.19874) — FAISS uses a higher-precision LUT at scoring time and k-means++ for codebook training. We reproduce the paper's TurboQuant numbers on OpenAI d=1536 / d=3072 and hit similar numbers to other community reference implementations on low-dim embeddings (see [`turboquant-py`](https://pypi.org/project/turboquant-py/) at d=384). The visible gap on GloVe reflects FAISS being a strong baseline, not a TurboQuant implementation issue.
 
@@ -150,7 +150,7 @@ All benchmarks: 100K vectors, 1K queries, k=64, median of 5 runs.
 
 ![ARM Speed — Multi-threaded](docs/arm_speed_mt.svg)
 
-On ARM, TurboQuant beats FAISS FastScan by 12–20% across every config.
+On ARM, TurboQuant beats FAISS FastScan by 10–19% across every config.
 
 ### x86 (Intel Xeon Platinum 8481C / Sapphire Rapids, 8 vCPUs)
 
@@ -158,7 +158,7 @@ On ARM, TurboQuant beats FAISS FastScan by 12–20% across every config.
 
 ![x86 Speed — Multi-threaded](docs/x86_speed_mt.svg)
 
-On x86, TurboQuant wins every 4-bit config by 1–6% and runs within ~1% of FAISS on 2-bit ST. The 2-bit MT rows (d=1536 and d=3072) are the only configs sitting slightly behind FAISS (2–4%), where the inner accumulate loop is too short for unrolling amortization to match FAISS's AVX-512 VBMI path.
+On x86, TurboQuant wins the 4-bit configs by up to ~5% (d=3072 multi-threaded is a tie) and trails FAISS on 2-bit by 3–8%, where the short 2-bit accumulate loop doesn't give the unrolling enough work to amortize against FAISS's AVX-512 VBMI path.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **A 10 million document corpus takes 31 GB of RAM as float32. turbovec fits it in 4 GB - and searches it faster than FAISS.**
 
-turbovec is a Rust vector index with Python bindings, built on Google Research's [**TurboQuant**](https://arxiv.org/abs/2504.19874) algorithm — a data-oblivious quantizer with near-optimal distortion (within a small constant of the Shannon lower bound), with no codebook training and no separate train phase.
+turbovec is a Rust vector index with Python bindings, built on Google Research's [**TurboQuant**](https://arxiv.org/abs/2504.19874) algorithm — a data-oblivious quantizer with near-optimal distortion and no separate training phase.
 
 - **Online ingest.** Add vectors, they're indexed — no train step, no parameter tuning, no rebuilds as the corpus grows.
 - **Fast SIMD search.** Hand-written NEON (ARM) and AVX-512BW (x86) kernels beat FAISS IndexPQFastScan by 10–19% on ARM; on x86 they win the 4-bit configs and trail by a few percent on 2-bit.
@@ -130,9 +130,9 @@ TurboQuant vs FAISS `IndexPQ` (LUT256, nbits=8) — the paper's Section 4.4 base
 
 ![Recall d=3072](docs/recall_d3072.svg)
 
-Across OpenAI d=1536 and d=3072, TurboQuant beats FAISS by 0.2–1.9 points at R@1 across 2-bit and 4-bit, and both reach ~1.0 by k=4. GloVe d=200 is the harder regime — at low dim the asymptotic Beta assumption is looser. TurboQuant beats FAISS by 0.9 points at 4-bit and is effectively tied at 2-bit (within 0.1 points) at R@1, both tracking FAISS closely by k≈16.
+Across OpenAI d=1536 and d=3072, TurboQuant beats FAISS by 0.2–1.9 points at R@1 across 2-bit and 4-bit, and both reach 1.0 by k=8 (≥0.997 already at k=4). GloVe d=200 is the harder regime — at low dim the asymptotic Beta assumption is looser. TurboQuant beats FAISS by 0.9 points at 4-bit and is effectively tied at 2-bit (within 0.1 points) at R@1, both tracking FAISS closely by k≈16.
 
-**A note on baselines.** We compare against FAISS `IndexPQ` (LUT256, nbits=8, float32 LUT) because it's the default production-grade PQ most users would reach for. This is a stronger baseline than the custom u8-LUT PQ in the [TurboQuant paper](https://arxiv.org/abs/2504.19874) — FAISS uses a higher-precision LUT at scoring time and k-means++ for codebook training. We reproduce the paper's TurboQuant numbers on OpenAI d=1536 / d=3072 and hit similar numbers to other community reference implementations on low-dim embeddings (see [`turboquant-py`](https://pypi.org/project/turboquant-py/) at d=384). The visible gap on GloVe reflects FAISS being a strong baseline, not a TurboQuant implementation issue.
+**A note on baselines.** We compare against FAISS `IndexPQ` (LUT256, nbits=8, float32 LUT) because it's the default production-grade PQ most users would reach for. This is a stronger baseline than the custom u8-LUT PQ in the [TurboQuant paper](https://arxiv.org/abs/2504.19874) — FAISS uses a higher-precision LUT at scoring time and k-means++ for codebook training. We reproduce the paper's TurboQuant numbers on OpenAI d=1536 / d=3072 and hit similar numbers to other community reference implementations on low-dim embeddings (see [`turboquant-py`](https://pypi.org/project/turboquant-py/) at d=384). On GloVe (d=200) — the low-dim regime where the asymptotic Beta assumption is loosest — TurboQuant lands level with FAISS at 2-bit and ahead at 4-bit; TQ+ calibration closes the low-dim gap the base algorithm leaves.
 
 Full results: [d=1536 2-bit](benchmarks/results/recall_d1536_2bit.json), [d=1536 4-bit](benchmarks/results/recall_d1536_4bit.json), [d=3072 2-bit](benchmarks/results/recall_d3072_2bit.json), [d=3072 4-bit](benchmarks/results/recall_d3072_4bit.json), [GloVe 2-bit](benchmarks/results/recall_glove_2bit.json), [GloVe 4-bit](benchmarks/results/recall_glove_4bit.json).
 
@@ -158,7 +158,7 @@ On ARM, TurboQuant beats FAISS FastScan by 10–19% across every config.
 
 ![x86 Speed — Multi-threaded](docs/x86_speed_mt.svg)
 
-On x86, TurboQuant wins the 4-bit configs by up to ~5% (d=3072 multi-threaded is a tie) and trails FAISS on 2-bit by 3–8%, where the short 2-bit accumulate loop doesn't give the unrolling enough work to amortize against FAISS's AVX-512 VBMI path.
+On x86, TurboQuant wins the 4-bit configs by up to ~5% (d=3072 multi-threaded ties) and is modestly behind FAISS on 2-bit — most visibly d=1536 single-threaded (~8%), within a few percent on the rest — where FAISS's AVX-512 VBMI path has the edge on the short 2-bit accumulate loop.
 
 ## How it works
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,76 @@
+# Security Policy
+
+Thank you for helping keep turbovec and its users safe. Security reports are
+genuinely appreciated.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security vulnerability.** A public
+report tips off attackers before a fix is available.
+
+Instead, report it privately through GitHub:
+
+1. Go to the [**Security** tab](https://github.com/RyanCodrai/turbovec/security)
+   of this repository.
+2. Click **"Report a vulnerability"** to open a private advisory visible only
+   to the maintainers.
+
+This routes the report through GitHub's private vulnerability reporting, where
+we can discuss, develop, and review a fix — and, if appropriate, request a CVE
+— without disclosing the issue until a patch is ready.
+
+If you are unable to use private reporting, you may contact the maintainer
+directly; do not include exploit details in a public channel.
+
+### What to include
+
+A good report makes a fix faster. Where you can, please include:
+
+- the affected component (core Rust crate, Python bindings, or a specific
+  framework integration) and the version,
+- a description of the issue and its impact,
+- a minimal reproduction — for a malformed-input bug, the crafted `.tv` /
+  `.tvim` bytes or the API call sequence that triggers it,
+- the platform/architecture if relevant.
+
+## What to expect
+
+- We aim to acknowledge a report within a few days.
+- We will confirm the issue, keep you updated on the fix, and coordinate a
+  disclosure timeline with you.
+- With your permission, we will credit you in the published advisory.
+
+Once a fix is released, we publish a GitHub Security Advisory so that the
+vulnerability is recorded in the GitHub Advisory Database and downstream users
+on crates.io and PyPI are alerted (e.g. via Dependabot) to upgrade.
+
+## Supported versions
+
+turbovec is pre-1.0 and ships frequently. Security fixes target the **latest
+released version** of each surface:
+
+- the `turbovec` crate on [crates.io](https://crates.io/crates/turbovec), and
+- the `turbovec` distribution on [PyPI](https://pypi.org/project/turbovec/).
+
+Please reproduce on the latest release before reporting where possible.
+
+## Scope
+
+In scope — for example:
+
+- memory-unsafety or out-of-bounds access reachable from the public API,
+- a panic, crash, or unbounded allocation triggered by loading an untrusted
+  `.tv` / `.tvim` index file,
+- a panic or silently-wrong result reachable from normal Python/Rust API use
+  (e.g. malformed query input),
+- data-integrity defects in the framework integration wrappers.
+
+Generally out of scope:
+
+- resource exhaustion driven only by a caller's own legitimately-large data on
+  a supported (64-bit) target,
+- behavior on unsupported targets (turbovec requires a 64-bit platform and
+  refuses to compile elsewhere).
+
+When in doubt, report it — we would rather triage an out-of-scope report than
+miss a real one.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,9 +19,6 @@ This routes the report through GitHub's private vulnerability reporting, where
 we can discuss, develop, and review a fix — and, if appropriate, request a CVE
 — without disclosing the issue until a patch is ready.
 
-If you are unable to use private reporting, you may contact the maintainer
-directly; do not include exploit details in a public channel.
-
 ### What to include
 
 A good report makes a fix faster. Where you can, please include:

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,9 +40,9 @@ Before the first add, `idx.dim` is `None`, `len(idx)` is `0`, and `search()` ret
 
 | Method | Notes |
 |---|---|
-| `TurboQuantIndex(dim=None, bit_width=4)` | `bit_width ∈ {2, 3, 4}`. `dim` is optional; when omitted it is inferred from the first `add` call. |
-| `add(vectors)` | `vectors` is a contiguous float32 array of shape `(n, dim)`. On a lazy index the first call locks `dim`; subsequent calls must match. Raises `ValueError` on dim mismatch. |
-| `search(queries, k, *, mask=None)` | Returns `(scores, indices)`, both shape `(nq, effective_k)`. Indices are `int64` slot positions. `mask` is an optional `bool` array of length `len(idx)`; when given, only slots with `mask[i] == True` contribute. `effective_k = min(k, mask.sum())`. |
+| `TurboQuantIndex(dim=None, bit_width=4)` | `bit_width ∈ {2, 3, 4}`. `dim` must be a positive multiple of 8 and `≤ 65536` (`MAX_DIM`). `dim` is optional; when omitted it is inferred from the first `add` call. |
+| `add(vectors)` | `vectors` is a contiguous float32 array of shape `(n, dim)`. On a lazy index the first call locks `dim`; subsequent calls must match. Raises `ValueError` on dim mismatch, a zero-width (0-column) batch, or any coordinate that is non-finite (NaN/Inf) or `\|value\| ≥ 1e16`. |
+| `search(queries, k, *, mask=None)` | Returns `(scores, indices)`, both shape `(nq, effective_k)`. Indices are `int64` slot positions. `mask` is an optional `bool` array of length `len(idx)`; when given, only slots with `mask[i] == True` contribute. `effective_k = min(k, mask.sum())`. Raises `ValueError` on a non-finite or `\|value\| ≥ 1e16` query coordinate. |
 | `swap_remove(idx)` | O(1). Moves the last vector into `idx`; returns the previous position of that moved vector (so external refs can be updated if needed). |
 | `prepare()` | Optional. Eagerly builds the rotation matrix, Lloyd-Max centroids and SIMD-blocked layout so the first `search` call doesn't pay the one-time cost. No-op on a lazy index that hasn't seen its first add. |
 | `write(path)` / `load(path)` | `.tv` format. |
@@ -87,10 +87,10 @@ idx.add_with_ids(vectors, ids)           # locks dim to vectors.shape[1]
 
 | Method | Notes |
 |---|---|
-| `IdMapIndex(dim=None, bit_width=4)` | `dim` is optional; when omitted it is inferred from the first `add_with_ids` call. |
-| `add_with_ids(vectors, ids)` | `ids` is a `uint64` array with length `vectors.shape[0]`. On a lazy index the first call locks `dim`. Raises `ValueError` on dim mismatch, duplicate ids, or `len(ids) != vectors.shape[0]`. |
+| `IdMapIndex(dim=None, bit_width=4)` | `bit_width ∈ {2, 3, 4}`; `dim` must be a positive multiple of 8 and `≤ 65536`. `dim` is optional; when omitted it is inferred from the first `add_with_ids` call. |
+| `add_with_ids(vectors, ids)` | `ids` is a `uint64` array with length `vectors.shape[0]`. On a lazy index the first call locks `dim`. Raises `ValueError` on dim mismatch, duplicate ids, `len(ids) != vectors.shape[0]`, a zero-width batch, or a non-finite / `\|value\| ≥ 1e16` coordinate. |
 | `remove(id) -> bool` | `True` if the id was present and removed, `False` otherwise. O(1). |
-| `search(queries, k, *, allowlist=None)` | Returns `(scores, ids)` — `ids` are `uint64` external ids. `allowlist` is an optional `uint64` array of ids; when given, results are restricted to those ids and `effective_k = min(k, len(allowlist))`. Raises `ValueError` on empty allowlist and `KeyError` on unknown ids. |
+| `search(queries, k, *, allowlist=None)` | Returns `(scores, ids)` — `ids` are `uint64` external ids. `allowlist` is an optional `uint64` array of ids; when given, results are restricted to those ids and `effective_k = min(k, len(allowlist))`. Raises `ValueError` on an empty allowlist or a non-finite / `\|value\| ≥ 1e16` query coordinate, and `KeyError` on unknown ids. |
 | `contains(id)` / `id in idx` | Membership. |
 | `write(path)` / `load(path)` | `.tvim` format. |
 | `len(idx)` / `idx.dim` / `idx.bit_width` / `prepare()` | Same as `TurboQuantIndex`. |
@@ -172,6 +172,8 @@ Common use cases:
 ```
 
 On load, the reverse `id → slot` map is rebuilt in memory. Duplicate ids in the `slot_to_id` table are rejected as corrupt.
+
+Both `.tv` and `.tvim` loads validate the header **before allocating**: `bit_width` must be 2/3/4, `dim` a positive multiple of 8 and `≤ 65536`, and every payload size is computed with checked arithmetic and read through a length-capped reader. A malformed or untrusted file therefore raises a clean error rather than panicking, dividing by zero, or driving an oversized allocation.
 
 `n_calib = 0` in the TQ+ trailer means identity calibration (a lazy index with no `add` yet, or a pre-TQ+ index that was re-saved); otherwise it equals `dim`. Loading a version-2 file (no TQ+ trailer) is still supported and is read as identity calibration; version 1 (headerless, no magic) is rejected.
 

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -57,6 +57,8 @@ TurboQuantVectorDb(
 
 `insert` and `upsert` follow the same `(content_hash, documents, filters)` signature as `LanceDb`. The internal `doc_id` is derived as `md5(f"{base_id}_{content_hash}")` where `base_id` is `doc.id` (or `md5(content)` when missing). The contract: the same `(base_id, content_hash)` pair always produces the same internal id, and the same `base_id` with a *different* `content_hash` is treated as a new entry — letting you keep content versions side-by-side.
 
+Because `doc_id` is derived from `base_id` + `content_hash` (not from `name`, `content_id`, or metadata), two documents can collide on the same `doc_id` — a repeated explicit `doc.id`, or two documents with identical content and no id. When that happens **both are stored and both remain individually deletable** — keep-all, matching `LanceDb`'s append-only behavior. (This differs from the LangChain store, which keeps the last write per id.)
+
 ```python
 from agno.knowledge.document import Document
 
@@ -102,7 +104,7 @@ vector_db.drop()                                  # clear all
 vector_db.delete()                                # alias for drop(), returns True
 ```
 
-Each `delete_by_*` returns `True` iff at least one document was removed.
+Each `delete_by_*` returns `True` iff at least one document was removed. `delete_by_name` / `delete_by_content_id` / `delete_by_metadata` remove only the documents matching that exact predicate, even when other stored documents share the same derived `doc_id`. `delete_by_id` removes every document under that internal id.
 
 ## update_metadata
 
@@ -127,7 +129,7 @@ Writes two files under the given folder path:
 - `index.tvim` — the `IdMapIndex` payload.
 - `docstore.json` — JSON-encoded document text, metadata, and id maps.
 
-Document metadata must be JSON-serializable — same constraint Agno's `LanceDb` imposes on its payload column. The side-car carries a `schema_version` field; loaders refuse to deserialize unknown versions.
+Document metadata must be JSON-serializable — same constraint Agno's `LanceDb` imposes on its payload column. The side-car carries a `schema_version` field; loaders refuse to deserialize unknown versions, and validate that the side-car's id maps are consistent with the loaded `index.tvim` (a mismatched or out-of-sync pair raises at load rather than failing later at query time).
 
 ## Async
 

--- a/docs/integrations/haystack.md
+++ b/docs/integrations/haystack.md
@@ -140,7 +140,7 @@ Writes two files under the given folder path:
 - `index.tvim` — the `IdMapIndex` payload (quantized vectors + id maps).
 - `docstore.json` — JSON-encoded document text, metadata, and id maps.
 
-Document metadata must be JSON-serializable — the same constraint `InMemoryDocumentStore.save_to_disk` imposes.
+Document metadata must be JSON-serializable — the same constraint `InMemoryDocumentStore.save_to_disk` imposes. If the `docstore.json` side-car is out of sync with its `index.tvim` (a partial copy, a stale backup, tampering), `load_from_disk` raises a `ValueError` immediately rather than failing later with a `KeyError` at query time.
 
 ## Using in a Haystack Pipeline
 

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -135,7 +135,7 @@ Writes two files under the given folder path:
 - `index.tvim` — the `IdMapIndex` payload (see [api.md](../api.md#tvim--idmapindex)).
 - `docstore.json` — JSON-encoded document text, metadata, and id maps.
 
-Document metadata must be JSON-serializable — the same constraint `InMemoryVectorStore.dump` imposes.
+Document metadata must be JSON-serializable — the same constraint `InMemoryVectorStore.dump` imposes. If the `docstore.json` side-car is out of sync with its `index.tvim` (a partial copy, a stale backup, tampering), `load` raises a `ValueError` immediately rather than failing later with a `KeyError` at query time.
 
 ## Known limitations
 

--- a/docs/integrations/llama_index.md
+++ b/docs/integrations/llama_index.md
@@ -180,7 +180,7 @@ vector_store.persist("./store/vectors.json")
 vector_store = TurboQuantVectorStore.from_persist_path("./store/vectors.json")
 ```
 
-`persist_path` is treated as a path *stem* — the binary index and JSON side-car are written next to each other as `{stem}.tvim` and `{stem}.nodes.json`. The extension on `persist_path` (e.g. `.json`, as LlamaIndex's StorageContext default uses) is replaced. Node metadata must be JSON-serializable.
+`persist_path` is treated as a path *stem* — the binary index and JSON side-car are written next to each other as `{stem}.tvim` and `{stem}.nodes.json`. The extension on `persist_path` (e.g. `.json`, as LlamaIndex's StorageContext default uses) is replaced. Node metadata must be JSON-serializable. If the `{stem}.nodes.json` side-car is out of sync with its `{stem}.tvim` index (a partial copy, a stale backup, tampering), `from_persist_path` raises a `ValueError` immediately rather than failing later with a `KeyError` at query time.
 
 ### Via `StorageContext`
 

--- a/turbovec-python/Cargo.toml
+++ b/turbovec-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbovec-python"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.70"
 

--- a/turbovec-python/pyproject.toml
+++ b/turbovec-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "turbovec"
-version = "0.7.1"
+version = "0.8.0"
 description = "Fast vector quantization with 2-4 bit compression and SIMD search"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/turbovec/Cargo.toml
+++ b/turbovec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbovec"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.70"
 description = "Fast vector quantization with 2-4 bit compression and SIMD search"

--- a/turbovec/src/error.rs
+++ b/turbovec/src/error.rs
@@ -23,7 +23,10 @@ use std::fmt;
 // Eq dropped from the derive because `InvalidInputValue` carries an f32,
 // which is not `Eq` (NaN != NaN). PartialEq still works for the
 // finite-input cases tests assert against.
+// `#[non_exhaustive]` so adding error variants in future releases is not a
+// breaking change — downstream `match` on this enum must carry a wildcard arm.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum AddError {
     /// Batch dim does not match the index's already-locked dim.
     DimMismatch { existing: usize, got: usize },
@@ -96,7 +99,10 @@ impl fmt::Display for AddError {
 
 impl Error for AddError {}
 
+// `#[non_exhaustive]` so adding error variants in future releases is not a
+// breaking change — downstream `match` on this enum must carry a wildcard arm.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ConstructError {
     /// `bit_width` must be 2, 3, or 4.
     BitWidthOutOfRange(usize),

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -34,6 +34,15 @@
 //! `OnceLock`. This keeps the invariant that once a cache is populated
 //! from `&self`, it matches the current `packed_codes`.
 
+// turbovec is 64-bit by design: the SIMD kernels, the `usize` size/offset
+// arithmetic in `encode`/`pack`/`search`, and all benchmarks assume a 64-bit
+// pointer width. On a 32-bit (or 16-bit) target those size computations could
+// overflow `usize` and index out of bounds. Refuse to compile there rather
+// than ship a silently-unsafe build — supporting 32-bit/wasm would require a
+// dedicated checked-arithmetic pass first.
+#[cfg(not(target_pointer_width = "64"))]
+compile_error!("turbovec requires a 64-bit target (target_pointer_width = \"64\")");
+
 pub mod codebook;
 pub mod encode;
 pub mod error;


### PR DESCRIPTION
Release **turbovec 0.9.0 (Rust crate)** + **0.8.0 (Python package)** — the security-audit release (#108 fixes).

## Version bumps
- `turbovec/Cargo.toml`: 0.8.1 → **0.9.0**
- `turbovec-python/Cargo.toml` + `pyproject.toml`: 0.7.1 → **0.8.0**

Minor bump on both because a few inputs that previously panicked or were silently accepted now return typed errors (NaN/Inf search → `ValueError`, `dim` capped at 65536, zero-dim lazy add rejected, side-car/index mismatch raises at load). Full details in `CHANGELOG.md`.

## Also in this PR
- **CHANGELOG** entry for the release, split by surface (Rust crate / Python package), resolving #104, #105, #106.
- **README fact-check**: corrected stale benchmark figures against `benchmarks/results/` — ARM speed (12–20% → 10–19%), OpenAI R@1 (+0.4–3.4 → +0.2–1.9 pts), GloVe R@1 (TQ+ closed the 2-bit gap), x86 2-bit speed (trails 3–8%, not "within 1%"), and softened "matches the Shannon lower bound" to "near-optimal". The charts are data-generated and were already correct; only the prose had drifted.

## Publishing
The release workflows trigger on tags after this merges:
- `v0.9.0` → `release-crates.yml` (crates.io)
- `py-v0.8.0` → `release-pypi.yml` (PyPI)

I have **not** pushed those tags — say the word once this is merged and I'll push them (or you can). No on-disk format change (still `.tv` / `.tvim` v3).
