### PR TITLE
Core I/O hardening: atomic save, write-side bounds, load-side value validation (#118, #119, #122, #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **Index saves are atomic.** `io::write` / `io::write_id_map` (and
+  `TurboQuantIndex::write` / `IdMapIndex::write` on top of them) now write
+  to a sibling temp file, fsync, and rename over the destination, so a
+  failed or interrupted save no longer destroys a previous good index at
+  the same path; the TQ+ calibration-length assert also runs before any
+  file is created. (#118)
+- **Saving an index with ≥ 2³² vectors errors instead of silently
+  wrapping.** `write_core` previously truncated `n_vectors` with `as u32`,
+  producing a corrupt file that loaded clean with `n mod 2³²` vectors; it
+  now returns `InvalidData`. (#119)
+- **Float payloads are value-validated on load.** A `.tv` / `.tvim` with a
+  non-finite or negative per-vector scale, a non-finite TQ+ shift, or a
+  non-positive/non-finite TQ+ scale previously loaded clean and silently
+  poisoned search results (NaN/Inf scores, vanishing or always-winning
+  slots); such files are now rejected with `InvalidData`. (#122)
+- **`search`/`prepare` on an empty index no longer build the dim×dim
+  rotation matrix.** Searching an empty index is now O(1), which also stops
+  a tiny file declaring a large `dim` with `n_vectors = 0` from driving a
+  multi-gigabyte allocation on first search. (#123)
 - **The published `.crate` now bundles the MIT LICENSE text.** The
   `LICENSE` file lived only at the repo root, outside the package
   directory, so cargo shipped the SPDX `license = "MIT"` metadata but not

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -24,7 +24,7 @@
 
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter, Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const TV_MAGIC: &[u8; 4] = b"TVPI";
 const TV_VERSION: u8 = 3;
@@ -40,6 +40,11 @@ const REBUILD_HINT: &str =
 type CoreLoad = (usize, usize, usize, Vec<u8>, Vec<f32>, Vec<f32>, Vec<f32>);
 
 /// `.tv` write — positional index.
+///
+/// The write is atomic with respect to the destination: the payload goes
+/// to a sibling temp file which is fsynced and then renamed over `path`,
+/// so a failed or interrupted write leaves any previous file at `path`
+/// intact.
 pub fn write(
     path: impl AsRef<Path>,
     bit_width: usize,
@@ -50,15 +55,17 @@ pub fn write(
     tqplus_shift: &[f32],
     tqplus_scale: &[f32],
 ) -> io::Result<()> {
-    let mut f = BufWriter::new(File::create(path)?);
-    f.write_all(TV_MAGIC)?;
-    f.write_all(&[TV_VERSION])?;
-    write_core(
-        &mut f, bit_width, dim, n_vectors, packed_codes, scales,
-        tqplus_shift, tqplus_scale,
-    )?;
-    f.flush()?;
-    Ok(())
+    // Validate before any file is created so a violation cannot destroy
+    // a previous good index at `path`.
+    assert_tqplus_calibration(dim, tqplus_shift, tqplus_scale);
+    write_atomic(path.as_ref(), |f| {
+        f.write_all(TV_MAGIC)?;
+        f.write_all(&[TV_VERSION])?;
+        write_core(
+            f, bit_width, dim, n_vectors, packed_codes, scales,
+            tqplus_shift, tqplus_scale,
+        )
+    })
 }
 
 /// `.tv` load — positional index. Transparently handles v2 (no TQ+) and
@@ -96,6 +103,8 @@ pub fn load(path: impl AsRef<Path>) -> io::Result<CoreLoad> {
 }
 
 /// `.tvim` write — positional index plus the id-map side-tables.
+///
+/// Atomic with respect to the destination, like [`write`].
 pub fn write_id_map(
     path: impl AsRef<Path>,
     bit_width: usize,
@@ -107,6 +116,8 @@ pub fn write_id_map(
     tqplus_scale: &[f32],
     slot_to_id: &[u64],
 ) -> io::Result<()> {
+    // Validate before any file is created so a violation cannot destroy
+    // a previous good index at `path`.
     assert_eq!(
         slot_to_id.len(),
         n_vectors,
@@ -114,20 +125,21 @@ pub fn write_id_map(
         slot_to_id.len(),
         n_vectors,
     );
+    assert_tqplus_calibration(dim, tqplus_shift, tqplus_scale);
 
-    let mut f = BufWriter::new(File::create(path)?);
-    f.write_all(TVIM_MAGIC)?;
-    f.write_all(&[TVIM_VERSION])?;
-    write_core(
-        &mut f, bit_width, dim, n_vectors, packed_codes, scales,
-        tqplus_shift, tqplus_scale,
-    )?;
+    write_atomic(path.as_ref(), |f| {
+        f.write_all(TVIM_MAGIC)?;
+        f.write_all(&[TVIM_VERSION])?;
+        write_core(
+            f, bit_width, dim, n_vectors, packed_codes, scales,
+            tqplus_shift, tqplus_scale,
+        )?;
 
-    for &id in slot_to_id {
-        f.write_all(&id.to_le_bytes())?;
-    }
-    f.flush()?;
-    Ok(())
+        for &id in slot_to_id {
+            f.write_all(&id.to_le_bytes())?;
+        }
+        Ok(())
+    })
 }
 
 /// `.tvim` load — positional index plus the id-map side-tables.
@@ -180,6 +192,52 @@ pub fn load_id_map(
 
 const CORE_HEADER_SIZE: usize = 9;
 
+/// TQ+ calibration length invariant shared by [`write`] and
+/// [`write_id_map`]. Must run before any file is created — see the
+/// callers.
+fn assert_tqplus_calibration(dim: usize, tqplus_shift: &[f32], tqplus_scale: &[f32]) {
+    // n_calib == 0 means identity calibration (lazy index with no add
+    // yet, or a loaded pre-TQ+ index that's been resaved); otherwise
+    // must equal dim.
+    assert!(
+        tqplus_shift.len() == tqplus_scale.len()
+            && (tqplus_shift.is_empty() || tqplus_shift.len() == dim),
+        "TQ+ shift/scale must have equal length and either be empty or equal dim"
+    );
+}
+
+/// Atomically replace `path` with a freshly-written payload: write to a
+/// sibling temp file in the same directory, flush + fsync, then rename
+/// over the destination (atomic on POSIX). On any failure the previous
+/// file at `path` is left untouched and the temp file is removed
+/// (best effort), so a reader never observes a partial index.
+fn write_atomic(
+    path: &Path,
+    write_payload: impl FnOnce(&mut BufWriter<&File>) -> io::Result<()>,
+) -> io::Result<()> {
+    let tmp: PathBuf = {
+        let mut name = path
+            .file_name()
+            .map(std::ffi::OsStr::to_os_string)
+            .unwrap_or_default();
+        name.push(format!(".tmp.{}", std::process::id()));
+        path.with_file_name(name)
+    };
+    let result = (|| {
+        let f = File::create(&tmp)?;
+        let mut w = BufWriter::new(&f);
+        write_payload(&mut w)?;
+        w.flush()?;
+        drop(w);
+        f.sync_all()?;
+        std::fs::rename(&tmp, path)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    result
+}
+
 /// Core header + packed codes + per-vector scales + TQ+ calibration —
 /// shared by `.tv` and `.tvim`.
 fn write_core<W: Write>(
@@ -192,21 +250,29 @@ fn write_core<W: Write>(
     tqplus_shift: &[f32],
     tqplus_scale: &[f32],
 ) -> io::Result<()> {
+    // The count field is u32 on disk; `dim` is bounded by MAX_DIM
+    // (65536) but nothing upstream caps `n_vectors`, so a silent `as`
+    // wrap here would save a corrupt file that loads clean with
+    // `n mod 2^32` vectors.
+    let n_vectors_u32 = u32::try_from(n_vectors).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "index too large for the .tv format: n_vectors {n_vectors} \
+                 exceeds the u32 count field (max {})",
+                u32::MAX,
+            ),
+        )
+    })?;
     w.write_all(&[bit_width as u8])?;
     w.write_all(&(dim as u32).to_le_bytes())?;
-    w.write_all(&(n_vectors as u32).to_le_bytes())?;
+    w.write_all(&n_vectors_u32.to_le_bytes())?;
     w.write_all(packed_codes)?;
     for &s in scales {
         w.write_all(&s.to_le_bytes())?;
     }
-    // TQ+ trailer. n_calib == 0 means identity calibration (lazy index
-    // with no add yet, or a loaded pre-TQ+ index that's been resaved);
-    // otherwise must equal dim.
-    assert!(
-        tqplus_shift.len() == tqplus_scale.len()
-            && (tqplus_shift.is_empty() || tqplus_shift.len() == dim),
-        "TQ+ shift/scale must have equal length and either be empty or equal dim"
-    );
+    // TQ+ trailer. Lengths are asserted by the callers before any file
+    // is created (`assert_tqplus_calibration`).
     let n_calib = tqplus_shift.len() as u32;
     w.write_all(&n_calib.to_le_bytes())?;
     for &s in tqplus_shift {
@@ -260,6 +326,34 @@ fn read_core_v3<R: Read>(r: &mut R) -> io::Result<CoreLoad> {
     }
     let tqplus_shift = read_f32_array(r, n_calib)?;
     let tqplus_scale = read_f32_array(r, n_calib)?;
+
+    // Value-level validation, mirroring the header checks: the encoder
+    // only ever emits finite shifts and strictly-positive scales
+    // (encode.rs initialises scale to 1.0 and overwrites it only with a
+    // positive span), so anything else is corruption or an attacker
+    // payload. Search divides by `tqplus_scale`, so a zero/negative/
+    // non-finite value — which a bare is_finite() check would not fully
+    // catch — silently turns every query's scores into NaN/Inf.
+    if let Some((i, &v)) = tqplus_shift
+        .iter()
+        .enumerate()
+        .find(|(_, v)| !v.is_finite())
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid TQ+ shift at coord {i}: {v} (must be finite)"),
+        ));
+    }
+    if let Some((i, &v)) = tqplus_scale
+        .iter()
+        .enumerate()
+        .find(|(_, v)| !v.is_finite() || **v <= 0.0)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid TQ+ scale at coord {i}: {v} (must be finite and > 0)"),
+        ));
+    }
 
     Ok((bit_width, dim, n_vectors, packed_codes, scales, tqplus_shift, tqplus_scale))
 }
@@ -320,6 +414,20 @@ fn read_header_codes_scales<R: Read>(
     let packed_codes = read_exact_vec(r, packed_bytes)?;
 
     let scales = read_f32_array(r, n_vectors)?;
+    // Value-level validation: the encoder only ever emits finite,
+    // non-negative per-vector scales. A NaN/Inf/negative scale loads
+    // without structural error but silently corrupts search — an Inf
+    // slot wins every top-1, a NaN slot vanishes from all results.
+    if let Some((i, &s)) = scales
+        .iter()
+        .enumerate()
+        .find(|(_, s)| !s.is_finite() || **s < 0.0)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid per-vector scale at slot {i}: {s} (must be finite and non-negative)"),
+        ));
+    }
     Ok((bit_width, dim, n_vectors, packed_codes, scales))
 }
 

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -450,6 +450,28 @@ impl TurboQuantIndex {
             );
         }
 
+        // An empty index has nothing to score: return the empty result
+        // shape without building the rotation/centroid/blocked caches.
+        // Besides skipping wasted work for a legitimately-empty index,
+        // this stops a tiny file declaring a large dim with n_vectors=0
+        // from driving the dim×dim rotation build on first search.
+        if self.n_vectors == 0 {
+            if let Some(m) = mask {
+                assert_eq!(
+                    m.len(),
+                    0,
+                    "mask length {} does not match index size 0",
+                    m.len(),
+                );
+            }
+            return SearchResults {
+                scores: Vec::new(),
+                indices: Vec::new(),
+                nq,
+                k: 0,
+            };
+        }
+
         let rotation = self
             .rotation
             .get_or_init(|| rotation::make_rotation_matrix(dim));
@@ -524,6 +546,13 @@ impl TurboQuantIndex {
         // On a lazy index that's seen no add, there's nothing to prepare
         // — dim is unknown and the caches depend on it.
         let Some(dim) = self.dim else { return };
+        // Same for an empty index: search short-circuits before touching
+        // the caches, and `add` builds the rotation itself if vectors
+        // arrive later — so building here is pure wasted work (and a
+        // DoS on a loaded empty file declaring a large dim).
+        if self.n_vectors == 0 {
+            return;
+        }
         self.rotation
             .get_or_init(|| rotation::make_rotation_matrix(dim));
         self.centroids.get_or_init(|| {

--- a/turbovec/tests/io_hardening.rs
+++ b/turbovec/tests/io_hardening.rs
@@ -1,0 +1,297 @@
+//! Core I/O hardening tests.
+//!
+//! Covers:
+//! 1. Atomic save — a failed or panicking `write`/`write_id_map` must leave
+//!    a pre-existing index file at the destination intact, and successful
+//!    writes must not leave stray temp files behind (#118).
+//! 2. Write-side bounds — `n_vectors` larger than the format's u32 count
+//!    field is rejected instead of silently wrapping (#119).
+//! 3. Load-side value validation — non-finite or out-of-range floats in
+//!    the per-vector scales or TQ+ calibration arrays are rejected at
+//!    load instead of poisoning search results (#122).
+//! 4. Empty-index search/prepare short-circuit — no dim×dim rotation
+//!    build when there is nothing to score (#123).
+
+use std::fs::File;
+use std::io::Write as _;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use turbovec::io::{load, load_id_map, write, write_id_map};
+use turbovec::TurboQuantIndex;
+
+fn temp_dir(name: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    p.push(format!("turbovec-{}-{}", nonce, name));
+    std::fs::create_dir(&p).unwrap();
+    p
+}
+
+/// Write a small valid index to `path` and return its parts for later
+/// comparison.
+fn write_good_tv(path: &PathBuf) -> (Vec<u8>, Vec<f32>) {
+    let packed = vec![0xABu8; (32 / 8) * 4 * 2];
+    let scales = vec![1.5f32, 2.5];
+    write(path, 4, 32, 2, &packed, &scales, &[], &[]).unwrap();
+    (packed, scales)
+}
+
+fn dir_entries(dir: &PathBuf) -> Vec<String> {
+    std::fs::read_dir(dir)
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// #118 — atomic save
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tv_panicking_write_leaves_previous_file_intact() {
+    let dir = temp_dir("tv-panic-write");
+    let path = dir.join("index.tv");
+    let (packed, scales) = write_good_tv(&path);
+
+    // TQ+ calibration length invariant violated (len 3 != dim 32): the
+    // write must panic BEFORE creating or truncating anything at `path`.
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        write(&path, 4, 32, 2, &packed, &scales, &[1.0; 3], &[1.0; 3])
+    }));
+    assert!(result.is_err(), "mismatched TQ+ lengths should panic");
+
+    let (bw, d, n, p, s, _, _) = load(&path).expect("previous good index must survive");
+    assert_eq!((bw, d, n), (4, 32, 2));
+    assert_eq!(p, packed);
+    assert_eq!(s, scales);
+    assert_eq!(dir_entries(&dir), vec!["index.tv"], "no partial/temp files may remain");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn tvim_panicking_write_leaves_previous_file_intact() {
+    let dir = temp_dir("tvim-panic-write");
+    let path = dir.join("index.tvim");
+    let packed = vec![0x55u8; (16 / 8) * 2 * 2];
+    let scales = vec![0.5f32, 1.0];
+    let ids = vec![7u64, 9];
+    write_id_map(&path, 2, 16, 2, &packed, &scales, &[], &[], &ids).unwrap();
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        write_id_map(&path, 2, 16, 2, &packed, &scales, &[1.0; 3], &[1.0; 3], &ids)
+    }));
+    assert!(result.is_err(), "mismatched TQ+ lengths should panic");
+
+    let (bw, d, n, p, s, _, _, slot_to_id) =
+        load_id_map(&path).expect("previous good index must survive");
+    assert_eq!((bw, d, n), (2, 16, 2));
+    assert_eq!(p, packed);
+    assert_eq!(s, scales);
+    assert_eq!(slot_to_id, ids);
+    assert_eq!(dir_entries(&dir), vec!["index.tvim"], "no partial/temp files may remain");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn tv_erroring_write_leaves_previous_file_intact_and_no_temp() {
+    let dir = temp_dir("tv-error-write");
+    let path = dir.join("index.tv");
+    let (packed, scales) = write_good_tv(&path);
+
+    // n_vectors over the u32 field errors mid-write (#119); the
+    // destination must be untouched and the temp file cleaned up.
+    let err = write(&path, 2, 8, (u32::MAX as usize) + 2, &[], &[], &[], &[])
+        .expect_err("oversized n_vectors must error, not silently wrap");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+
+    let (bw, d, n, p, s, _, _) = load(&path).expect("previous good index must survive");
+    assert_eq!((bw, d, n), (4, 32, 2));
+    assert_eq!(p, packed);
+    assert_eq!(s, scales);
+    assert_eq!(dir_entries(&dir), vec!["index.tv"], "no partial/temp files may remain");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn tv_successful_overwrite_leaves_no_temp_files() {
+    let dir = temp_dir("tv-overwrite");
+    let path = dir.join("index.tv");
+    write_good_tv(&path);
+
+    let packed = vec![0xCDu8; (32 / 8) * 4 * 3];
+    let scales = vec![1.0f32, 2.0, 3.0];
+    write(&path, 4, 32, 3, &packed, &scales, &[], &[]).unwrap();
+
+    let (_, _, n, p, s, _, _) = load(&path).unwrap();
+    assert_eq!(n, 3);
+    assert_eq!(p, packed);
+    assert_eq!(s, scales);
+    assert_eq!(dir_entries(&dir), vec!["index.tv"], "no temp files may remain");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ---------------------------------------------------------------------------
+// #119 — write-side n_vectors bounds
+// ---------------------------------------------------------------------------
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn tv_write_rejects_n_vectors_over_u32_max() {
+    let dir = temp_dir("tv-n-overflow");
+    let path = dir.join("index.tv");
+
+    let err = write(&path, 2, 8, (1usize << 32) + 2, &[], &[], &[], &[])
+        .expect_err("n_vectors >= 2^32 must not silently truncate to u32");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    let msg = err.to_string();
+    assert!(
+        msg.contains("n_vectors") && msg.contains("4294967298"),
+        "error should name the offending count, got: {msg}",
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ---------------------------------------------------------------------------
+// #122 — load-side float value validation
+// ---------------------------------------------------------------------------
+
+/// Craft a dim=8, n=1 v3 file through the raw writer (which does not
+/// value-validate) and expect `load` to reject it.
+fn expect_load_rejects(
+    name: &str,
+    scales: &[f32],
+    tqplus_shift: &[f32],
+    tqplus_scale: &[f32],
+    expect_in_msg: &str,
+) {
+    let dir = temp_dir(name);
+    let path = dir.join("bad.tv");
+    write(&path, 4, 8, 1, &[0x12, 0x34, 0x56, 0x78], scales, tqplus_shift, tqplus_scale)
+        .unwrap();
+    let err = load(&path).expect_err("bad float payload must be rejected at load");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains(expect_in_msg),
+        "expected {expect_in_msg:?} in error, got: {err}",
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn load_rejects_bad_per_vector_scales() {
+    for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY, -1.0] {
+        expect_load_rejects("scales-bad", &[bad], &[0.0; 8], &[1.0; 8], "scale");
+    }
+}
+
+#[test]
+fn load_rejects_nonfinite_tqplus_shift() {
+    for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+        let mut shift = [0.0f32; 8];
+        shift[3] = bad;
+        expect_load_rejects("shift-bad", &[1.0], &shift, &[1.0; 8], "shift");
+    }
+}
+
+#[test]
+fn load_rejects_nonpositive_or_nonfinite_tqplus_scale() {
+    // Zero and negative are finite — a bare is_finite() check would pass
+    // them; they must still be rejected (division by tqplus_scale).
+    for bad in [0.0f32, -1.0, f32::NAN, f32::INFINITY] {
+        let mut scale = [1.0f32; 8];
+        scale[5] = bad;
+        expect_load_rejects("tqscale-bad", &[1.0], &[0.0; 8], &scale, "scale");
+    }
+}
+
+#[test]
+fn load_id_map_rejects_zero_tqplus_scale() {
+    // Same core reader as .tv — one case to pin the shared path.
+    let dir = temp_dir("tvim-tqscale-zero");
+    let path = dir.join("bad.tvim");
+    write_id_map(&path, 4, 8, 1, &[0x12, 0x34, 0x56, 0x78], &[1.0], &[0.0; 8], &[0.0; 8], &[42])
+        .unwrap();
+    let err = load_id_map(&path).expect_err("zero tqplus_scale must be rejected at load");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn load_v2_rejects_nonfinite_scales() {
+    // Hand-construct a v2 file (no TQ+ trailer) with a NaN per-vector
+    // scale — the v2 read path must apply the same value validation.
+    let dir = temp_dir("v2-nan-scale");
+    let path = dir.join("bad-v2.tv");
+    {
+        let mut f = File::create(&path).unwrap();
+        f.write_all(b"TVPI").unwrap();
+        f.write_all(&[2u8]).unwrap(); // version 2
+        f.write_all(&[4u8]).unwrap(); // bit_width
+        f.write_all(&8u32.to_le_bytes()).unwrap(); // dim
+        f.write_all(&1u32.to_le_bytes()).unwrap(); // n_vectors
+        f.write_all(&[0xAA; 4]).unwrap(); // packed codes
+        f.write_all(&f32::NAN.to_le_bytes()).unwrap(); // scale = NaN
+    }
+    let err = load(&path).expect_err("NaN per-vector scale must be rejected at load");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ---------------------------------------------------------------------------
+// #123 — empty-index search/prepare short-circuit
+// ---------------------------------------------------------------------------
+
+const EMPTY_DIM: usize = 8192;
+// Building the 8192x8192 rotation takes multiple seconds and ~0.75 GiB;
+// the short-circuit path is sub-millisecond, so 2s gives wide CI margin
+// while still failing decisively if the rotation build comes back.
+const EMPTY_BUDGET: Duration = Duration::from_secs(2);
+
+fn load_empty_large_dim(dir: &PathBuf) -> TurboQuantIndex {
+    let path = dir.join("empty.tv");
+    write(&path, 4, EMPTY_DIM, 0, &[], &[], &[], &[]).unwrap();
+    TurboQuantIndex::load(&path).unwrap()
+}
+
+#[test]
+fn empty_index_search_returns_empty_without_rotation_build() {
+    let dir = temp_dir("empty-search");
+    let idx = load_empty_large_dim(&dir);
+    assert_eq!(idx.len(), 0);
+
+    let query = vec![0.5f32; EMPTY_DIM];
+    let start = Instant::now();
+    let res = idx.search(&query, 5);
+    let elapsed = start.elapsed();
+
+    assert_eq!(res.nq, 1);
+    assert_eq!(res.k, 0);
+    assert!(res.scores.is_empty());
+    assert!(res.indices.is_empty());
+    assert!(
+        elapsed < EMPTY_BUDGET,
+        "search on an empty index took {elapsed:?} — it must not build the dim×dim rotation",
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn empty_index_prepare_skips_rotation_build() {
+    let dir = temp_dir("empty-prepare");
+    let idx = load_empty_large_dim(&dir);
+
+    let start = Instant::now();
+    idx.prepare();
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < EMPTY_BUDGET,
+        "prepare on an empty index took {elapsed:?} — it must not build the dim×dim rotation",
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
Closes #118
Closes #119
Closes #122
Part of #123 (n==0 short-circuit only; MAX_DIM decision parked)

## What / why

### #118 — atomic save
`io::write` and `io::write_id_map` previously opened the destination with `File::create`, truncating it up front — a failed or interrupted save (ENOSPC, panic) destroyed the previous good index at the same path. Both writers now write the full payload to a sibling temp file (`<name>.tmp.<pid>` in the same directory), `flush` + `sync_all`, then `rename` over the destination (atomic on POSIX); on any failure the temp file is removed and the destination is untouched. The TQ+ calibration-length assert is hoisted out of `write_core` into both public writers so it fires **before** any file is created (`write_id_map` already ordered its `slot_to_id` assert that way).

### #119 — write-side `n_vectors` bounds
`write_core` cast `n_vectors` to the on-disk u32 count field with `as u32`, silently wrapping for ≥ 2³² vectors — the file saved "successfully" and later loaded clean with `n mod 2³²` vectors. It now uses `u32::try_from` and returns `InvalidData` ("index too large for the .tv format: n_vectors … exceeds the u32 count field"). The format stays v3/u32; widening to u64 is a parked v4 design decision (with the `search.rs` heap `i as u32` cast to widen in lockstep, per the issue comment).

### #122 — load-side float value validation
The load path structurally validated headers/lengths (#108) but accepted any float payload: non-finite or negative per-vector `scales`, non-finite `tqplus_shift`, and zero/negative/non-finite `tqplus_scale` all loaded clean and silently poisoned search (NaN/Inf scores index-wide for a bad TQ+ scale, always-winning or vanishing slots for a bad per-vector scale). After reading the arrays, load now rejects with `InvalidData`: non-finite anywhere, `scales < 0`, and `tqplus_scale <= 0` — the strictly-positive check matters because zero/negative TQ+ scales are finite and slip past a bare `is_finite()`. The encoder provably never emits any of these (`encode.rs` initialises scale to 1.0 and only overwrites with strictly-positive spans), so no valid file is affected. Validation sits in the shared core reader, covering `.tv`, `.tvim`, and v2 files.

### #123 (partial) — empty-index short-circuit
`search_with_mask` and `prepare` eagerly built the dim×dim rotation matrix (plus centroid/blocked caches) even with `n_vectors == 0` — wasted seconds for a legitimately-empty index, and a multi-GiB allocation from a ~20-byte file declaring a large dim. Both now short-circuit on `n_vectors == 0` (search returns the empty result shape with `nq` preserved and `k = 0`, matching the previous return shape). This is the wasted-work half only; the MAX_DIM / n≥1 large-dim question stays open on #123 as a parked design decision.

## Test evidence

New regression suite `turbovec/tests/io_hardening.rs` (12 tests). Pre-fix: 11 failed for the targeted reasons — clobbered destination after panicking/erroring write, silent u32 wrap, bad floats loading clean (verified end-to-end: zero `tqplus_scale` loaded and searched to `scores=[NaN]`), empty-index search/prepare paying the 8192×8192 rotation build (~5s). Post-fix: all 12 pass; the crafted-file repro now fails at load with `InvalidData: invalid TQ+ scale at coord 0: 0 (must be finite and > 0)`.

Full suite `cargo test -p turbovec --release`: **155 passed, 0 failed** (143 baseline + 12 new).

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)