### PR TITLE
fix: validate side-car keysets at load across all four integrations (#115, #125, #133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,6 @@ appears under each surface it touches.
   and `avx2_post_flush_heap_update`; the dead copy's logic had drifted
   from them, so keeping it invited confusion in future kernel edits. No
   behavior change. (#134)
-
 ### turbovec — Python package
 
 #### Fixed
@@ -168,6 +167,24 @@ appears under each surface it touches.
   checks (`in` / `contains` / `remove`) return `False` for ids that can
   never be present, and `k` / `dim` / `bit_width` raise a `ValueError`
   naming the argument. (#128)
+- **Integration load paths now validate the side-car's internal key-sets,
+  not just the handle ↔ index bijection.** A desynced side-car (partial
+  copy, stale backup, hand edit) previously loaded clean and failed later —
+  an opaque `KeyError` mid-query, or silently missing results. All four
+  integrations now raise a clean `ValueError` at load instead:
+  - **agno**: `_load_from` skipped the index/side-car consistency check the
+    other integrations run; a desynced `docstore.json` loaded clean and
+    orphaned vectors were silently dropped from search results. It now
+    calls the shared handle check. (#115)
+  - **LangChain**: `load()` didn't require `docs` and `str_to_u64` to hold
+    the same document ids; a `docs` entry missing for a mapped id raised
+    `KeyError` inside `similarity_search`. (#125)
+  - **LlamaIndex**: `from_persist_path` didn't require `nodes` and
+    `node_id_to_u64` to hold the same node ids (nor the id map to be 1:1);
+    a missing `nodes` entry raised `KeyError` inside `query()`. (#133)
+  - **Haystack**: `load_from_disk` accepted a side-car with duplicate
+    document ids, which collapsed the rebuilt id map and left a shadow
+    document that was searchable but unreachable by id.
 
 ### Docs
 

--- a/turbovec-python/python/turbovec/_persist.py
+++ b/turbovec-python/python/turbovec/_persist.py
@@ -12,6 +12,13 @@ time. ``IdMapIndex`` exposes only ``__len__`` and ``contains``; that's
 sufficient: if the side-car's handle set and the index have equal size and
 every side-car handle is present in the index, the two are a bijection (no
 index handle can be missing from the side-car).
+
+Some side-cars additionally hold *two* structures keyed by the same string
+ids (e.g. an id -> handle map plus an id -> payload map). Those can desync
+independently of the index — a hand-edited or partially-written side-car
+where one map lost an entry still passes the handle check and would raise
+an opaque ``KeyError`` mid-query. ``check_sidecar_keysets`` turns that into
+the same clean ``ValueError`` at load time.
 """
 from __future__ import annotations
 
@@ -52,4 +59,45 @@ def check_persisted_handles(index, handles: Iterable[int], *, what: str = "entry
             )
 
 
-__all__ = ["check_persisted_handles"]
+def check_sidecar_keysets(
+    mapping_keys: Iterable,
+    sidecar_keys: Iterable,
+    *,
+    what: str = "entry",
+    mapping_name: str = "id map",
+    sidecar_name: str = "payload map",
+) -> None:
+    """Validate that two side-car structures keyed by the same ids agree.
+
+    Args:
+        mapping_keys: ids resolvable through the id -> handle map.
+        sidecar_keys: ids present in the id -> payload map.
+        what: noun for error messages (e.g. "document", "node").
+        mapping_name: side-car field name of the id -> handle map.
+        sidecar_name: side-car field name of the id -> payload map.
+
+    Raises:
+        ValueError: if either map holds an id the other lacks.
+    """
+    mapping_set = set(mapping_keys)
+    sidecar_set = set(sidecar_keys)
+    if mapping_set == sidecar_set:
+        return
+    missing = mapping_set - sidecar_set
+    if missing:
+        sample = ", ".join(repr(k) for k in sorted(missing)[:3])
+        raise ValueError(
+            f"persisted store is corrupt: {len(missing)} {what} id(s) present "
+            f"in `{mapping_name}` but missing from `{sidecar_name}` "
+            f"(e.g. {sample}). The JSON side-car's maps are out of sync."
+        )
+    extraneous = sidecar_set - mapping_set
+    sample = ", ".join(repr(k) for k in sorted(extraneous)[:3])
+    raise ValueError(
+        f"persisted store is corrupt: {len(extraneous)} {what} id(s) present "
+        f"in `{sidecar_name}` but missing from `{mapping_name}` "
+        f"(e.g. {sample}). The JSON side-car's maps are out of sync."
+    )
+
+
+__all__ = ["check_persisted_handles", "check_sidecar_keysets"]

--- a/turbovec-python/python/turbovec/_persist.py
+++ b/turbovec-python/python/turbovec/_persist.py
@@ -85,14 +85,18 @@ def check_sidecar_keysets(
         return
     missing = mapping_set - sidecar_set
     if missing:
-        sample = ", ".join(repr(k) for k in sorted(missing)[:3])
+        # key=repr: a hand-corrupted side-car can hold mixed-type ids
+        # (JSON arrays survive parsing with e.g. an int among strings),
+        # which plain sorted() would turn into a TypeError instead of
+        # the promised ValueError.
+        sample = ", ".join(repr(k) for k in sorted(missing, key=repr)[:3])
         raise ValueError(
             f"persisted store is corrupt: {len(missing)} {what} id(s) present "
             f"in `{mapping_name}` but missing from `{sidecar_name}` "
             f"(e.g. {sample}). The JSON side-car's maps are out of sync."
         )
     extraneous = sidecar_set - mapping_set
-    sample = ", ".join(repr(k) for k in sorted(extraneous)[:3])
+    sample = ", ".join(repr(k) for k in sorted(extraneous, key=repr)[:3])
     raise ValueError(
         f"persisted store is corrupt: {len(extraneous)} {what} id(s) present "
         f"in `{sidecar_name}` but missing from `{mapping_name}` "

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Union
 
 import numpy as np
 
+from ._persist import check_persisted_handles
 from ._turbovec import IdMapIndex
 
 try:
@@ -839,6 +840,12 @@ class TurboQuantVectorDb(VectorDb):
             name = data.get("name")
             if name:
                 self._name_to_ids.setdefault(name, set()).add(data["id"])
+
+        # Reject a side-car whose handle set desynced from the .tvim index
+        # (partial copy, stale backup, hand edit) with a clean ValueError
+        # here rather than misbehaving later — matching the other
+        # integrations' load paths (issue #115).
+        check_persisted_handles(self._index, self._u64_to_doc.keys(), what="document")
 
 
 __all__ = ["TurboQuantVectorDb"]

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -675,6 +675,14 @@ class TurboQuantDocumentStore:
         store._str_to_u64 = {
             data["id"]: handle for handle, data in store._u64_to_doc.items()
         }
+        # Two handles sharing a document id would silently collapse in the
+        # rebuild above, leaving a shadow document that is searchable but
+        # unreachable (and undeletable) by id. The write path enforces
+        # unique ids, so a duplicate can only mean a corrupt side-car.
+        if len(store._str_to_u64) != len(store._u64_to_doc):
+            raise ValueError(
+                "persisted store is corrupt: duplicate document ids in the side-car"
+            )
         check_persisted_handles(store._index, store._u64_to_doc.keys(), what="document")
         return store
 

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Iterable, Sequence
 import numpy as np
 
 from ._dedup import DuplicatePolicy, resolve_duplicates
-from ._persist import check_persisted_handles
+from ._persist import check_persisted_handles, check_sidecar_keysets
 from ._turbovec import IdMapIndex
 
 try:
@@ -590,6 +590,17 @@ class TurboQuantVectorStore(VectorStore):
         # ints in the payload, just need to confirm.
         str_to_u64 = {sid: int(h) for sid, h in state["str_to_u64"].items()}
         check_persisted_handles(index, str_to_u64.values(), what="document")
+        # The side-car holds two maps keyed by document id (`docs` and
+        # `str_to_u64`); they can desync independently of the index. A
+        # `docs` entry missing for a mapped id would otherwise surface as
+        # a KeyError deep inside a later query (issue #125).
+        check_sidecar_keysets(
+            str_to_u64.keys(),
+            docs.keys(),
+            what="document",
+            mapping_name="str_to_u64",
+            sidecar_name="docs",
+        )
         return cls(
             embedding=embedding,
             index=index,

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -13,7 +13,7 @@ from typing import Any, List, Optional, Sequence
 import numpy as np
 
 from ._dedup import DuplicatePolicy, resolve_duplicates
-from ._persist import check_persisted_handles
+from ._persist import check_persisted_handles, check_sidecar_keysets
 from ._turbovec import IdMapIndex
 
 try:
@@ -663,6 +663,24 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         store._node_id_to_u64 = {nid: int(h) for nid, h in state["node_id_to_u64"]}
         store._u64_to_node_id = {h: nid for nid, h in store._node_id_to_u64.items()}
         store._next_u64 = int(state["next_u64"])
+        # Two node ids sharing a handle would silently collapse in the
+        # inverse map built above; require the id map to be 1:1 before
+        # trusting either direction.
+        if len(store._u64_to_node_id) != len(store._node_id_to_u64):
+            raise ValueError(
+                "persisted store is corrupt: duplicate node handles in the side-car"
+            )
+        # The side-car holds two structures keyed by node id (`nodes` and
+        # `node_id_to_u64`); they can desync independently of the index. A
+        # `nodes` entry missing for a mapped id would otherwise surface as
+        # a KeyError deep inside a later query (issue #133).
+        check_sidecar_keysets(
+            store._node_id_to_u64.keys(),
+            store._nodes.keys(),
+            what="node",
+            mapping_name="node_id_to_u64",
+            sidecar_name="nodes",
+        )
         check_persisted_handles(index, store._u64_to_node_id.keys(), what="node")
         return store
 

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -857,6 +857,49 @@ def test_load_rejects_dimension_mismatch(tmp_path):
         TurboQuantVectorDb(embedder=StubEmbedder(dim=128), path=str(tmp_path)).create()
 
 
+def test_load_rejects_side_car_desynced_from_index(tmp_path):
+    # A side-car that lost a handle entry while index.tvim kept the vector
+    # must fail cleanly at load (issue #115), matching the other
+    # integrations — not load clean and silently drop the orphaned vector
+    # from search results.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a"), _doc("b"), _doc("c")])
+    db.save(str(tmp_path))
+
+    # Clean reload works.
+    TurboQuantVectorDb(embedder=StubEmbedder(), path=str(tmp_path)).create()
+
+    with open(tmp_path / "docstore.json") as f:
+        state = json.load(f)
+    state["u64_to_doc"] = state["u64_to_doc"][1:]  # drop one handle->doc
+    with open(tmp_path / "docstore.json", "w") as f:
+        json.dump(state, f)
+
+    with pytest.raises(ValueError, match="out of sync"):
+        TurboQuantVectorDb(embedder=StubEmbedder(), path=str(tmp_path)).create()
+
+
+def test_load_rejects_side_car_with_extra_handle(tmp_path):
+    # Reverse desync direction: the side-car holds a handle the index
+    # doesn't contain. Must also fail cleanly at load (issue #115).
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a"), _doc("b")])
+    db.save(str(tmp_path))
+
+    with open(tmp_path / "docstore.json") as f:
+        state = json.load(f)
+    ghost = dict(state["u64_to_doc"][0][1])
+    ghost["id"] = "ghost"
+    state["u64_to_doc"].append([999, ghost])
+    with open(tmp_path / "docstore.json", "w") as f:
+        json.dump(state, f)
+
+    with pytest.raises(ValueError, match="out of sync"):
+        TurboQuantVectorDb(embedder=StubEmbedder(), path=str(tmp_path)).create()
+
+
 # ---- Protocol coverage ----------------------------------------------------
 
 

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -1227,3 +1227,28 @@ def test_load_rejects_side_car_desynced_from_index(tmp_path):
 
     with pytest.raises(ValueError):
         TurboQuantDocumentStore.load_from_disk(tmp_path)
+
+
+def test_load_rejects_duplicate_document_ids_in_side_car(tmp_path):
+    # Two handles sharing a document id collapse in the rebuilt
+    # str_to_u64 map, leaving a shadow document that is searchable but
+    # unreachable (and undeletable) by id, and a count_documents() that
+    # disagrees with filter_documents(). The write path enforces unique
+    # ids, so a duplicate can only mean a corrupt side-car — reject it
+    # cleanly at load.
+    import json
+
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(2))
+    store.save_to_disk(tmp_path)
+
+    TurboQuantDocumentStore.load_from_disk(tmp_path)  # clean reload works
+
+    with open(tmp_path / "docstore.json") as f:
+        state = json.load(f)
+    state["u64_to_doc"][1][1]["id"] = state["u64_to_doc"][0][1]["id"]
+    with open(tmp_path / "docstore.json", "w") as f:
+        json.dump(state, f)
+
+    with pytest.raises(ValueError, match="duplicate document ids"):
+        TurboQuantDocumentStore.load_from_disk(tmp_path)

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -396,6 +396,54 @@ def test_load_rejects_unknown_schema_version(tmp_path):
         TurboQuantVectorStore.load(tmp_path, emb)
 
 
+def test_load_rejects_docs_key_set_desynced_from_id_map(tmp_path):
+    # Issue #125: `docs` lost an entry while `str_to_u64` (and the index)
+    # kept it. The handle↔index check passes, so without a key-set check
+    # this loads clean and raises a bare KeyError mid-query instead of a
+    # clean ValueError at load.
+    import json
+
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["alpha", "beta"], emb, bit_width=4, ids=["1", "2"]
+    )
+    store.dump(tmp_path)
+
+    # Clean reload works.
+    TurboQuantVectorStore.load(tmp_path, emb)
+
+    with open(tmp_path / "docstore.json") as f:
+        state = json.load(f)
+    del state["docs"]["1"]  # leave str_to_u64 (and the index) intact
+    with open(tmp_path / "docstore.json", "w") as f:
+        json.dump(state, f)
+
+    with pytest.raises(ValueError, match="missing from `docs`"):
+        TurboQuantVectorStore.load(tmp_path, emb)
+
+
+def test_load_rejects_docs_entry_without_id_mapping(tmp_path):
+    # Reverse desync direction: a `docs` entry with no `str_to_u64`
+    # mapping. Such a document would be returned by get_by_ids but be
+    # invisible to search and delete — reject it at load instead.
+    import json
+
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["alpha", "beta"], emb, bit_width=4, ids=["1", "2"]
+    )
+    store.dump(tmp_path)
+
+    with open(tmp_path / "docstore.json") as f:
+        state = json.load(f)
+    state["docs"]["ghost"] = {"text": "g", "metadata": {}}
+    with open(tmp_path / "docstore.json", "w") as f:
+        json.dump(state, f)
+
+    with pytest.raises(ValueError, match="missing from `str_to_u64`"):
+        TurboQuantVectorStore.load(tmp_path, emb)
+
+
 def test_delete_removes_documents_returns_none():
     # Match InMemoryVectorStore convention: delete returns None.
     emb = StubEmbeddings(dim=64)

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -1356,3 +1356,73 @@ def test_from_persist_path_rejects_side_car_desynced_from_index(tmp_path):
 
     with pytest.raises(ValueError):
         TurboQuantVectorStore.from_persist_path(base)
+
+
+def test_from_persist_path_rejects_nodes_desynced_from_id_map(tmp_path):
+    # Issue #133: the `nodes` object lost an entry while `node_id_to_u64`
+    # (and the index) kept it. The handle↔index check passes, so without a
+    # key-set check this loads clean and raises a bare KeyError inside the
+    # first query that hits the missing node.
+    import json
+
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([_make_node(t, seed=i) for i, t in enumerate(["a", "b", "c"])])
+    base = str(tmp_path / "store")
+    store.persist(base)
+
+    TurboQuantVectorStore.from_persist_path(base)  # clean reload works
+
+    side_car = tmp_path / "store.nodes.json"
+    with open(side_car) as f:
+        state = json.load(f)
+    # Drop one node payload, leaving node_id_to_u64 and the index intact.
+    del state["nodes"][next(iter(state["nodes"]))]
+    with open(side_car, "w") as f:
+        json.dump(state, f)
+
+    with pytest.raises(ValueError, match="missing from `nodes`"):
+        TurboQuantVectorStore.from_persist_path(base)
+
+
+def test_from_persist_path_rejects_node_entry_without_id_mapping(tmp_path):
+    # Reverse desync direction: a `nodes` entry with no `node_id_to_u64`
+    # mapping. Such a node would surface from get_nodes but be invisible
+    # to query and delete — reject it at load instead.
+    import json
+
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([_make_node(t, seed=i) for i, t in enumerate(["a", "b"])])
+    base = str(tmp_path / "store")
+    store.persist(base)
+
+    side_car = tmp_path / "store.nodes.json"
+    with open(side_car) as f:
+        state = json.load(f)
+    state["nodes"]["ghost"] = next(iter(state["nodes"].values()))
+    with open(side_car, "w") as f:
+        json.dump(state, f)
+
+    with pytest.raises(ValueError, match="missing from `node_id_to_u64`"):
+        TurboQuantVectorStore.from_persist_path(base)
+
+
+def test_from_persist_path_rejects_duplicate_handles_in_id_map(tmp_path):
+    # Two node ids mapped to the same handle silently collapse in the
+    # inverse (u64 -> node_id) map; the id map must be 1:1 to trust
+    # either direction.
+    import json
+
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([_make_node(t, seed=i) for i, t in enumerate(["a", "b", "c"])])
+    base = str(tmp_path / "store")
+    store.persist(base)
+
+    side_car = tmp_path / "store.nodes.json"
+    with open(side_car) as f:
+        state = json.load(f)
+    state["node_id_to_u64"][1][1] = state["node_id_to_u64"][0][1]
+    with open(side_car, "w") as f:
+        json.dump(state, f)
+
+    with pytest.raises(ValueError, match="duplicate node handles"):
+        TurboQuantVectorStore.from_persist_path(base)

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -1426,3 +1426,35 @@ def test_from_persist_path_rejects_duplicate_handles_in_id_map(tmp_path):
 
     with pytest.raises(ValueError, match="duplicate node handles"):
         TurboQuantVectorStore.from_persist_path(base)
+
+
+def test_from_persist_path_rejects_collapsed_id_map_with_truncated_index(tmp_path):
+    # Consistent-truncation variant of the duplicate-handle corruption:
+    # the id map collapsed (two node ids sharing one handle) AND the
+    # index lost the orphaned vector, so the surviving handle set still
+    # matches the index and the handle-count check alone passes. Without
+    # the explicit 1:1 check this loaded clean and one node was silently
+    # aliased to another node's vector.
+    import json
+
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([_make_node(t, seed=i) for i, t in enumerate(["a", "b", "c"])])
+    base = str(tmp_path / "store")
+    store.persist(base)
+
+    side_car = tmp_path / "store.nodes.json"
+    with open(side_car) as f:
+        state = json.load(f)
+    # Collapse: the second node id now shares the first node's handle...
+    orphaned = state["node_id_to_u64"][1][1]
+    state["node_id_to_u64"][1][1] = state["node_id_to_u64"][0][1]
+    with open(side_car, "w") as f:
+        json.dump(state, f)
+    # ...and truncate the index to match by dropping the orphaned handle.
+    index_path = str(tmp_path / "store.tvim")
+    index = IdMapIndex.load(index_path)
+    index.remove(orphaned)
+    index.write(index_path)
+
+    with pytest.raises(ValueError, match="duplicate node handles"):
+        TurboQuantVectorStore.from_persist_path(base)

--- a/turbovec-python/tests/test_persist.py
+++ b/turbovec-python/tests/test_persist.py
@@ -1,0 +1,31 @@
+"""Tests for the shared persistence consistency helpers."""
+from __future__ import annotations
+
+import pytest
+
+from turbovec._persist import check_sidecar_keysets
+
+
+def test_check_sidecar_keysets_mixed_type_ids_raise_value_error():
+    # A hand-corrupted side-car can hold mixed-type ids — JSON arrays
+    # (e.g. llama_index's node_id_to_u64 pairs) survive parsing with an
+    # int among the strings. Building the error's id sample must not
+    # itself blow up sorting unorderable types: the promise is a
+    # ValueError, never a TypeError.
+    with pytest.raises(ValueError, match="out of sync"):
+        check_sidecar_keysets(
+            ["a", 1],
+            [],
+            what="node",
+            mapping_name="node_id_to_u64",
+            sidecar_name="nodes",
+        )
+    # Same for the extraneous direction.
+    with pytest.raises(ValueError, match="out of sync"):
+        check_sidecar_keysets(
+            [],
+            ["a", 1],
+            what="node",
+            mapping_name="node_id_to_u64",
+            sidecar_name="nodes",
+        )


### PR DESCRIPTION
Closes #115 / Closes #125 / Closes #133

## Root cause (one family)

Each integration persists a binary `index.tvim` plus a JSON side-car. `_persist.check_persisted_handles` validates the **handle ↔ index** bijection at load, but nothing validated the side-car's **own paired keysets** against each other. A side-car where one map lost (or gained) an entry — partial copy, stale backup, hand edit — passed the handle check, loaded clean, and failed later: an opaque `KeyError` deep inside a query, or silently-wrong results. That late/unclear failure is exactly what `_persist.py` exists to prevent.

The architecture-level fix is a second shared validated-boundary helper in `_persist.py`, `check_sidecar_keysets(mapping_keys, sidecar_keys, what=..., mapping_name=..., sidecar_name=...)`, raising the same style of load-time `ValueError` (store kind, offending direction — missing vs extraneous — counts, and a small id sample), called from each affected load path. `check_persisted_handles` and its existing call sites are untouched beyond the new calls.

## Per-issue

### #115 — agno (reported by @Aravindargutus)

`TurboQuantVectorDb._load_from` rebuilt `_u64_to_doc` / `_str_to_u64` / `_content_hashes` / `_name_to_ids` but never ran `check_persisted_handles` at all — the only one of the four integrations that skipped it.

**Repro on `main` @ 1e7200c:** save 3 docs, drop one `u64_to_doc` entry from `docstore.json` → `create()` loads clean (`index len: 3, side-car docs: 2`), and `search()` returns 2 results from a 3-vector index — the orphaned vector is **silently dropped** (agno's `_build_results` uses `.get`, so here the family symptom is silent data loss rather than a `KeyError`). The reverse edit (extra side-car handle `999`) also loaded clean.

**Fix:** `check_persisted_handles(self._index, self._u64_to_doc.keys(), what="document")` at the end of `_load_from`, matching the other integrations. Both desync directions now raise `ValueError: persisted store is inconsistent with its index: … out of sync` at load. All of agno's reverse maps are derived from the single `u64_to_doc` structure, so no additional keyset pair exists there.

### #125 — LangChain

`load()` ran the handle check on `str_to_u64.values()`, but the side-car holds **two** maps keyed by document id (`docs` and `str_to_u64`) that can desync independently of the index.

**Repro on `main` @ 1e7200c:** dump a 2-doc store, `del state["docs"]["1"]` (leave `str_to_u64` intact) → `load()` succeeds, `similarity_search("alpha", k=2)` → `KeyError: '1'` (surfacing from `langchain.py:336`), exactly as filed.

**Fix:** `load()` now requires `docs.keys() == str_to_u64.keys()` via the shared helper. Observed post-fix: `ValueError: persisted store is corrupt: 1 document id(s) present in `str_to_u64` but missing from `docs` (e.g. '1'). The JSON side-car's maps are out of sync.` The reverse direction (a `docs` entry with no mapping — unsearchable/undeletable ghost) is also rejected. (`_u64_to_str` is derived in `__init__`, and duplicate handle values in `str_to_u64` were already caught by the existing handle check — probed, clean.)

### #133 — LlamaIndex

`from_persist_path` validated only the `_u64_to_node_id` ↔ index bijection, not `node_id_to_u64.keys() == nodes.keys()`, nor that the id map is 1:1 (duplicate handle values silently collapse in the inverse-map build one line above the check).

**Repro on `main` @ 1e7200c:** persist 3 nodes, delete one entry from `nodes.json`'s `"nodes"` object keeping `node_id_to_u64` intact → `loaded OK; nodes: 2  id_map: 3`, then `query()` → `KeyError: 'a'` at `llama_index.py:519`, exactly as filed.

**Fix:** after building the maps, `from_persist_path` asserts the 1:1 property (`duplicate node handles in the side-car`) and the keyset equality via the shared helper, both directions.

## Un-filed sibling found and fixed — Haystack `load_from_disk`

Haystack's side-car is a single source-of-truth map (`u64_to_doc`, reverse maps derived), so no paired-keyset gap exists — the existing handle check covers missing/extra handle entries (probed, clean). But the `_str_to_u64` **rebuild collapses on duplicate document ids**: a hand-edited side-car where two handles share an id loaded clean and left a shadow document unreachable/undeletable by id — probed on `main`: after `delete_documents(["x"])`, `count_documents()` returned 0 while a shadow copy of `x` was still stored and visible via `filter_documents()` (it also stays searchable via `embedding_retrieval` whenever at least one counted document remains; the fully-collapsed 2-doc probe hits the `count_documents() == 0` early-return there). The write path enforces unique ids, so a duplicate can only mean a corrupt side-car; `load_from_disk` now rejects it with the same `ValueError` style (`duplicate document ids in the side-car`).

## Tests

Ten new regression tests, each verified to **fail on the unfixed sources** and pass with the fix; the desync tests corrupt the side-car exactly as the issues describe and assert a `ValueError` at load (message-substring matched), with the clean-reload happy path exercised first:

- `test_agno.py::test_load_rejects_side_car_desynced_from_index`, `::test_load_rejects_side_car_with_extra_handle`
- `test_langchain.py::test_load_rejects_docs_key_set_desynced_from_id_map`, `::test_load_rejects_docs_entry_without_id_mapping`
- `test_llama_index.py::test_from_persist_path_rejects_nodes_desynced_from_id_map`, `::test_from_persist_path_rejects_node_entry_without_id_mapping`, `::test_from_persist_path_rejects_duplicate_handles_in_id_map`, `::test_from_persist_path_rejects_collapsed_id_map_with_truncated_index` (the consistent-truncation variant — id map collapsed **and** index truncated to match passes the handle-count check alone; on main it loaded clean with one node silently aliased to another's vector)
- `test_haystack.py::test_load_rejects_duplicate_document_ids_in_side_car`
- `test_persist.py::test_check_sidecar_keysets_mixed_type_ids_raise_value_error` (direct helper test: mixed-type ids in a corrupted side-car must produce the promised `ValueError`, not a `TypeError` from sorting the id sample — hence `sorted(..., key=repr)`)

Full suite: **388 passed, 0 failed** (`main` baseline re-measured at 378; 378 + 10 new).

## Merge checks vs open PRs

`git merge-tree` against the three open PRs touching these files (all hunks here are load-path only; those PRs touch add/delete/filter regions):

| Branch | Result |
|---|---|
| `origin/fix/langchain-add-boundary` (#171) | CHANGELOG conflict only (trivial); `langchain.py` + `test_langchain.py` auto-merge clean |
| `origin/fix/llamaindex-filters-and-ordering` (#172) | CHANGELOG conflict only (trivial); `llama_index.py` + `test_llama_index.py` auto-merge clean |
| `origin/fix/haystack-agno-correctness` (#174) | CHANGELOG conflict only (trivial); `agno.py`, `haystack.py`, and both test files auto-merge clean |

(The langchain test additions were deliberately placed in the persistence-test section mid-file after an initial end-of-file placement conflicted with #171's appended tests.)

## Docs

`docs/integrations/*.md` load-validation statements checked: `agno.md:132` already described load-time id-map validation (now actually true with #115 fixed); `langchain.md:138`, `haystack.md:143`, and `llama_index.md:183` describe the out-of-sync `ValueError` behavior in terms this change extends but doesn't contradict. No doc edits needed. CHANGELOG updated under Unreleased → Python package → Fixed.

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
