### PR TITLE
LlamaIndex: NE/NIN filter parity, get_nodes ordering, add() iterable materialization (#132, #150, #157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,10 @@ appears under each surface it touches.
   filtered key**, mirroring llama-index-core's `build_metadata_filter_fn`.
   Previously such nodes were silently dropped from filtered `query`,
   `get_nodes`, and `delete_nodes` results. (#132)
+- **LlamaIndex: `get_nodes(node_ids=...)` returns nodes in requested-id
+  order** (previously storage/insertion order), consistent with the
+  LangChain integration's `get_by_ids`. The filters-only path keeps
+  storage order. (#150)
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,12 @@ appears under each surface it touches.
   ambiguous-truth-value errors. `delete` / `adelete` get the same
   treatment: a multi-element numpy array of ids previously crashed on the
   `if not ids:` emptiness test. (#157)
+### Fixed
+
+- **LlamaIndex: `NE` / `NIN` metadata filters now match nodes missing the
+  filtered key**, mirroring llama-index-core's `build_metadata_filter_fn`.
+  Previously such nodes were silently dropped from filtered `query`,
+  `get_nodes`, and `delete_nodes` results. (#132)
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,11 @@ appears under each surface it touches.
   order** (previously storage/insertion order), consistent with the
   LangChain integration's `get_by_ids`. The filters-only path keeps
   storage order. (#150)
+- **LlamaIndex: `add()` accepts generators and other one-shot iterables.**
+  The input was iterated twice, so a generator drained on the first pass
+  and crashed with a misleading "expected 2D embedding batch, got 1D";
+  it is now materialized once up front, as `async_add` already did.
+  (#157, LlamaIndex case)
 
 ### Docs
 

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -136,6 +136,10 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         return self._index
 
     def add(self, nodes: list[BaseNode], **_: Any) -> list[str]:
+        # Materialize once up front: the input is iterated multiple times
+        # below, so a generator / one-shot iterable would silently drain on
+        # the first pass (async_add already does this via list(nodes)).
+        nodes = list(nodes)
         if not nodes:
             return []
 

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -287,11 +287,17 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         here because it doesn't store nodes), turbovec keeps node text
         and metadata in a side-car so this can return populated
         ``TextNode`` objects directly.
+
+        When ``node_ids`` is given, results come back in the requested-id
+        order (matching the LangChain integration's ``get_by_ids``);
+        otherwise in storage order.
         """
-        candidates = list(self._nodes.items())
         if node_ids is not None:
-            node_id_set = set(node_ids)
-            candidates = [(nid, data) for nid, data in candidates if nid in node_id_set]
+            candidates = [
+                (nid, self._nodes[nid]) for nid in node_ids if nid in self._nodes
+            ]
+        else:
+            candidates = list(self._nodes.items())
         if filters is not None:
             candidates = [
                 (nid, data)

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -407,11 +407,12 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         if op == FilterOperator.IS_EMPTY:
             return value is None or value == "" or value == []
 
-        # Every other operator returns False when the key is absent — this
-        # matches the reference implementation (notably NE returns False on
-        # missing, not True).
+        # Missing key: the reference (`build_metadata_filter_fn`,
+        # `utils.py`) treats an absent value as a MATCH for the negative
+        # operators NE / NIN ("not equal to X" is trivially true when the
+        # key isn't there) and a non-match for every other operator.
         if value is None:
-            return False
+            return op in (FilterOperator.NE, FilterOperator.NIN)
 
         if op == FilterOperator.EQ:
             return value == target

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -789,6 +789,17 @@ def test_get_nodes_by_node_ids():
     assert {n.node_id for n in fetched} == {ids[0]}
 
 
+def test_get_nodes_returns_requested_id_order():
+    # Results come back in the order the ids were requested (missing ids
+    # silently skipped), matching the LangChain integration's get_by_ids —
+    # not in storage/insertion order. (#150)
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [_make_node(f"doc {i}", seed=i) for i in range(3)]
+    ids = store.add(nodes)  # storage order: ids[0], ids[1], ids[2]
+    fetched = store.get_nodes(node_ids=[ids[2], "nonexistent", ids[0]])
+    assert [n.node_id for n in fetched] == [ids[2], ids[0]]
+
+
 def test_get_nodes_by_filters():
     store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
     nodes = [

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -193,6 +193,20 @@ def test_from_persist_dir_with_custom_namespace(tmp_path):
     assert len(loaded._nodes) == 1
 
 
+def test_add_accepts_generator_input():
+    # A generator (one-shot iterable) of N nodes adds N nodes. `add` used
+    # to iterate its input twice — the second pass saw an exhausted
+    # iterator and crashed with a misleading "expected 2D embedding batch,
+    # got 1D". async_add already materialized with list(). (#157)
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    ids = store.add(_make_node(f"gen doc {i}", seed=i) for i in range(5))
+    assert len(ids) == 5
+    result = store.query(
+        VectorStoreQuery(query_embedding=_unit_vec(0, 64), similarity_top_k=5)
+    )
+    assert len(result.nodes) == 5
+
+
 def test_delete_by_ref_doc_id_removes_every_matching_node():
     store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
     nodes = [

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -436,8 +436,10 @@ def test_query_with_node_ids_and_filters_intersect():
     assert {n.node_id for n in result.nodes} == {nodes[1].node_id, nodes[3].node_id}
 
 
-def test_query_ne_filter_treats_missing_key_as_no_match():
-    # Matches SimpleVectorStore reference: NE on a missing key returns False.
+def test_query_ne_filter_treats_missing_key_as_match():
+    # Matches the reference `build_metadata_filter_fn` (`utils.py`): a node
+    # MISSING the filtered key satisfies NE — "not equal to X" is trivially
+    # true when the key is absent. (#132)
     store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
     nodes = [
         _make_node("with", seed=0, metadata={"tier": "free"}),
@@ -451,10 +453,43 @@ def test_query_ne_filter_treats_missing_key_as_no_match():
         query_embedding=_unit_vec(0, 64), similarity_top_k=10, filters=filters
     )
     result = store.query(q)
-    # Only the doc with `tier=="free"` matches (free != pro). The doc with
-    # no `tier` key is NOT a match — its key is missing.
-    assert len(result.nodes) == 1
-    assert result.nodes[0].metadata.get("tier") == "free"
+    # Both nodes match: `free != pro`, and the node with no `tier` key is
+    # also a match under reference NE semantics.
+    assert len(result.nodes) == 2
+    assert {n.get_content() for n in result.nodes} == {"with", "without"}
+
+
+def test_single_filter_missing_key_parity_with_reference():
+    # Table-driven parity check: for a node missing the filtered key, each
+    # operator must agree with llama-index-core's build_metadata_filter_fn
+    # (missing key matches only the negative operators NE / NIN). (#132)
+    from llama_index.core.vector_stores.utils import build_metadata_filter_fn
+
+    metadata: dict = {"other": 1}  # no "color" key
+    cases = [
+        (FilterOperator.EQ, "red"),
+        (FilterOperator.NE, "red"),
+        (FilterOperator.IN, ["red", "blue"]),
+        (FilterOperator.NIN, ["red", "blue"]),
+    ]
+    for op, value in cases:
+        filters = MetadataFilters(
+            filters=[MetadataFilter(key="color", value=value, operator=op)]
+        )
+        expected = build_metadata_filter_fn(lambda _nid: metadata, filters)("any")
+        actual = TurboQuantVectorStore._filters_match(metadata, filters)
+        assert actual == expected, (
+            f"{op.name} on missing key: turbovec={actual}, reference={expected}"
+        )
+    # Sanity-check the table itself: NE/NIN match on missing key, EQ/IN don't.
+    ne = MetadataFilters(
+        filters=[MetadataFilter(key="color", value="red", operator=FilterOperator.NE)]
+    )
+    nin = MetadataFilters(
+        filters=[MetadataFilter(key="color", value=["red"], operator=FilterOperator.NIN)]
+    )
+    assert TurboQuantVectorStore._filters_match(metadata, ne) is True
+    assert TurboQuantVectorStore._filters_match(metadata, nin) is True
 
 
 def test_query_text_match_is_case_sensitive():


### PR DESCRIPTION
Closes #132
Closes #150
Part of #157 (LlamaIndex case only)

## What / why

Three fixes to `turbovec-python/python/turbovec/llama_index.py`, each reproduced against `llama-index-core` 0.14.23 before and after, with the in-tree `SimpleVectorStore` / `build_metadata_filter_fn` as the parity reference:

- **#132 — NE/NIN filters dropped nodes missing the key.** The blanket `if value is None: return False` in `_single_filter_match` sat before operator dispatch, but the reference `build_metadata_filter_fn` returns `operator in (NE, NIN)` for a missing metadata value — "not equal to X" is trivially true when the key is absent. Nodes lacking the key were silently excluded from filtered `query` / `get_nodes` / `delete_nodes`, and the adjacent comment claimed the opposite of what the reference does. Added the NE/NIN carve-out, corrected the comment, rewrote the inverted regression test, and added a table-driven missing-key parity check (EQ/NE/IN/NIN, asserted directly against the reference's `build_metadata_filter_fn`).
- **#150 — `get_nodes(node_ids=...)` returned storage order.** It filtered `self._nodes.items()` instead of iterating the requested ids. Now iterates `node_ids` when provided (missing ids still silently skipped), matching the LangChain integration's `get_by_ids`; the filters-only path keeps storage order.
- **#157 (llama case) — `add(generator)` drained the input twice** (node-id collection, then embeddings), crashing with a misleading `expected 2D embedding batch, got 1D`. Now materialized once with `list(nodes)` at the top, mirroring `async_add`. The LangChain/Haystack cases of #157 are not touched here.

## #130 — investigated, deliberately NOT fixed (needs a ruling)

The prescribed fix (`is not None` instead of truthiness for `query.node_ids` at the `query()` gate and in `_resolve_allowed_handles`) **breaks all retrieval through `VectorStoreIndex`**. Verified in this branch's worktree:

- `VectorStoreIndex._add_nodes_to_index` only populates `index_struct.nodes_dict` when `vector_store.stores_text` is False. turbovec is `stores_text=True`, so `nodes_dict` stays empty even when nodes are inserted through the index.
- `VectorStoreIndex.as_retriever` passes `node_ids=list(index_struct.nodes_dict.values())` — i.e. **always `[]`** for turbovec.
- With `is not None` semantics, every `as_retriever(...).retrieve(...)` call returns 0 results (two existing e2e tests fail: `test_vector_store_index_from_vector_store_retrieve`, `test_storage_context_persist_and_load_roundtrip`). The `_resolve_allowed_handles`-only variant still breaks filtered retrieval, because the retriever sends `filters` together with `node_ids=[]`.
- `SimpleVectorStore`'s `is not None` semantics only coexist with the framework because it is `stores_text=False` (it always receives the full tracked id list, and `from_vector_store` rejects it outright). For a `stores_text=True` store, framework-`[]` means "no restriction", which is why the current truthiness behavior is what keeps the integration working.

So #130 is a real inconsistency (docstring at `_resolve_allowed_handles` says "Empty list means no node matches", and `get_nodes`/`delete_nodes` use `is not None`), but the direct fix trades a direct-call edge case for breaking the primary framework path. Options are (a) keep truthiness and fix the docstring to document `[]` = no-filter for `query()`, or (b) strict semantics plus some way to distinguish framework-provided `[]` — either way it needs a maintainer decision, so it is left out of this PR.

## Test evidence

- `turbovec-python/tests/test_llama_index.py`: 71 passed (3 new tests: `test_single_filter_missing_key_parity_with_reference`, `test_get_nodes_returns_requested_id_order`, `test_add_accepts_generator_input`; 1 inverted test rewritten: `test_query_ne_filter_treats_missing_key_as_match`).
- Full `turbovec-python/tests/`: 381 passed.
- Each fix was reproduced failing before the change and passing after, against `llama-index-core` 0.14.23.

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)