### PR TITLE
Docs/metadata accuracy: Windows classifier, crate LICENSE, agno example, api.md Rust drift (#143, #164, #166, #168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -718,8 +718,6 @@ turbovec 0.4.4 or later.
 
 ## turbovec 0.3.0 (Rust crate) — 2026-05-17
 
-## turbovec 0.3.0 (Rust crate) — 2026-05-17
-
 ### turbovec — Rust crate (current: 0.2.0 → next: 0.3.0)
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,41 @@ appears under each surface it touches.
 
 ## [Unreleased]
 
+### turbovec — Rust crate
+
+#### Fixed
+
+- **The published `.crate` now bundles the MIT LICENSE text.** The
+  `LICENSE` file lived only at the repo root, outside the package
+  directory, so cargo shipped the SPDX `license = "MIT"` metadata but not
+  the notice itself (MIT requires the notice to accompany copies). A copy
+  of the license is now committed inside `turbovec/`, which cargo
+  auto-includes in the package. (#166)
+
+### turbovec — Python package
+
+#### Fixed
+
+- Added the `Operating System :: Microsoft :: Windows` classifier to the
+  PyPI metadata — Windows x64 wheels have shipped since 0.4.3 but the OS
+  classifiers listed only Linux and macOS. (#143)
+
+### Docs
+
+- Agno integration: the "Basic usage" example called
+  `Knowledge.load_text(...)`, which no longer exists in current agno
+  (2.7.x) and raised `AttributeError` on copy-paste. The example now uses
+  `knowledge.add_content(text_content=...)`. (#164)
+- `docs/api.md`: two points where the Rust API doesn't mirror the Python
+  examples are now called out — a lazy index's first add on the Rust API
+  must use `add_2d` / `add_with_ids_2d` (the flat forms require an
+  already-committed dim and panic otherwise); and the allowlist result
+  width is `min(k, unique ids in allowlist)` — the allowlist is
+  deduplicated, so repeated ids don't widen the result. (#168)
+- The `[Unreleased]` compare link pointed at the stale `v0.8.1` tag,
+  folding the entire 0.9.0 release into "Unreleased"; it now compares
+  against `v0.9.0`. (#143)
+
 ## turbovec 0.8.0 (Python package) + turbovec 0.9.0 (Rust crate) — 2026-06-10
 
 Security-audit release. Two adversarial audit passes over the core crate,
@@ -868,6 +903,6 @@ turbovec 0.4.4 or later.
   `schema_version` field; loaders reject unknown versions instead of
   silently misinterpreting bytes.
 
-[Unreleased]: https://github.com/RyanCodrai/turbovec/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/RyanCodrai/turbovec/compare/v0.9.0...HEAD
 [py-v0.4.2]: https://github.com/RyanCodrai/turbovec/compare/py-v0.4.1...py-v0.4.2
 [py-v0.4.1]: https://github.com/RyanCodrai/turbovec/compare/py-v0.4.0...py-v0.4.1

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,7 +6,7 @@ turbovec exposes two index types and one serialization format per type.
 - [`IdMapIndex`](#idmapindex) — stable external `u64` ids on top of `TurboQuantIndex`.
 - [File formats](#file-formats) — `.tv` and `.tvim`.
 
-All examples below are Python. The Rust API mirrors it — see each type's rustdoc for the exact signatures.
+All examples below are Python. The Rust API mirrors it closely (exceptions noted below) — see each type's rustdoc for the exact signatures.
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,7 +41,7 @@ Before the first add, `idx.dim` is `None`, `len(idx)` is `0`, and `search()` ret
 | Method | Notes |
 |---|---|
 | `TurboQuantIndex(dim=None, bit_width=4)` | `bit_width ∈ {2, 3, 4}`. `dim` must be a positive multiple of 8 and `≤ 65536` (`MAX_DIM`). `dim` is optional; when omitted it is inferred from the first `add` call. |
-| `add(vectors)` | `vectors` is a contiguous float32 array of shape `(n, dim)`. On a lazy index the first call locks `dim`; subsequent calls must match. Raises `ValueError` on dim mismatch, a zero-width (0-column) batch, or any coordinate that is non-finite (NaN/Inf) or `\|value\| ≥ 1e16`. |
+| `add(vectors)` | `vectors` is a contiguous float32 array of shape `(n, dim)`. On a lazy index the first call locks `dim`; subsequent calls must match. Raises `ValueError` on dim mismatch, a zero-width (0-column) batch, or any coordinate that is non-finite (NaN/Inf) or `\|value\| ≥ 1e16`. On the Rust API, a lazy index's first add must use `add_2d(vectors, dim)` — the flat `add(&[f32])` requires an already-committed dim and panics otherwise. (Python arrays carry their shape, so this applies to Rust only.) |
 | `search(queries, k, *, mask=None)` | Returns `(scores, indices)`, both shape `(nq, effective_k)`. Indices are `int64` slot positions. `mask` is an optional `bool` array of length `len(idx)`; when given, only slots with `mask[i] == True` contribute. `effective_k = min(k, mask.sum())`. Raises `ValueError` on a non-finite or `\|value\| ≥ 1e16` query coordinate. |
 | `swap_remove(idx)` | O(1). Moves the last vector into `idx`; returns the previous position of that moved vector (so external refs can be updated if needed). |
 | `prepare()` | Optional. Eagerly builds the rotation matrix, Lloyd-Max centroids and SIMD-blocked layout so the first `search` call doesn't pay the one-time cost. No-op on a lazy index that hasn't seen its first add. |
@@ -88,9 +88,9 @@ idx.add_with_ids(vectors, ids)           # locks dim to vectors.shape[1]
 | Method | Notes |
 |---|---|
 | `IdMapIndex(dim=None, bit_width=4)` | `bit_width ∈ {2, 3, 4}`; `dim` must be a positive multiple of 8 and `≤ 65536`. `dim` is optional; when omitted it is inferred from the first `add_with_ids` call. |
-| `add_with_ids(vectors, ids)` | `ids` is a `uint64` array with length `vectors.shape[0]`. On a lazy index the first call locks `dim`. Raises `ValueError` on dim mismatch, duplicate ids, `len(ids) != vectors.shape[0]`, a zero-width batch, or a non-finite / `\|value\| ≥ 1e16` coordinate. |
+| `add_with_ids(vectors, ids)` | `ids` is a `uint64` array with length `vectors.shape[0]`. On a lazy index the first call locks `dim`. Raises `ValueError` on dim mismatch, duplicate ids, `len(ids) != vectors.shape[0]`, a zero-width batch, or a non-finite / `\|value\| ≥ 1e16` coordinate. On the Rust API, a lazy index's first add must use `add_with_ids_2d(vectors, dim, ids)` — the flat `add_with_ids` requires an already-committed dim and panics otherwise. (Rust only; Python arrays carry their shape.) |
 | `remove(id) -> bool` | `True` if the id was present and removed, `False` otherwise. O(1). |
-| `search(queries, k, *, allowlist=None)` | Returns `(scores, ids)` — `ids` are `uint64` external ids. `allowlist` is an optional `uint64` array of ids; when given, results are restricted to those ids and `effective_k = min(k, len(allowlist))`. Raises `ValueError` on an empty allowlist or a non-finite / `\|value\| ≥ 1e16` query coordinate, and `KeyError` on unknown ids. |
+| `search(queries, k, *, allowlist=None)` | Returns `(scores, ids)` — `ids` are `uint64` external ids. `allowlist` is an optional `uint64` array of ids; when given, results are restricted to those ids and `effective_k = min(k, number of unique ids in allowlist)` (the allowlist is deduplicated; repeated ids don't widen the result). Raises `ValueError` on an empty allowlist or a non-finite / `\|value\| ≥ 1e16` query coordinate, and `KeyError` on unknown ids. |
 | `contains(id)` / `id in idx` | Membership. |
 | `write(path)` / `load(path)` | `.tvim` format. |
 | `len(idx)` / `idx.dim` / `idx.bit_width` / `prepare()` | Same as `TurboQuantIndex`. |
@@ -112,7 +112,7 @@ Both index types support restricting the returned top-`k` to a caller-supplied s
 # IdMapIndex — allowlist of external ids (typical use)
 allowed = np.array([1003, 1010, 1042], dtype=np.uint64)
 scores, ids = idx.search(queries, k=10, allowlist=allowed)
-# scores.shape == (nq, min(k, len(allowed))) == (nq, 3)
+# scores.shape == (nq, min(k, n_allowed)) == (nq, 3)   # 3 unique allowed ids
 
 # TurboQuantIndex — bool mask over slots
 mask = np.ones(len(idx), dtype=bool)
@@ -120,7 +120,7 @@ mask[disabled_slots] = False
 scores, slots = idx.search(queries, k=10, mask=mask)
 ```
 
-The output shape is `(nq, min(k, n_allowed))` — same shrinking behaviour you already see when `k > len(idx)`. No `-1` / `NaN` padding; pad on the caller side if you need a fixed-width batch.
+The output shape is `(nq, min(k, n_allowed))`, where `n_allowed` is the number of *distinct* allowed vectors — unique ids in the allowlist, or `mask.sum()` for a mask — the same shrinking behaviour you already see when `k > len(idx)`. No `-1` / `NaN` padding; pad on the caller side if you need a fixed-width batch.
 
 Common use cases:
 

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -19,7 +19,7 @@ from turbovec.agno import TurboQuantVectorDb
 vector_db = TurboQuantVectorDb(embedder=OpenAIEmbedder())
 
 knowledge = Knowledge(vector_db=vector_db)
-knowledge.load_text("Turbovec compresses vectors to 4 bits per dimension.")
+knowledge.add_content(text_content="Turbovec compresses vectors to 4 bits per dimension.")
 
 agent = Agent(knowledge=knowledge)
 agent.print_response("What does turbovec do?")

--- a/turbovec-python/pyproject.toml
+++ b/turbovec-python/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/turbovec/LICENSE
+++ b/turbovec/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ryan Codrai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Closes #143
Closes #164
Closes #166
Closes #168

Four verified docs/packaging-metadata accuracy fixes. No code changes.

## What / why

### #143 — Release-metadata accuracy
- **`turbovec-python/pyproject.toml`**: added `Operating System :: Microsoft :: Windows` to the classifiers. `release-pypi.yml` builds, tests, and publishes a Windows x64 wheel (shipped since 0.4.3), but the PyPI OS metadata listed only Linux and macOS.
- **`CHANGELOG.md`**: the `[Unreleased]` compare link pointed at the stale `v0.8.1` tag, folding the entire 0.9.0 release into "Unreleased"; it now compares against `v0.9.0` (latest tag, confirmed via `git tag`).

### #164 — agno.md example calls removed API
`Knowledge.load_text(...)` doesn't exist in agno 2.7.4 — the "Basic usage" example raised `AttributeError` on copy-paste before any turbovec code ran. Updated to `knowledge.add_content(text_content=...)`.

### #166 — published crate omitted the MIT LICENSE text
Root `LICENSE` sits outside `turbovec/`; cargo special-cases `readme = "../README.md"` but not license files, so the `.crate` shipped only the SPDX `license = "MIT"` field, not the notice MIT requires to accompany copies. Committed a copy of the root LICENSE into `turbovec/` (kept `license = "MIT"`; cargo auto-includes `LICENSE*` files in the package dir).

### #168 — docs/api.md Rust drift
- `add` / `add_with_ids` rows now note that on the Rust API a lazy index's first add must use `add_2d(vectors, dim)` / `add_with_ids_2d(vectors, dim, ids)` — the flat forms panic without a committed dim (`turbovec/src/lib.rs:244`, `turbovec/src/id_map.rs:86`). Python arrays carry their shape, so this is Rust-only; the rows say so.
- Allowlist result width corrected from `min(k, len(allowlist))` to `min(k, number of unique ids in allowlist)` — the allowlist is deduplicated into a bool mask (`id_map.rs:208-219`; the Python binding dedups identically, `turbovec-python/src/lib.rs:315-330`). The Filtering section's `n_allowed` wording and example comment updated to match.

## Verification

- **#164**: ran the corrected snippet shape against the installed agno 2.7.4 (`turbovec-python/.venv`) with a stub embedder (`dimensions=8`): `add_content(text_content=...)` stored 1 document, `search` retrieved it; `hasattr(knowledge, "load_text")` is `False`.
- **#166**: `cargo package -p turbovec --offline --no-verify --allow-dirty --list | grep -i licens` → `LICENSE` (previously no output).
- **#143**: `release-pypi.yml` `release` job `needs: [linux, macos, windows, sdist]`; `git tag` confirms `v0.9.0` is latest.
- **#168**: verified the panic messages and dedup mask at the cited lines in this tree; dedup semantics confirmed in both the Rust core and the Python binding.

CHANGELOG entries added under `[Unreleased]` in the file's existing per-surface style.

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
