### PR TITLE
Core-encode hardening: frozen-calibration scale explosion, encode OOB write, lazy add_2d dim wedge (#116, #117, #129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,29 @@ appears under each surface it touches.
   the notice itself (MIT requires the notice to accompany copies). A copy
   of the license is now committed inside `turbovec/`, which cargo
   auto-includes in the package. (#166)
+- **Out-of-distribution vectors no longer explode their correction scale
+  under frozen TQ+ calibration.** When a vector added after calibration was
+  frozen reconstructed with a non-positive inner product, the
+  `inner.max(1e-10)` clamp turned the stored scale into ~1e10 with a
+  flipped sign, letting that one vector falsely dominate every top-k.
+  Degenerate reconstructions now store scale 0, so the vector scores ~0
+  and ranks last; healthy vectors encode bit-identically to before on both
+  the SIMD and scalar paths. (#116)
+- **`encode::encode` rejects dims that are not a multiple of 8 instead of
+  writing out of bounds.** The packed layout allocates `dim / 8` bytes per
+  bit-plane, so tail coordinates of a non-multiple-of-8 dim wrote past the
+  end of each row — the top bit-plane panicked with an index-out-of-bounds
+  and lower planes silently corrupted the next plane's bytes. The dead
+  tail branch is removed and `encode` now panics up front with a clear
+  message, matching the index-level validation. Unreachable through
+  `TurboQuantIndex`, which already validated dim at construction. (#117)
+- **A failed `add_2d` length check no longer wedges a lazy index.**
+  `add_2d` committed the inferred dim before the `vectors.len() % dim`
+  validation panicked, leaving the index with a locked dim and zero
+  vectors — a follow-up add with a different dim saw a confusing
+  `DimMismatch` instead of a fresh start. The length check now runs before
+  the dim commit. (`IdMapIndex::add_with_ids_2d` already validated before
+  committing and is unchanged.) (#129)
 
 ### turbovec — Python package
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,16 @@ appears under each surface it touches.
   auto-includes in the package. (#166)
 - **Out-of-distribution vectors no longer explode their correction scale
   under frozen TQ+ calibration.** When a vector added after calibration was
-  frozen reconstructed with a non-positive inner product, the
-  `inner.max(1e-10)` clamp turned the stored scale into ~1e10 with a
-  flipped sign, letting that one vector falsely dominate every top-k.
-  Degenerate reconstructions now store scale 0, so the vector scores ~0
-  and ranks last; healthy vectors encode bit-identically to before on both
-  the SIMD and scalar paths. (#116)
+  frozen reconstructed with a near-zero or negative inner product, the
+  `inner.max(1e-10)` clamp turned the stored scale into up to ~1e10 (with
+  a flipped sign for negative inners), letting that one vector falsely
+  dominate every top-k. Reconstructions whose unit-space inner product
+  falls at or below 0.1 are now treated as degenerate and store scale 0,
+  so the vector scores ~0 and ranks last; any stored scale is thereby
+  bounded by 10× the vector's norm. Healthy reconstructions sit well
+  above the threshold (measured minima ≥ 0.56 even at 2-bit dim-8), so
+  healthy vectors encode bit-identically to before on both the SIMD and
+  scalar paths; the zero-vector behavior (scale 0) is unchanged. (#116)
 - **`encode::encode` rejects dims that are not a multiple of 8 instead of
   writing out of bounds.** The packed layout allocates `dim / 8` bytes per
   bit-plane, so tail coordinates of a non-multiple-of-8 dim wrote past the

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -52,6 +52,12 @@ const TQPLUS_MIN_SAMPLES: usize = 1000;
 /// fresh calibration from this batch's empirical quantiles.
 ///
 /// Returns (packed_codes, scales, shift_used, scale_tq_used).
+///
+/// # Panics
+///
+/// Panics if `dim` is zero or not a multiple of 8 — the packed layout
+/// allocates `dim / 8` bytes per bit-plane, so no other dim has a valid
+/// layout. (`TurboQuantIndex` enforces the same rule at construction.)
 pub fn encode(
     vectors: &[f32],
     n: usize,
@@ -62,6 +68,16 @@ pub fn encode(
     bit_width: usize,
     existing_calibration: Option<(&[f32], &[f32])>,
 ) -> (Vec<u8>, Vec<f32>, Vec<f32>, Vec<f32>) {
+    // The packed layout allocates `dim / 8` bytes per bit-plane, so a dim
+    // that is not a multiple of 8 has no valid layout: the tail
+    // coordinates would write past the end of each plane (top plane
+    // panics, lower planes silently corrupt the next plane's bytes —
+    // #117). TurboQuantIndex enforces this at construction; enforce it
+    // here too for direct callers of the public function.
+    assert!(
+        dim != 0 && dim % 8 == 0,
+        "encode requires dim to be a nonzero multiple of 8, got {dim}",
+    );
     let mut norms = vec![0.0f32; n];
     let mut unit_flat = vec![0.0f32; n * dim];
 
@@ -326,30 +342,32 @@ fn fused_quantize_scale_pack(
                 packed_row[p * bytes_per_plane + offset / 8] = vaddv_u8(vand_u8(hit, wv));
             }
         }
-
-        // Tail elements when dim isn't a multiple of 8 (kept for parity even
-        // though TurboQuantIndex::new rejects non-multiples-of-8 today).
-        for j in (chunks * 8)..dim {
-            let mut code = 0u8;
-            for &b in boundaries {
-                if rot_calib[j] > b { code += 1; }
-            }
-            let centroid_in_orig =
-                (centroids[code as usize] as f64) * (inv_scale_tq[j] as f64)
-                    - (shift[j] as f64);
-            inner += (rot_orig[j] as f64) * centroid_in_orig;
-            let byte_pos = j / 8;
-            let bit_pos = 7 - (j % 8);
-            for p in 0..bits {
-                if code & (1 << p) != 0 {
-                    packed_row[p * bytes_per_plane + byte_pos] |= 1 << bit_pos;
-                }
-            }
-        }
+        // No tail loop: `encode` asserts dim % 8 == 0, so `chunks * 8 == dim`.
+        // (The old tail branch could never work — `bytes_per_plane = dim / 8`
+        // truncates, so tail coordinates have no bytes to land in; see #117.)
     }
 
-    let inner = inner.max(1e-10) as f32;
-    norm / inner
+    scale_from_inner(inner, norm)
+}
+
+/// Convert the reconstruction inner product `<u_rot, x_hat>` into the stored
+/// per-vector correction scale `||v|| / inner`.
+///
+/// A vanishing or negative `inner` means the quantized reconstruction points
+/// away from the vector — the codebook cannot represent it under the current
+/// (possibly frozen) calibration. The old `inner.max(1e-10)` clamp turned
+/// that into a ~1e10 scale with a flipped sign, letting a single
+/// out-of-distribution vector falsely dominate every top-k (#116). Store
+/// scale 0 instead so the vector scores ~0 and ranks last; this also
+/// preserves the zero-vector behavior the clamp originally guarded
+/// (`norm == 0` ⇒ scale 0). For `inner > 1e-10` the result is bit-identical
+/// to the previous code on both the SIMD and scalar paths.
+#[inline(always)]
+fn scale_from_inner(inner: f64, norm: f32) -> f32 {
+    if inner <= 1e-10 {
+        return 0.0;
+    }
+    norm / inner as f32
 }
 
 // ─── Fused quantize + scale + pack (fallback) ───────────────────────────────
@@ -390,6 +408,5 @@ fn fused_quantize_scale_pack(
         }
     }
 
-    let inner = inner.max(1e-10) as f32;
-    norm / inner
+    scale_from_inner(inner, norm)
 }

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -350,24 +350,49 @@ fn fused_quantize_scale_pack(
     scale_from_inner(inner, norm)
 }
 
+/// Degeneracy threshold for the reconstruction inner product.
+///
+/// `inner = <u_rot, x_hat>` is computed against the *unit-normalized*
+/// rotated vector, so it is already norm-relative (cosine-like, ≈ 1 for a
+/// healthy reconstruction regardless of the vector's magnitude). Measured
+/// healthy minima stay above ~0.56 (dim 8 at 2 bits, the coarsest
+/// supported config; every other measured config is ≥ 0.70, and
+/// in-distribution data under fitted calibration sits at ≈ 1.0). By
+/// contrast, reconstructions of vectors a frozen calibration cannot
+/// represent collapse below ~0.06 on their way to the sign flip (#116).
+/// 0.1 splits that gap: healthy vectors are untouched (their encode
+/// output stays bit-identical), while every stored scale is bounded by
+/// `norm / EPS`, capping score inflation at 10× the vector's true
+/// magnitude instead of the old ~1e10 blowup.
+const DEGENERATE_INNER_EPS: f64 = 0.1;
+
 /// Convert the reconstruction inner product `<u_rot, x_hat>` into the stored
 /// per-vector correction scale `||v|| / inner`.
 ///
-/// A vanishing or negative `inner` means the quantized reconstruction points
-/// away from the vector — the codebook cannot represent it under the current
-/// (possibly frozen) calibration. The old `inner.max(1e-10)` clamp turned
-/// that into a ~1e10 scale with a flipped sign, letting a single
-/// out-of-distribution vector falsely dominate every top-k (#116). Store
-/// scale 0 instead so the vector scores ~0 and ranks last; this also
-/// preserves the zero-vector behavior the clamp originally guarded
-/// (`norm == 0` ⇒ scale 0). For `inner > 1e-10` the result is bit-identical
-/// to the previous code on both the SIMD and scalar paths.
+/// A small or negative `inner` means the quantized reconstruction points
+/// away from (or nearly orthogonal to) the vector — the codebook cannot
+/// represent it under the current (possibly frozen) calibration, and any
+/// finite scale would inflate its scores by `1 / inner`. The old
+/// `inner.max(1e-10)` clamp turned a negative `inner` into a ~1e10 scale
+/// with a flipped sign, letting a single out-of-distribution vector falsely
+/// dominate every top-k (#116); a purely non-positive test would have left
+/// the same explosion reachable through the open window just above zero.
+/// Degenerate reconstructions (`inner <= DEGENERATE_INNER_EPS`) store scale
+/// 0 instead so the vector scores ~0 and ranks last; this also preserves
+/// the zero-vector behavior the clamp originally guarded (`norm == 0` ⇒
+/// `inner == 0` ⇒ scale 0). The comparison is written positively so a NaN
+/// `inner` (reachable only via direct `encode` calls with non-finite input,
+/// which the index-level API rejects) lands in the degenerate branch rather
+/// than poisoning the stored scale. Both the SIMD path and the scalar
+/// fallback route through this helper, so the two stay in agreement; for
+/// `inner > EPS` the result is bit-identical to the previous code.
 #[inline(always)]
 fn scale_from_inner(inner: f64, norm: f32) -> f32 {
-    if inner <= 1e-10 {
-        return 0.0;
+    if inner > DEGENERATE_INNER_EPS {
+        norm / inner as f32
+    } else {
+        0.0
     }
-    norm / inner as f32
 }
 
 // ─── Fused quantize + scale + pack (fallback) ───────────────────────────────

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -374,6 +374,17 @@ impl TurboQuantIndex {
                 value: v,
             });
         }
+        // Validate the length/dim relationship BEFORE committing dim on a
+        // lazy index. add() re-checks this, but by then the dim would
+        // already be locked — a panic there left the lazy index wedged
+        // (committed dim, zero vectors), turning a follow-up add_2d with a
+        // different dim into a confusing DimMismatch instead of a fresh
+        // start (#129).
+        assert_eq!(
+            vectors.len() % dim,
+            0,
+            "vectors length must be a multiple of dim"
+        );
         // Lazy commit happens via add() (which goes through `self.dim.expect`),
         // so re-do the dim assignment here for the lazy-first-add case.
         if self.dim.is_none() {

--- a/turbovec/tests/core_encode_hardening.rs
+++ b/turbovec/tests/core_encode_hardening.rs
@@ -1,0 +1,202 @@
+//! Regression tests for the core-encode hardening fixes (#116, #117, #129).
+//!
+//! Bugs pinned here:
+//!
+//! 1. **#116 — frozen-calibration scale explosion.** The per-vector
+//!    correction scale is `||v|| / <u_rot, x_hat>`. With a genuinely
+//!    fitted (frozen) TQ+ calibration, a later-added out-of-distribution
+//!    vector can reconstruct with a *negative* inner product; the old
+//!    `inner.max(1e-10)` clamp turned that into a denominator of `1e-10`,
+//!    producing a ~1e10 scale with a flipped sign — one garbage vector
+//!    then falsely dominated every top-k. Degenerate reconstructions
+//!    (`inner <= 1e-10`) must instead store scale 0 so the vector scores
+//!    ~0 and ranks last.
+//!
+//! 2. **#117 — public `encode::encode` OOB write for dim % 8 != 0.**
+//!    `bytes_per_plane = dim / 8` truncates; the tail-coordinate branch
+//!    then wrote past the end of each row: the top bit-plane panicked
+//!    with an index-out-of-bounds and lower planes silently corrupted
+//!    the next plane's bytes. `encode` must reject non-multiple-of-8
+//!    dims up front with a clear message, matching the index-level
+//!    validation.
+//!
+//! 3. **#129 — `add_2d` on a lazy index committed dim before the
+//!    length-validation panic.** `vectors.len() % dim` was only checked
+//!    inside the inner `add()`, *after* `self.dim = Some(dim)`, so the
+//!    panic left the lazy index wedged with a committed dim and zero
+//!    vectors — a follow-up `add_2d` with a different dim saw a
+//!    confusing `DimMismatch` instead of a fresh start. The length
+//!    check must run before the dim commit.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use turbovec::codebook::codebook;
+use turbovec::encode::encode;
+use turbovec::rotation::make_rotation_matrix;
+use turbovec::{AddError, IdMapIndex, TurboQuantIndex};
+
+/// Deterministic small noise in [-1, 1] (xorshift).
+fn noise(state: &mut u64) -> f32 {
+    *state ^= *state << 13;
+    *state ^= *state >> 7;
+    *state ^= *state << 17;
+    let raw = (*state >> 40) as u32;
+    raw as f32 / (1u32 << 23) as f32 - 1.0
+}
+
+// ─── #116: frozen-calibration scale explosion ───────────────────────────────
+
+#[test]
+fn ood_vector_under_frozen_calibration_does_not_dominate_topk() {
+    let dim = 64;
+    let n = 1200; // >= TQPLUS_MIN_SAMPLES so a real calibration is fitted
+    let mut index = TurboQuantIndex::new(dim, 4).unwrap();
+
+    // Cluster tightly around +e1 so the fitted calibration is frozen to a
+    // distribution the later outlier does not belong to.
+    let mut state = 0x1234_5678_9abc_def0u64;
+    let mut vectors = vec![0.0f32; n * dim];
+    for row in vectors.chunks_mut(dim) {
+        row[0] = 1.0;
+        for coord in row.iter_mut().skip(1) {
+            *coord = 0.01 * noise(&mut state);
+        }
+    }
+    index.add(&vectors);
+
+    // Out-of-distribution vector: -e1, the exact opposite of the cluster.
+    let mut ood = vec![0.0f32; dim];
+    ood[0] = -1.0;
+    index.add(&ood);
+    let ood_slot = n as i64;
+
+    // Query +e1. True scores: cluster ≈ +1.0, OOD vector = -1.0 (worst
+    // possible). The OOD vector must not appear in the top-k at all, and
+    // no score may be inflated beyond the plausible inner-product range.
+    let mut query = vec![0.0f32; dim];
+    query[0] = 1.0;
+    let results = index.search(&query, 5);
+
+    let top_indices = results.indices_for_query(0);
+    let top_scores = results.scores_for_query(0);
+    assert!(
+        !top_indices.contains(&ood_slot),
+        "out-of-distribution vector (slot {ood_slot}) reached the top-5: \
+         indices {top_indices:?}, scores {top_scores:?}",
+    );
+    for &s in top_scores {
+        assert!(
+            s.is_finite() && s.abs() < 10.0,
+            "top-5 score {s} is outside the plausible inner-product range \
+             (scale explosion): scores {top_scores:?}",
+        );
+    }
+}
+
+#[test]
+fn degenerate_reconstruction_scale_is_zero_not_exploded() {
+    // Same setup as above, but check the encode-level contract directly:
+    // a vector whose quantized reconstruction points away from it must
+    // get scale 0 (unrepresentable ⇒ scores ~0), never a huge negative-
+    // inner-product blowup.
+    let dim = 64;
+    let n = 1200;
+    let mut state = 0xdead_beef_dead_beefu64;
+    let mut vectors = vec![0.0f32; n * dim];
+    for row in vectors.chunks_mut(dim) {
+        row[0] = 1.0;
+        for coord in row.iter_mut().skip(1) {
+            *coord = 0.01 * noise(&mut state);
+        }
+    }
+
+    let rotation = make_rotation_matrix(dim);
+    let (boundaries, centroids) = codebook(4, dim);
+    let (_, _, shift, scale_tq) = encode(
+        &vectors, n, dim, &rotation, &boundaries, &centroids, 4, None,
+    );
+
+    let mut ood = vec![0.0f32; dim];
+    ood[0] = -1.0;
+    let (_, scales, _, _) = encode(
+        &ood, 1, dim, &rotation, &boundaries, &centroids, 4,
+        Some((&shift, &scale_tq)),
+    );
+    assert!(
+        scales[0].abs() < 10.0,
+        "degenerate reconstruction produced exploded scale {}",
+        scales[0],
+    );
+
+    // The zero vector keeps its historical behavior: norm 0 ⇒ scale 0.
+    let zero = vec![0.0f32; dim];
+    let (_, zero_scales, _, _) = encode(
+        &zero, 1, dim, &rotation, &boundaries, &centroids, 4,
+        Some((&shift, &scale_tq)),
+    );
+    assert_eq!(zero_scales[0], 0.0, "zero vector must keep scale 0");
+}
+
+// ─── #117: encode rejects dim not a multiple of 8 ───────────────────────────
+
+#[test]
+#[should_panic(expected = "multiple of 8")]
+fn encode_rejects_dim_not_multiple_of_8() {
+    // dim = 12 truncates bytes_per_plane to 1; before the fix the four
+    // tail coordinates wrote out of bounds (top bit-plane panicked with
+    // an index-out-of-bounds, lower planes silently corrupted the next
+    // plane's bytes). encode must reject this up front with a clear
+    // message instead.
+    let dim = 12;
+    let n = 4;
+    let rotation = make_rotation_matrix(dim);
+    let (boundaries, centroids) = codebook(2, dim);
+    let vectors = vec![0.25f32; n * dim];
+    let _ = encode(
+        &vectors, n, dim, &rotation, &boundaries, &centroids, 2, None,
+    );
+}
+
+// ─── #129: failed length validation leaves a lazy index uncommitted ─────────
+
+#[test]
+fn lazy_add_2d_length_panic_does_not_commit_dim() {
+    let mut index = TurboQuantIndex::new_lazy(4).unwrap();
+
+    // 100 is not a multiple of 64 → add_2d panics (documented contract).
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let _ = index.add_2d(&vec![0.5f32; 100], 64);
+    }));
+    assert!(result.is_err(), "add_2d must panic on non-multiple length");
+
+    // The failed add must NOT have committed the dim: the index stays
+    // lazy/uncommitted and a fresh start with a different dim succeeds.
+    assert_eq!(
+        index.dim_opt(),
+        None,
+        "failed add_2d left the lazy index wedged with a committed dim",
+    );
+    index
+        .add_2d(&vec![0.5f32; 16], 8)
+        .expect("fresh add with a different dim must succeed after the failed add");
+    assert_eq!(index.dim_opt(), Some(8));
+    assert_eq!(index.len(), 2);
+}
+
+#[test]
+fn lazy_add_with_ids_2d_length_error_does_not_commit_dim() {
+    // IdMapIndex::add_with_ids_2d validates length/dim up front and
+    // returns a typed error without touching the inner index — pin that
+    // the lazy index stays uncommitted there too.
+    let mut index = IdMapIndex::new_lazy(4).unwrap();
+    let err = index
+        .add_with_ids_2d(&vec![0.5f32; 100], 64, &[1, 2])
+        .unwrap_err();
+    assert!(matches!(err, AddError::VectorBufferNotMultipleOfDim { .. }));
+    assert_eq!(index.dim_opt(), None);
+
+    index
+        .add_with_ids_2d(&vec![0.5f32; 16], 8, &[1, 2])
+        .expect("fresh add with a different dim must succeed after the failed add");
+    assert_eq!(index.dim_opt(), Some(8));
+}

--- a/turbovec/tests/core_encode_hardening.rs
+++ b/turbovec/tests/core_encode_hardening.rs
@@ -135,6 +135,105 @@ fn degenerate_reconstruction_scale_is_zero_not_exploded() {
         Some((&shift, &scale_tq)),
     );
     assert_eq!(zero_scales[0], 0.0, "zero vector must keep scale 0");
+
+    // NaN input through the *direct* encode path (the index-level API
+    // rejects non-finite values before encoding) must land in the
+    // degenerate branch and store scale 0, not a NaN/garbage scale. The
+    // helper's comparison is written positively (`inner > EPS`) so NaN
+    // fails it.
+    let mut nan_vec = vec![0.5f32; dim];
+    nan_vec[3] = f32::NAN;
+    let (_, nan_scales, _, _) = encode(
+        &nan_vec, 1, dim, &rotation, &boundaries, &centroids, 4,
+        Some((&shift, &scale_tq)),
+    );
+    assert_eq!(
+        nan_scales[0], 0.0,
+        "NaN input must store scale 0, got {}",
+        nan_scales[0],
+    );
+}
+
+#[test]
+fn near_orthogonal_window_under_frozen_calibration_is_bounded() {
+    // Adversarial-review follow-up on #116: zeroing only `inner <= 1e-10`
+    // moved the explosion cliff instead of removing it — a unit vector at
+    // theta ≈ 1.6293 rad from the cluster axis reconstructed with a tiny
+    // *positive* inner (1.5e-4 .. 1.8e-3), storing scales of 559 .. 6.6e3
+    // and again dominating the top-k with a hugely inflated score. The
+    // degeneracy test is now `inner <= 0.1` (inner is unit-space /
+    // cosine-like), so every stored scale for a unit vector is bounded by
+    // 1 / 0.1 = 10 and the near-orthogonal window collapses to scale 0.
+    let dim = 64;
+    let n = 1200;
+    let mut state = 0x1234_5678_9abc_def0u64;
+    let mut cluster = vec![0.0f32; n * dim];
+    for row in cluster.chunks_mut(dim) {
+        row[0] = 1.0;
+        for coord in row.iter_mut().skip(1) {
+            *coord = 0.01 * noise(&mut state);
+        }
+    }
+
+    // Encode-level sweep: 720 unit vectors cos(t)*e1 + sin(t)*e2 across
+    // (0, pi), quantized under the calibration frozen from the cluster.
+    // No stored scale may exceed the 1/EPS = 10 bound (or be non-finite).
+    let rotation = make_rotation_matrix(dim);
+    let (boundaries, centroids) = codebook(4, dim);
+    let (_, _, shift, scale_tq) = encode(
+        &cluster, n, dim, &rotation, &boundaries, &centroids, 4, None,
+    );
+    let steps = 720;
+    let mut sweep = vec![0.0f32; steps * dim];
+    for (t, row) in sweep.chunks_mut(dim).enumerate() {
+        let theta = std::f32::consts::PI * (t as f32 + 0.5) / steps as f32;
+        row[0] = theta.cos();
+        row[1] = theta.sin();
+    }
+    let (_, sweep_scales, _, _) = encode(
+        &sweep, steps, dim, &rotation, &boundaries, &centroids, 4,
+        Some((&shift, &scale_tq)),
+    );
+    for (t, &s) in sweep_scales.iter().enumerate() {
+        assert!(
+            s.is_finite() && (0.0..=10.0).contains(&s),
+            "sweep step {t}: stored scale {s} escapes the [0, 1/EPS] bound",
+        );
+    }
+
+    // Index-level: the two pathological angles found by the reviewer's
+    // coarse sweep (theta = 1.6275, stored scale 559 pre-fix) and
+    // bisection (theta = 1.629281051794, stored scale 6.6e3 pre-fix)
+    // must never reach the top-k. Their true inner products with the +e1
+    // query are ≈ -0.057 / -0.059 — worse than every cluster member.
+    let mut index = TurboQuantIndex::new(dim, 4).unwrap();
+    index.add(&cluster);
+    for theta in [1.6275f32, 1.629281051794] {
+        let mut v = vec![0.0f32; dim];
+        v[0] = theta.cos();
+        v[1] = theta.sin();
+        index.add(&v);
+    }
+    let pathological: Vec<i64> = vec![n as i64, n as i64 + 1];
+
+    let mut query = vec![0.0f32; dim];
+    query[0] = 1.0;
+    let results = index.search(&query, 5);
+    let top_indices = results.indices_for_query(0);
+    let top_scores = results.scores_for_query(0);
+    for slot in &pathological {
+        assert!(
+            !top_indices.contains(slot),
+            "near-orthogonal vector (slot {slot}) reached the top-5: \
+             indices {top_indices:?}, scores {top_scores:?}",
+        );
+    }
+    for &s in top_scores {
+        assert!(
+            s.is_finite() && s.abs() < 10.0,
+            "top-5 score {s} is outside the plausible range: {top_scores:?}",
+        );
+    }
 }
 
 // ─── #117: encode rejects dim not a multiple of 8 ───────────────────────────


### PR DESCRIPTION
Fixes three core-encode bugs in the Rust crate. Each was reproduced on `main` before fixing; the regression tests below fail on the unfixed code (verified by stashing the `src` changes and re-running).

## #116 — TQ+ frozen-calibration scale explosion

**Root cause:** the per-vector correction scale is `||v|| / <u_rot, x_hat>`. With a genuinely fitted frozen calibration (n ≥ 1000), a later-added out-of-distribution vector can reconstruct with a near-zero or *negative* inner product. The `inner.max(1e-10)` clamp (`turbovec/src/encode.rs`, both SIMD and scalar paths) turned that into a huge scale (flipped sign for negative inners) — so one garbage vector falsely dominated every top-k.

**Repro on main:** dim=64, bits=4; add 1200 vectors clustered at +e1 (1.0 + 0.01 noise), then a single −e1; search +e1, k=5 → top-1 was the −e1 vector at slot 1200 with score **9,007,540,000** (true score −1.0; cluster scores ≈ 1.0005). Adversarial review of the first-pass fix (zeroing only `inner <= 1e-10`) showed the cliff was moved, not removed: a unit vector at θ ≈ 1.6293 rad from the cluster axis reconstructed with inner ≈ 1.5e-4 – 1.8e-3, storing scales of 559 – 6.6e3 and again dominating the top-k.

**Fix:** reconstructions with `inner <= DEGENERATE_INNER_EPS` (0.1) are treated as degenerate and store scale 0 — the vector scores ~0 and ranks last. `inner` is computed against the unit-normalized rotated vector, so it is already norm-relative (cosine-like, ≈ 1 when healthy); 0.1 splits the measured gap between the worst healthy reconstruction (0.5643 at 2-bit dim-8, the coarsest config; ≥ 0.70 elsewhere; ≈ 1.0 in-distribution under fitted calibration) and the degenerate window (< ~0.06 past the true-IP sign flip in the repro geometry). Every stored scale is thereby bounded by `norm / 0.1`, capping score inflation at 10× the vector's true magnitude instead of ~1e10. The comparison is written positively (`inner > EPS`) so a NaN inner — reachable only through direct `encode::encode` calls with non-finite input, which the index API rejects — also lands in the degenerate branch (scale 0) instead of storing a NaN scale. Zero-vector behavior (scale 0) preserved; both paths route through one shared `scale_from_inner` helper, so SIMD and scalar fallback stay in agreement.

**Bit-identity re-verified against main (1e7200c):** FNV hashes of `(packed_codes, scales, shift, scale_tq)` identical across 10 deterministic healthy configs, including 2-bit dim-8 fitted/identity calibration and a norm-1e6 variant. No change to the warm-up/identity-freeze calibration behavior.

Closes #116

## #117 — public `encode::encode` OOB write when dim % 8 != 0

**Root cause:** `bytes_per_plane = dim / 8` truncates, so the tail-coordinate branch wrote past the end of each packed row: the top bit-plane panicked with index-OOB, and lower planes silently corrupted the next plane's bytes. The branch's "kept for parity" comment was false — it could never work. Latent public-API bug only: `TurboQuantIndex` already validates dim % 8 at construction.

**Repro on main:** direct `encode()` call with dim=12, n=4, bits=2 → `panicked at turbovec/src/encode.rs:345: index out of bounds: the len is 2 but the index is 2`.

**Fix:** deleted the dead tail branch and added an up-front assert that dim is a nonzero multiple of 8, matching the index-level validation (the assert route rather than `div_ceil`, which would change the packed layout that repack/search/io expect). Documented under `# Panics` in the rustdoc.

Closes #117

## #129 — lazy `add_2d` commits dim before length validation

**Root cause:** `TurboQuantIndex::add_2d` set `self.dim = Some(dim)` before the `vectors.len() % dim` assert inside `add()` fired, contradicting the invariant comment ("Don't commit dim until validation passes") that the value-validation path honors. The panic left a lazy index wedged: committed dim, zero vectors, and a follow-up `add_2d` with a different dim got `DimMismatch` instead of a fresh start.

**Repro on main:** `new_lazy(4)`, `catch_unwind(add_2d(&vec![0.5; 100], 64))` → panicked = true, but `dim_opt()` returned `Some(64)`.

**Fix:** the length check now runs in `add_2d` before the dim commit, with the same panic message as `add()`. Checked `IdMapIndex::add_with_ids_2d`: it already validates length/dim up front and returns `VectorBufferNotMultipleOfDim` before touching the inner index — no change needed there (behavior pinned by a test).

Closes #129

## Tests

New file `turbovec/tests/core_encode_hardening.rs`:

- `ood_vector_under_frozen_calibration_does_not_dominate_topk` (#116, fails on main)
- `degenerate_reconstruction_scale_is_zero_not_exploded` (#116, encode-level contract incl. zero-vector and NaN-input behavior, fails on main and on the first-pass fix)
- `near_orthogonal_window_under_frozen_calibration_is_bounded` (#116 follow-up: 720-step θ sweep asserting every stored scale stays within [0, 1/EPS], plus the θ = 1.6275 / 1.629281051794 vectors never reach top-k; fails on main and on the first-pass fix — sweep escapes the bound at step 350)
- `encode_rejects_dim_not_multiple_of_8` (#117, fails on main)
- `lazy_add_2d_length_panic_does_not_commit_dim` (#129, fails on main)
- `lazy_add_with_ids_2d_length_error_does_not_commit_dim` (pins the already-correct `IdMapIndex` path)

Full suite: `cargo test -p turbovec` — **149 passed, 0 failed**. Bindings: `cargo check -p turbovec-python` clean. No format changes (`TV_VERSION`/`TVIM_VERSION` still 3, `MAX_DIM` untouched). CHANGELOG updated under Unreleased → Rust crate → Fixed.

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
