### PR TITLE
Haystack/agno: filter and lifecycle correctness (#131, #135, #144, #146, #169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,6 @@ appears under each surface it touches.
   and `avx2_post_flush_heap_update`; the dead copy's logic had drifted
   from them, so keeping it invited confusion in future kernel edits. No
   behavior change. (#134)
-
 ### turbovec — Python package
 
 #### Fixed
@@ -131,6 +130,31 @@ appears under each surface it touches.
   and crashed with a misleading "expected 2D embedding batch, got 1D";
   it is now materialized once up front, as `async_add` already did.
   (#157, LlamaIndex case)
+- **Haystack: `embedding_retrieval(filters={})` no longer raises
+  `FilterError`.** An empty filter dict is now treated as "no filter",
+  matching the reference `InMemoryDocumentStore` and the store's own
+  `filter_documents`. (#131)
+- **Haystack: `write_documents` no longer crashes on a `Document` whose
+  `meta` was force-set to `None`** (off-contract but reachable via
+  deserialization); it is coerced to `{}`. (#139)
+- **agno: `insert()` / `upsert()` accept numpy-array embeddings** instead
+  of raising numpy's truth-value-ambiguous `ValueError`, matching
+  LanceDb's tolerance. (#135)
+- **agno: a `None`-valued metadata filter no longer matches documents
+  missing the key.** `search(filters={"k": None})` returned — and
+  `delete_by_metadata({"k": None})` deleted — the entire collection;
+  both now require the key to be present and equal, matching LanceDb. (#144)
+- **agno: concurrent `async_upsert` calls of the same `content_hash` no
+  longer retain stale generations.** The previous generation's handles
+  were captured before the awaited embed, so sibling tasks never removed
+  each other's rows; `async_upsert` now awaits only the embedding and
+  delegates to the sync `upsert` (last-writer-wins, same as sync). (#146)
+- **agno: `drop()` on a store with a persistence `path` deletes the
+  on-disk artifacts** (`index.tvim` / `docstore.json`), so a later
+  `create()` starts empty instead of resurrecting the dropped data.
+  Also, `delete_by_content_id(None)` / `update_metadata(None, ...)` are
+  now no-ops instead of matching every document stored without a
+  `content_id`. (#169)
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ appears under each surface it touches.
   ambiguous-truth-value errors. `delete` / `adelete` get the same
   treatment: a multi-element numpy array of ids previously crashed on the
   `if not ids:` emptiness test. (#157)
-### Fixed
+
 
 - **LlamaIndex: `NE` / `NIN` metadata filters now match nodes missing the
   filtered key**, mirroring llama-index-core's `build_metadata_filter_fn`.
@@ -135,8 +135,8 @@ appears under each surface it touches.
   matching the reference `InMemoryDocumentStore` and the store's own
   `filter_documents`. (#131)
 - **Haystack: `write_documents` no longer crashes on a `Document` whose
-  `meta` was force-set to `None`** (off-contract but reachable via
-  deserialization); it is coerced to `{}`. (#139)
+  `meta` is `None`** (off-contract, but `Document(..., meta=None)` keeps
+  the `None` as-is); it is coerced to `{}`. (#139)
 - **agno: `insert()` / `upsert()` accept numpy-array embeddings** instead
   of raising numpy's truth-value-ambiguous `ValueError`, matching
   LanceDb's tolerance. (#135)

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -423,10 +423,16 @@ class TurboQuantVectorDb(VectorDb):
         documents: List[Document],
         filters: Optional[Dict[str, Any]] = None,
     ) -> None:
-        old_handles = self._handles_for_content_hash(content_hash)
-        await self.async_insert(content_hash, documents, filters)
-        for handle in old_handles:
-            self._remove_handle(handle)
+        # Await ONLY the embedding step, then delegate to the sync upsert
+        # so no suspension point splits the old-handle capture from the
+        # insert+remove. Capturing before an await let concurrent upserts
+        # of the same content_hash all snapshot the same pre-insert
+        # handle set, so no task removed a sibling's rows and stale
+        # generations accumulated (issue #146). Delegating preserves the
+        # insert-before-delete ordering (issue #89) and makes concurrent
+        # async upserts last-writer-wins — identical to sync semantics.
+        await self._embed_missing_async(documents)
+        self.upsert(content_hash, documents, filters)
 
     def _handles_for_content_hash(self, content_hash: str) -> List[int]:
         """Internal handles of every document currently stored under this

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -676,6 +676,11 @@ class TurboQuantVectorDb(VectorDb):
     def delete_by_name(self, name: str) -> bool:
         if self._index is None:
             return False
+        # Docs stored without a name keep it as None, so a None argument
+        # (off-contract, param typed str) would delete every unnamed doc.
+        # Same guard as delete_by_content_id — no-op instead.
+        if name is None:
+            return False
         # Remove exactly the handles whose stored name matches. Delegating to
         # delete_by_id would key on the derived doc_id, which excludes `name`,
         # so it would also delete a differently-named doc that happens to
@@ -686,7 +691,16 @@ class TurboQuantVectorDb(VectorDb):
         return bool(handles)
 
     def delete_by_metadata(self, metadata: Dict[str, Any]) -> bool:
+        """Delete every document whose ``meta_data`` has all of
+        ``metadata``'s keys present and equal (AND). An empty dict is a
+        vacuous AND and therefore matches — and deletes — every document,
+        matching LanceDb's behavior for the same input."""
         if self._index is None:
+            return False
+        # None is off-contract (param typed dict); LanceDb returns False
+        # rather than raising. Same guard family as delete_by_name /
+        # delete_by_content_id.
+        if metadata is None:
             return False
         items = list(metadata.items())
         # Remove the matching handles directly (see delete_by_name): the

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -180,6 +180,14 @@ class TurboQuantVectorDb(VectorDb):
         """Drop the underlying index. After this call ``exists()`` returns
         ``False`` until ``create()`` is called again — matches LanceDb's
         contract where ``drop()`` removes the table entirely."""
+        # Remove the persisted artifacts too, so a later create() starts
+        # fresh instead of reloading — and resurrecting — the dropped
+        # data (issue #169). Matches LanceDb's drop_table, which deletes
+        # the on-disk table.
+        if self.path is not None:
+            folder = Path(self.path)
+            for filename in (_INDEX_FILENAME, _STORE_FILENAME):
+                (folder / filename).unlink(missing_ok=True)
         self._index = None
         self._str_to_u64.clear()
         self._u64_to_doc.clear()
@@ -696,6 +704,11 @@ class TurboQuantVectorDb(VectorDb):
     def delete_by_content_id(self, content_id: str) -> bool:
         if self._index is None:
             return False
+        # Docs stored without a content_id keep it as None, so a None
+        # argument (off-contract, param typed str) would match — and
+        # delete — every such doc. Treat it as a no-op (issue #169).
+        if content_id is None:
+            return False
         # Remove the matching handles directly (see delete_by_name): the
         # derived doc_id ignores content_id, so delete_by_id would over-delete
         # distinct docs that collide on the id.
@@ -715,6 +728,10 @@ class TurboQuantVectorDb(VectorDb):
         fields (used by callers that pass filter-style restrictions at
         retrieval time)."""
         if self._index is None:
+            return
+        # See delete_by_content_id: a None content_id would match every
+        # doc stored without one — no-op instead (issue #169).
+        if content_id is None:
             return
         for data in self._u64_to_doc.values():
             if data.get("content_id") == content_id:

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -328,7 +328,13 @@ class TurboQuantVectorDb(VectorDb):
 
         # Raise on any document that still lacks an embedding rather than
         # silently dropping — silent drops mask data-pipeline bugs.
-        missing = [doc for doc in documents if not doc.embedding]
+        # None/len check instead of truthiness: `not <ndarray>` raises the
+        # numpy truth-value-ambiguous ValueError (issue #135).
+        missing = [
+            doc
+            for doc in documents
+            if doc.embedding is None or len(doc.embedding) == 0
+        ]
         if missing:
             ids = [doc.id or "<no id>" for doc in missing]
             raise ValueError(

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -481,6 +481,19 @@ class TurboQuantVectorDb(VectorDb):
 
     # ---- VectorDb protocol: search ----------------------------------------
 
+    @staticmethod
+    def _meta_matches(data: Dict[str, Any], items: List[Any]) -> bool:
+        """True iff the stored payload's ``meta_data`` has every filter key
+        PRESENT and equal to the filter value (AND). Key presence matters:
+        ``.get(k) == v`` coerces absence to ``None``, so a ``None``-valued
+        filter would match every doc *missing* the key — leaking (or
+        deleting) the whole collection (issue #144). LanceDb requires the
+        key to be present, and skips docs whose ``meta_data`` is ``None``."""
+        md = data.get("meta_data")
+        if md is None:
+            return False
+        return all(k in md and md[k] == v for k, v in items)
+
     def _resolve_filter_to_handles(
         self, filters: Optional[Union[Dict[str, Any], List[Any]]]
     ) -> Optional[List[int]]:
@@ -507,7 +520,7 @@ class TurboQuantVectorDb(VectorDb):
         return [
             handle
             for handle, data in self._u64_to_doc.items()
-            if all((data.get("meta_data") or {}).get(k) == v for k, v in items)
+            if self._meta_matches(data, items)
         ]
 
     def _scaled_similarity(self, raw: float) -> float:
@@ -668,7 +681,7 @@ class TurboQuantVectorDb(VectorDb):
         handles = [
             h
             for h, data in self._u64_to_doc.items()
-            if all((data.get("meta_data") or {}).get(k) == v for k, v in items)
+            if self._meta_matches(data, items)
         ]
         for handle in handles:
             self._remove_handle(handle)

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -256,9 +256,9 @@ class TurboQuantDocumentStore:
             self._u64_to_doc[h] = {
                 "id": doc.id,
                 "content": doc.content,
-                # `meta or {}`: Haystack's Document contract guarantees
-                # `meta={}`, but a hand-forced/deserialized `meta=None`
-                # is coerced gracefully rather than crashing (issue #139).
+                # `meta or {}`: Haystack's Document contract is `meta={}`,
+                # but `Document(..., meta=None)` keeps the None as-is —
+                # coerce gracefully rather than crashing (issue #139).
                 "meta": dict(doc.meta or {}),
                 "blob": doc.blob,
                 "sparse_embedding": doc.sparse_embedding,

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -256,7 +256,10 @@ class TurboQuantDocumentStore:
             self._u64_to_doc[h] = {
                 "id": doc.id,
                 "content": doc.content,
-                "meta": dict(doc.meta),
+                # `meta or {}`: Haystack's Document contract guarantees
+                # `meta={}`, but a hand-forced/deserialized `meta=None`
+                # is coerced gracefully rather than crashing (issue #139).
+                "meta": dict(doc.meta or {}),
                 "blob": doc.blob,
                 "sparse_embedding": doc.sparse_embedding,
             }
@@ -451,7 +454,7 @@ class TurboQuantDocumentStore:
         if not qvec.flags["C_CONTIGUOUS"]:
             qvec = np.ascontiguousarray(qvec)
 
-        if filters is None:
+        if not filters:
             fetch_k = min(top_k, self.count_documents())
             scores, handles = self._index.search(qvec, fetch_k)
         else:

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -387,6 +387,29 @@ def test_drop_returns_to_uncreated_state():
     assert db.get_count() == 0
 
 
+def test_drop_with_path_removes_persisted_artifacts(tmp_path):
+    # Regression test for issue #169: drop() on a store with a
+    # persistence path cleared memory but left index.tvim/docstore.json
+    # on disk, so the next create() reloaded — resurrecting — the
+    # "dropped" data. drop() must remove the persisted table entirely,
+    # matching its docstring and LanceDb's drop_table.
+    path = str(tmp_path / "store")
+    db = TurboQuantVectorDb(embedder=StubEmbedder(), path=path)
+    db.create()
+    db.insert("h", [_doc("secret")])
+    db.save()
+    assert (tmp_path / "store" / "index.tvim").exists()
+    assert (tmp_path / "store" / "docstore.json").exists()
+
+    db.drop()
+    assert db.exists() is False
+    assert not (tmp_path / "store" / "index.tvim").exists()
+    assert not (tmp_path / "store" / "docstore.json").exists()
+    # Re-create starts empty instead of reloading the dropped data.
+    db.create()
+    assert db.get_count() == 0
+
+
 def test_delete_returns_false_per_lancedb_contract():
     # LanceDb's delete() unconditionally returns False — actual removal
     # is via drop(). Mirror that exactly.
@@ -1135,6 +1158,21 @@ def test_update_metadata_unknown_content_id_is_noop():
     # Nothing changed on the known doc.
     docs = list(db._u64_to_doc.values())
     assert docs[0]["meta_data"] == {"k": 1}
+
+
+def test_none_content_id_does_not_match_docs_without_content_id():
+    # Secondary part of issue #169: docs stored without a content_id keep
+    # it as None, so `.get("content_id") == content_id` made
+    # delete_by_content_id(None) / update_metadata(None, ...) match every
+    # such doc. None is off-contract (param typed str) — treat it as a
+    # no-op instead of a whole-collection match.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a"), _doc("b")])  # no content_id on either
+    assert db.delete_by_content_id(None) is False
+    assert db.get_count() == 2
+    db.update_metadata(None, {"tag": "oops"})
+    assert all(d["meta_data"] == {} for d in db._u64_to_doc.values())
 
 
 # ---- Tier-2 field-completeness tests. Each pins behaviour around

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -182,6 +182,30 @@ def test_insert_reembeds_document_with_empty_list_embedding():
     assert db.get_count() == 1
 
 
+def test_insert_accepts_numpy_array_embedding():
+    # Regression test for issue #135: a numpy-array embedding hit
+    # `if not doc.embedding`, raising the numpy truth-value-ambiguous
+    # ValueError. LanceDb tolerates array embeddings; so must we.
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    vec = np.asarray(embedder.get_embedding("x"), dtype=np.float32)
+    db.insert("h-np", [Document(id="d1", content="x", embedding=vec)])
+    assert db.get_count() == 1
+    [hit] = db.search("x", limit=1)
+    assert hit.content == "x"
+
+
+def test_upsert_accepts_numpy_array_embedding():
+    # Same ndarray-tolerance for the upsert path (issue #135).
+    embedder = StubEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+    vec = np.asarray(embedder.get_embedding("y"), dtype=np.float32)
+    db.upsert("h-np", [Document(id="d1", content="y", embedding=vec)])
+    assert db.get_count() == 1
+
+
 def test_insert_empty_document_list_is_noop():
     # Drop-in safety: callers passing an empty list (e.g. a Knowledge
     # batch where every doc was filtered out upstream) must not raise

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -692,6 +692,40 @@ def test_delete_by_metadata_uses_and_semantics():
     assert len(db._index) == 2
 
 
+def test_delete_by_metadata_empty_dict_deletes_all():
+    # Pin the documented behavior: an empty dict is a vacuous AND, so it
+    # matches — and deletes — every document. This is exact LanceDb
+    # parity (its match loop over zero conditions also matches all).
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a"), _doc("b"), _doc("c")])
+    assert db.delete_by_metadata({}) is True
+    assert db.get_count() == 0
+
+
+def test_delete_by_metadata_none_returns_false():
+    # None is off-contract (param typed dict). LanceDb's except-all
+    # swallows the resulting AttributeError and returns False; guard
+    # explicitly instead of raising.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a")])
+    assert db.delete_by_metadata(None) is False
+    assert db.get_count() == 1
+
+
+def test_delete_by_name_none_is_noop():
+    # Same footgun class as delete_by_content_id(None): docs stored
+    # without a name keep it as None, so a None argument would delete
+    # every unnamed doc. Deliberate divergence from LanceDb's idiom —
+    # no-op instead.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a"), _doc("b")])  # no name on either
+    assert db.delete_by_name(None) is False
+    assert db.get_count() == 2
+
+
 def test_delete_by_metadata_none_value_requires_key_present():
     # Regression test for issue #144 (delete sibling): a None-valued
     # delete filter must delete only docs where the key is present and

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -1021,6 +1021,57 @@ def test_async_upsert_replaces_by_content_hash():
     asyncio.run(runner())
 
 
+def test_async_upsert_concurrent_same_content_hash_is_last_writer_wins():
+    # Regression test for issue #146: async_upsert captured old_handles
+    # BEFORE the awaited embed, so concurrent upserts of the same
+    # content_hash all snapshotted the same pre-insert handle set and no
+    # task removed a sibling's rows — stale generations accumulated.
+    # Deterministic: the embedder suspends both tasks at an asyncio.Event
+    # gate, guaranteeing both are in flight before either inserts.
+    import asyncio
+
+    class GatedEmbedder(StubEmbedder):
+        enable_batch = True
+        gate: asyncio.Event
+
+        def get_embeddings_batch_and_usage(self, texts):
+            return [self._embed(t) for t in texts], [None] * len(texts)
+
+        async def async_get_embeddings_batch_and_usage(self, texts):
+            # Controlled suspension: park here until the test releases
+            # the gate, so both upsert tasks interleave deterministically.
+            await self.gate.wait()
+            return [self._embed(t) for t in texts], [None] * len(texts)
+
+    embedder = GatedEmbedder(DIM)
+    db = TurboQuantVectorDb(embedder=embedder)
+    db.create()
+
+    async def runner():
+        embedder.gate = asyncio.Event()
+        # Seed an existing generation so stale-generation removal is
+        # exercised too, not just sibling-batch removal.
+        db.upsert("ch", [_doc("gen 0", doc_id="d")])
+        assert db.get_count() == 1
+        t1 = asyncio.create_task(
+            db.async_upsert("ch", [Document(id="d", content="gen A")])
+        )
+        t2 = asyncio.create_task(
+            db.async_upsert("ch", [Document(id="d", content="gen B")])
+        )
+        # Let both tasks run up to the gate (both suspended mid-embed).
+        await asyncio.sleep(0)
+        embedder.gate.set()
+        await asyncio.gather(t1, t2)
+
+    asyncio.run(runner())
+    # Replace-all contract: exactly one generation survives, and it's the
+    # last writer's (t2 resumes after t1, matching sync semantics).
+    assert db.get_count() == 1
+    [survivor] = db._u64_to_doc.values()
+    assert survivor["content"] == "gen B"
+
+
 # ---- Batch embedder paths -------------------------------------------------
 
 

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -557,6 +557,24 @@ def test_search_with_no_matching_filter_returns_empty():
     assert results == []
 
 
+def test_search_filter_none_value_requires_key_present():
+    # Regression test for issue #144: `{"k": None}` must match only docs
+    # where the key is PRESENT and equal to None (LanceDb semantics).
+    # `.get(k) == v` coerced key-absence to None, so filtering on an
+    # unset field leaked the entire collection.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [
+        _doc("a", meta_data={"x": "v"}),
+        _doc("b", meta_data={}),
+        _doc("d", meta_data={"x": None}),
+    ])
+    hits = db.search("a", limit=10, filters={"x": None})
+    assert sorted(h.content for h in hits) == ["d"]
+    # Filtering on a key no document has must match nothing, not everything.
+    assert db.search("a", limit=10, filters={"missing": None}) == []
+
+
 def test_search_list_filter_silently_ignored():
     # Match LanceDb behavior: list-of-FilterExpr filters are ignored.
     db = TurboQuantVectorDb(embedder=StubEmbedder())
@@ -649,6 +667,24 @@ def test_delete_by_metadata_uses_and_semantics():
     ])
     assert db.delete_by_metadata({"tag": "x", "src": "web"}) is True
     assert len(db._index) == 2
+
+
+def test_delete_by_metadata_none_value_requires_key_present():
+    # Regression test for issue #144 (delete sibling): a None-valued
+    # delete filter must delete only docs where the key is present and
+    # None — not every doc missing the key (which over-deleted the
+    # whole collection via `.get(k) == v`).
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [
+        _doc("a", meta_data={"x": "v"}),
+        _doc("b", meta_data={}),
+        _doc("d", meta_data={"x": None}),
+    ])
+    assert db.delete_by_metadata({"x": None}) is True
+    assert len(db._index) == 2  # only "d" removed
+    assert db.delete_by_metadata({"missing": None}) is False
+    assert len(db._index) == 2  # nothing else removed
 
 
 def test_delete_by_content_id():

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -545,6 +545,37 @@ def test_embedding_retrieval_with_filter():
     assert all(doc.meta["group"] == "b" for doc in results)
 
 
+def test_embedding_retrieval_empty_filters_treated_as_no_filter():
+    # Regression test for issue #131: `filters={}` must behave like
+    # `filters=None` (reference InMemoryDocumentStore guards `if filters:`),
+    # not fall through to document_matches_filter({}) which raises
+    # FilterError. filter_documents/count_documents_by_filter already
+    # treat {} as "no filter"; embedding_retrieval must agree.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    docs = make_docs(10)
+    store.write_documents(docs)
+    results = store.embedding_retrieval(
+        query_embedding=docs[0].embedding, top_k=3, filters={}
+    )
+    assert len(results) == 3
+    assert results[0].id == "doc-0"
+
+
+def test_write_documents_with_none_meta_coerced_to_empty():
+    # Regression test for the Haystack half of issue #139: a Document
+    # whose `meta` was force-set to None (off-contract, but reachable via
+    # deserialization) must not crash `dict(doc.meta)` at write time.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    doc = Document(id="none-meta", content="text", embedding=unit_vector(0))
+    # Bypass Document.__setattr__'s mutation warning — forcing the
+    # off-contract shape is the point of this test.
+    object.__setattr__(doc, "meta", None)
+    assert store.write_documents([doc]) == 1
+    [stored] = store.filter_documents()
+    assert stored.id == "none-meta"
+    assert stored.meta == {}
+
+
 def test_embedding_retrieval_selective_filter_returns_top_k():
     # Regression test for the over-fetch / post-filter recall hit: with a
     # filter that matches only 3 docs out of 50, top_k=3 must return all 3.

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -562,14 +562,12 @@ def test_embedding_retrieval_empty_filters_treated_as_no_filter():
 
 
 def test_write_documents_with_none_meta_coerced_to_empty():
-    # Regression test for the Haystack half of issue #139: a Document
-    # whose `meta` was force-set to None (off-contract, but reachable via
-    # deserialization) must not crash `dict(doc.meta)` at write time.
+    # Regression test for the Haystack half of issue #139: Haystack's
+    # contract is `meta={}`, but `Document(..., meta=None)` keeps the
+    # None as-is — writing such a document must not crash on
+    # `dict(doc.meta)`.
     store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
-    doc = Document(id="none-meta", content="text", embedding=unit_vector(0))
-    # Bypass Document.__setattr__'s mutation warning — forcing the
-    # off-contract shape is the point of this test.
-    object.__setattr__(doc, "meta", None)
+    doc = Document(id="none-meta", content="text", embedding=unit_vector(0), meta=None)
     assert store.write_documents([doc]) == 1
     [stored] = store.filter_documents()
     assert stored.id == "none-meta"


### PR DESCRIPTION
Closes #131
Closes #135
Closes #144
Closes #146
Closes #169

Also fixes the Haystack sibling recorded on #139 (LangChain half in a separate PR).

## What / why

All fixes are correctness alignments of the Haystack and agno integrations against their drop-in references (Haystack's `InMemoryDocumentStore`; agno's `LanceDb`). Each was reproduced on this branch's base before fixing, and each fix ships with a regression test that fails on the old code.

### Haystack (`turbovec-python/python/turbovec/haystack.py`)

- **#131 — `embedding_retrieval(filters={})` raised `FilterError`.** `if filters is None:` let an empty dict reach `document_matches_filter({})`. Now guarded with truthiness (`if not filters:`), matching the reference and this store's own `filter_documents` / `count_documents_by_filter`.
- **#139 (Haystack half) — `Document` with `meta` force-set to `None` crashed `write_documents`** with `TypeError` at `dict(doc.meta)`. `meta=None` is off-contract in Haystack, so it is gracefully coerced: `dict(doc.meta or {})`.

### agno (`turbovec-python/python/turbovec/agno.py`)

- **#135 — `insert()`/`upsert()` crashed on numpy-array embeddings** with numpy's truth-value-ambiguous `ValueError` (`if not doc.embedding`). Now uses the same None/len emptiness idiom `_embed_missing` already used. LanceDb tolerates array embeddings.
- **#144 — `{'k': None}` dict filter matched docs *missing* the key**, so a search filter on an unset field leaked the entire collection, and the identical idiom in `delete_by_metadata` deleted the entire collection. Both call sites now share a `_meta_matches` predicate with LanceDb's semantics: key present AND equal (docs with `meta_data=None` never match).
- **#146 — `async_upsert` captured the previous generation's handles before the awaited embed**, so concurrent upserts of the same `content_hash` all snapshotted the same pre-insert handle set and stale generations accumulated (deterministically: `gather` x2 → 2 docs, x5 → 5). Now awaits only the embedding step and delegates capture+insert+remove to the sync `upsert` (no interleaving await). Preserves the #89 insert-before-delete ordering; concurrent upserts become last-writer-wins, identical to sync semantics. The regression test uses a controlled-suspension (asyncio.Event-gated) embedder, not a racy one.
- **#169 — `drop()` on a store with a persistence `path` left `index.tvim`/`docstore.json` on disk**, so the next `create()` reloaded — resurrected — the dropped data, violating `drop()`'s own docstring and LanceDb's `drop_table`. `drop()` now unlinks both artifacts. Secondary (same issue): `delete_by_content_id(None)` / `update_metadata(None, ...)` matched every doc stored without a `content_id`; both now early-return on `None`.

## Test evidence

- Each issue reproduced before the fix and re-verified fixed after (repro scripts run against this worktree).
- New regression tests (each confirmed failing pre-fix):
  - `test_embedding_retrieval_empty_filters_treated_as_no_filter` (#131)
  - `test_write_documents_with_none_meta_coerced_to_empty` (#139)
  - `test_insert_accepts_numpy_array_embedding`, `test_upsert_accepts_numpy_array_embedding` (#135)
  - `test_search_filter_none_value_requires_key_present`, `test_delete_by_metadata_none_value_requires_key_present` (#144)
  - `test_async_upsert_concurrent_same_content_hash_is_last_writer_wins` (#146)
  - `test_drop_with_path_removes_persisted_artifacts`, `test_none_content_id_does_not_match_docs_without_content_id` (#169)
- Full Python suite: **387 passed** (`turbovec-python/tests/`, includes langchain/llama_index/core suites — no regressions).

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
