### PR TITLE
fix: atomic persistence for integration saves and benchmark downloads (#159, #140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,23 @@ appears under each surface it touches.
   - **Haystack**: `load_from_disk` accepted a side-car with duplicate
     document ids, which collapsed the rebuilt id map and left a shadow
     document that was searchable but unreachable by id.
+- **Integration saves no longer destroy a previously-good store on
+  failure.** All four framework integrations (LangChain `dump`, LlamaIndex
+  `persist`, Haystack `save_to_disk`, agno `save`) wrote the index and then
+  truncate-and-wrote the JSON side-car in place, so a save that failed
+  mid-serialization — e.g. a document whose metadata holds a `set` or
+  ndarray — left the destination with a new index and a truncated side-car,
+  unloadable and unrecoverable. Saves now serialize the side-car fully in
+  memory first (bad metadata raises before any file is touched) and write
+  both files via fsynced sibling temp files moved into place with
+  `os.replace`, removing the temp files on failure. (#159)
+
+### Benchmarks
+
+- `benchmarks/download_data.py` downloads to a `.tmp` sibling and renames
+  into place on success, so an interrupted download no longer leaves a
+  partial file at the final path that the existence guard then treats as
+  complete. (#140)
 
 ### Docs
 

--- a/benchmarks/download_data.py
+++ b/benchmarks/download_data.py
@@ -23,7 +23,12 @@ def download_glove():
         return
     os.makedirs(DATA_DIR, exist_ok=True)
     print(f"Downloading {GLOVE_URL}...")
-    subprocess.run(["curl", "-L", "-o", GLOVE_PATH, GLOVE_URL], check=True)
+    # Download to a temp path, then rename into place on success — an
+    # interrupted run leaves only a .tmp the existence guard ignores,
+    # never a partial file at the final path.
+    tmp = GLOVE_PATH + ".tmp"
+    subprocess.run(["curl", "-L", "-o", tmp, GLOVE_URL], check=True)
+    os.replace(tmp, GLOVE_PATH)
     print(f"Saved: {GLOVE_PATH} ({os.path.getsize(GLOVE_PATH) / 1024 / 1024:.0f} MB)")
 
 
@@ -41,7 +46,13 @@ def download_openai(dim):
     ds = load_dataset(name, split="train")
     ds.set_format("numpy")
     vecs = ds[col].astype(np.float32)
-    np.save(path, vecs)
+    # Save to a temp path, then rename into place on success (same
+    # rationale as download_glove). Pass an open file object so np.save
+    # can't append a `.npy` suffix to the temp name.
+    tmp = path + ".tmp"
+    with open(tmp, "wb") as f:
+        np.save(f, vecs)
+    os.replace(tmp, path)
     print(f"Saved: {path} ({os.path.getsize(path) / 1024 / 1024:.0f} MB)")
 
 

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -131,6 +131,8 @@ Writes two files under the given folder path:
 
 Document metadata must be JSON-serializable — same constraint Agno's `LanceDb` imposes on its payload column. The side-car carries a `schema_version` field; loaders refuse to deserialize unknown versions, and validate that the side-car's id maps are consistent with the loaded `index.tvim` (a mismatched or out-of-sync pair raises at load rather than failing later at query time).
 
+`save` is atomic with respect to the destination: both files are written to sibling temp files and moved into place, so a failed save (e.g. non-JSON-serializable metadata) leaves a store previously saved at the same path intact.
+
 ## Async
 
 The lifecycle, write, and read methods have async counterparts: `async_create`, `async_drop`, `async_exists`, `async_name_exists`, `async_get_count`, `async_insert`, `async_upsert`, `async_search`. The remaining methods (the `delete_by_*` family, `update_metadata`, `save`, `id_exists`, `content_hash_exists`, `optimize`) are sync-only. When the embedder exposes `async_get_embedding` / `async_get_embeddings_batch_and_usage`, the async paths use it for genuine async embedding generation.

--- a/docs/integrations/haystack.md
+++ b/docs/integrations/haystack.md
@@ -142,6 +142,8 @@ Writes two files under the given folder path:
 
 Document metadata must be JSON-serializable — the same constraint `InMemoryDocumentStore.save_to_disk` imposes. If the `docstore.json` side-car is out of sync with its `index.tvim` (a partial copy, a stale backup, tampering), `load_from_disk` raises a `ValueError` immediately rather than failing later with a `KeyError` at query time.
 
+`save_to_disk` is atomic with respect to the destination: both files are written to sibling temp files and moved into place, so a failed save (e.g. non-JSON-serializable metadata) leaves a store previously saved at the same path intact.
+
 ## Using in a Haystack Pipeline
 
 `TurboQuantDocumentStore` implements `to_dict` / `from_dict` so it can be serialized as part of a Haystack `Pipeline`. `to_dict` captures the component *config* (`dim`, `bit_width`, `embedding_similarity_function`, `return_embedding`); persisting the stored documents is the job of `save_to_disk` / `load_from_disk`.

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -137,6 +137,8 @@ Writes two files under the given folder path:
 
 Document metadata must be JSON-serializable — the same constraint `InMemoryVectorStore.dump` imposes. If the `docstore.json` side-car is out of sync with its `index.tvim` (a partial copy, a stale backup, tampering), `load` raises a `ValueError` immediately rather than failing later with a `KeyError` at query time.
 
+`dump` is atomic with respect to the destination: both files are written to sibling temp files and moved into place, so a failed dump (e.g. non-JSON-serializable metadata) leaves a store previously saved at the same path intact.
+
 ## Known limitations
 
 - **Max-marginal-relevance search is not supported.** `max_marginal_relevance_search` and its variants raise `NotImplementedError` with an explanation. MMR requires the full-precision embedding of each candidate to compute pairwise diversity; turbovec discards full-precision vectors after quantization. If you need MMR, keep a parallel store with the raw embeddings and run MMR over that.

--- a/docs/integrations/llama_index.md
+++ b/docs/integrations/llama_index.md
@@ -182,6 +182,8 @@ vector_store = TurboQuantVectorStore.from_persist_path("./store/vectors.json")
 
 `persist_path` is treated as a path *stem* — the binary index and JSON side-car are written next to each other as `{stem}.tvim` and `{stem}.nodes.json`. The extension on `persist_path` (e.g. `.json`, as LlamaIndex's StorageContext default uses) is replaced. Node metadata must be JSON-serializable. If the `{stem}.nodes.json` side-car is out of sync with its `{stem}.tvim` index (a partial copy, a stale backup, tampering), `from_persist_path` raises a `ValueError` immediately rather than failing later with a `KeyError` at query time.
 
+`persist` is atomic with respect to the destination: both files are written to sibling temp files and moved into place, so a failed persist (e.g. non-JSON-serializable metadata) leaves a store previously persisted at the same stem intact.
+
 ### Via `StorageContext`
 
 The store works with `StorageContext.from_defaults(persist_dir=...)` the same way `SimpleVectorStore` does:

--- a/turbovec-python/python/turbovec/_persist.py
+++ b/turbovec-python/python/turbovec/_persist.py
@@ -28,8 +28,8 @@ from typing import Any, Iterable
 
 
 def _tmp_path(path: str) -> str:
-    """Sibling temp-file name in the same directory as ``path`` (same
-    naming scheme as the Rust core's atomic index write)."""
+    """Pid-suffixed sibling temp-file name in the same directory as
+    ``path``."""
     return f"{path}.tmp.{os.getpid()}"
 
 
@@ -50,9 +50,11 @@ def atomic_save(index, index_path, payload: Any, sidecar_path) -> None:
 
     The one remaining non-atomic window is between the two ``replace``
     calls: a hard crash exactly there leaves a new index beside the old
-    side-car. ``check_persisted_handles`` detects that mismatch at load
-    time and raises a clean ``ValueError`` instead of returning silently
-    corrupted data.
+    side-car. The LangChain, LlamaIndex, and Haystack load paths detect
+    that mismatch via ``check_persisted_handles`` and raise a clean
+    ``ValueError`` instead of returning silently corrupted data; the agno
+    load path gains the same check with the side-car keyset validation
+    work (#178).
 
     Args:
         index: the ``IdMapIndex`` to persist (uses ``index.write``).

--- a/turbovec-python/python/turbovec/_persist.py
+++ b/turbovec-python/python/turbovec/_persist.py
@@ -22,7 +22,68 @@ the same clean ``ValueError`` at load time.
 """
 from __future__ import annotations
 
-from typing import Iterable
+import json
+import os
+from typing import Any, Iterable
+
+
+def _tmp_path(path: str) -> str:
+    """Sibling temp-file name in the same directory as ``path`` (same
+    naming scheme as the Rust core's atomic index write)."""
+    return f"{path}.tmp.{os.getpid()}"
+
+
+def atomic_save(index, index_path, payload: Any, sidecar_path) -> None:
+    """Atomically persist an index + JSON side-car pair — the shared
+    write path for all four integrations' save methods.
+
+    The failure-ordering guarantees:
+
+    1. ``payload`` is JSON-serialized fully in memory *first*, so a
+       non-serializable value (a set or ndarray in document metadata)
+       raises ``TypeError`` before any file is touched.
+    2. Both artifacts are written to sibling temp files in the
+       destination directory, flushed and fsynced, then moved into place
+       with ``os.replace`` (atomic on POSIX). A failure or crash before
+       the first replace leaves a previous store at these paths intact.
+    3. On failure the temp files are removed (best effort).
+
+    The one remaining non-atomic window is between the two ``replace``
+    calls: a hard crash exactly there leaves a new index beside the old
+    side-car. ``check_persisted_handles`` detects that mismatch at load
+    time and raises a clean ``ValueError`` instead of returning silently
+    corrupted data.
+
+    Args:
+        index: the ``IdMapIndex`` to persist (uses ``index.write``).
+        index_path: destination for the binary ``.tvim`` file.
+        payload: JSON-serializable side-car payload.
+        sidecar_path: destination for the JSON side-car.
+    """
+    payload_str = json.dumps(payload)  # fail before touching any file
+
+    index_path = os.fspath(index_path)
+    sidecar_path = os.fspath(sidecar_path)
+    index_tmp = _tmp_path(index_path)
+    sidecar_tmp = _tmp_path(sidecar_path)
+    try:
+        # The Rust binding owns the index file handle, so fsync via a
+        # reopened read descriptor (fsync flushes the inode, not the fd).
+        index.write(index_tmp)
+        with open(index_tmp, "rb") as f:
+            os.fsync(f.fileno())
+        with open(sidecar_tmp, "w") as f:
+            f.write(payload_str)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(index_tmp, index_path)
+        os.replace(sidecar_tmp, sidecar_path)
+    finally:
+        for tmp in (index_tmp, sidecar_tmp):
+            try:
+                os.unlink(tmp)
+            except FileNotFoundError:
+                pass
 
 
 def check_persisted_handles(index, handles: Iterable[int], *, what: str = "entry") -> None:

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from ._persist import check_persisted_handles
 from ._turbovec import IdMapIndex
+from ._persist import atomic_save  # isort:skip
 
 try:
     from agno.knowledge.document import Document
@@ -786,7 +787,6 @@ class TurboQuantVectorDb(VectorDb):
             )
         folder = Path(path)
         folder.mkdir(parents=True, exist_ok=True)
-        self._index.write(str(folder / _INDEX_FILENAME))
         payload = {
             "schema_version": _DOCSTORE_SCHEMA_VERSION,
             # Round-trip int handles via list-of-pairs (JSON keys must be
@@ -796,8 +796,14 @@ class TurboQuantVectorDb(VectorDb):
             "bit_width": self.bit_width,
             "dimensions": self.dimensions,
         }
-        with open(folder / _STORE_FILENAME, "w") as f:
-            json.dump(payload, f)
+        # Atomic: serializes in memory first, then temp-file + replace,
+        # so a failed save can't destroy a previous store at this path.
+        atomic_save(
+            self._index,
+            folder / _INDEX_FILENAME,
+            payload,
+            folder / _STORE_FILENAME,
+        )
 
     def _load_from(self, folder: Path) -> None:
         side_car = folder / _STORE_FILENAME

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
 
 import numpy as np
 
-from ._persist import check_persisted_handles
+from ._persist import atomic_save, check_persisted_handles
 from ._turbovec import IdMapIndex
 
 try:
@@ -618,7 +618,6 @@ class TurboQuantDocumentStore:
         """
         folder = Path(folder_path)
         folder.mkdir(parents=True, exist_ok=True)
-        self._index.write(str(folder / "index.tvim"))
         # Keys in `_u64_to_doc` are ints (u64 handles); JSON object keys
         # must be strings. Serialize as a list of [handle, data] pairs
         # so we don't lose type fidelity on the round-trip.
@@ -632,8 +631,14 @@ class TurboQuantDocumentStore:
             "embedding_similarity_function": self.embedding_similarity_function,
             "return_embedding": self.return_embedding,
         }
-        with open(folder / "docstore.json", "w") as f:
-            json.dump(payload, f)
+        # Atomic: serializes in memory first, then temp-file + replace,
+        # so a failed save can't destroy a previous store at this path.
+        atomic_save(
+            self._index,
+            folder / "index.tvim",
+            payload,
+            folder / "docstore.json",
+        )
 
     @classmethod
     def load_from_disk(

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -18,6 +18,7 @@ import numpy as np
 from ._dedup import DuplicatePolicy, resolve_duplicates
 from ._persist import check_persisted_handles, check_sidecar_keysets
 from ._turbovec import IdMapIndex
+from ._persist import atomic_save  # isort:skip
 
 try:
     from langchain_core.documents import Document
@@ -539,7 +540,6 @@ class TurboQuantVectorStore(VectorStore):
         """
         folder = Path(folder_path)
         folder.mkdir(parents=True, exist_ok=True)
-        self._index.write(str(folder / _INDEX_FILENAME))
         # `_docs` stores tuples `(text, metadata)` — JSON would drop the
         # tuple-ness on round-trip, so serialize each entry as an explicit
         # `{"text": ..., "metadata": ...}` dict.
@@ -556,8 +556,14 @@ class TurboQuantVectorStore(VectorStore):
             # the index was constructed eagerly or lazily.
             "bit_width": self._index.bit_width,
         }
-        with open(folder / _STORE_FILENAME, "w") as f:
-            json.dump(payload, f)
+        # Atomic: serializes in memory first, then temp-file + replace,
+        # so a failed dump can't destroy a previous store at this path.
+        atomic_save(
+            self._index,
+            folder / _INDEX_FILENAME,
+            payload,
+            folder / _STORE_FILENAME,
+        )
 
     @classmethod
     def load(

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -15,6 +15,7 @@ import numpy as np
 from ._dedup import DuplicatePolicy, resolve_duplicates
 from ._persist import check_persisted_handles, check_sidecar_keysets
 from ._turbovec import IdMapIndex
+from ._persist import atomic_save  # isort:skip
 
 try:
     from llama_index.core.bridge.pydantic import PrivateAttr
@@ -613,7 +614,6 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
             )
         base = _split_persist_base(persist_path)
         base.parent.mkdir(parents=True, exist_ok=True)
-        self._index.write(str(base.with_suffix(_INDEX_EXT)))
         payload = {
             "schema_version": _NODES_SCHEMA_VERSION,
             "nodes": self._nodes,
@@ -623,8 +623,14 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
             "node_id_to_u64": list(self._node_id_to_u64.items()),
             "next_u64": self._next_u64,
         }
-        with open(base.with_suffix(_STORE_EXT), "w") as f:
-            json.dump(payload, f)
+        # Atomic: serializes in memory first, then temp-file + replace,
+        # so a failed persist can't destroy a previous store at this path.
+        atomic_save(
+            self._index,
+            base.with_suffix(_INDEX_EXT),
+            payload,
+            base.with_suffix(_STORE_EXT),
+        )
 
     @classmethod
     def from_persist_path(

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -826,6 +826,29 @@ def test_save_and_load_via_path_param(tmp_path):
     assert len(results) == 3
 
 
+def test_failed_save_preserves_previous_store(tmp_path):
+    # Regression test for #159: a save that fails mid-serialization
+    # (non-JSON-serializable meta_data) must not destroy a previously
+    # persisted store at the same path, and must not leave temp files.
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a"), _doc("b")])
+    db.save(str(tmp_path))
+    before = {p.name: p.read_bytes() for p in tmp_path.iterdir()}
+
+    db.insert("h2", [_doc("bad", meta_data={"bad": {1, 2, 3}})])
+    with pytest.raises(TypeError):
+        db.save(str(tmp_path))
+
+    # Exact directory equality: both files byte-identical, no strays.
+    after = {p.name: p.read_bytes() for p in tmp_path.iterdir()}
+    assert after == before
+    assert not list(tmp_path.glob("*.tmp*"))
+    db2 = TurboQuantVectorDb(embedder=StubEmbedder(), path=str(tmp_path))
+    db2.create()  # loads from disk
+    assert len(db2._index) == 2
+
+
 def test_save_requires_path():
     db = TurboQuantVectorDb(embedder=StubEmbedder())
     db.create()

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -669,6 +669,36 @@ def test_save_and_load_roundtrip(tmp_path):
         assert results[0].id == doc.id
 
 
+def test_failed_save_preserves_previous_store(tmp_path):
+    # Regression test for #159: a save_to_disk that fails mid-serialization
+    # (non-JSON-serializable document meta) must not destroy a previously
+    # persisted store at the same path, and must not leave temp files.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents(make_docs(2))
+    store.save_to_disk(tmp_path)
+    before = {p.name: p.read_bytes() for p in tmp_path.iterdir()}
+
+    store.write_documents(
+        [
+            Document(
+                id="bad",
+                content="bad",
+                embedding=unit_vector(9),
+                meta={"bad": {1, 2, 3}},
+            )
+        ]
+    )
+    with pytest.raises(TypeError):
+        store.save_to_disk(tmp_path)
+
+    # Exact directory equality: both files byte-identical, no strays.
+    after = {p.name: p.read_bytes() for p in tmp_path.iterdir()}
+    assert after == before
+    assert not list(tmp_path.glob("*.tmp*"))
+    restored = TurboQuantDocumentStore.load_from_disk(tmp_path)
+    assert restored.count_documents() == 2
+
+
 def test_save_writes_json_sidecar(tmp_path):
     # Side-car is plain JSON now, not pickle. A reviewer auditing a
     # turbovec-saved store should be able to read it with a text editor.

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -366,6 +366,27 @@ def test_dump_and_load_roundtrip(tmp_path):
     assert {doc.page_content for doc in results} == {"one", "two", "three"}
 
 
+def test_failed_dump_preserves_previous_store(tmp_path):
+    # Regression test for #159: a dump that fails mid-serialization
+    # (non-JSON-serializable metadata) must not destroy a previously
+    # persisted store at the same path, and must not leave temp files.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(["one", "two"], emb, bit_width=4)
+    store.dump(tmp_path)
+    before = {p.name: p.read_bytes() for p in tmp_path.iterdir()}
+
+    store.add_texts(["bad"], metadatas=[{"bad": {1, 2, 3}}])
+    with pytest.raises(TypeError):
+        store.dump(tmp_path)
+
+    # Exact directory equality: both files byte-identical, no strays.
+    after = {p.name: p.read_bytes() for p in tmp_path.iterdir()}
+    assert after == before
+    assert not list(tmp_path.glob("*.tmp*"))
+    loaded = TurboQuantVectorStore.load(tmp_path, emb)
+    assert len(loaded._docs) == 2
+
+
 def test_dump_writes_json_sidecar(tmp_path):
     # Side-car is plain JSON. A reviewer auditing a turbovec-saved store
     # should be able to read it with a text editor.

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -165,6 +165,28 @@ def test_persist_and_from_persist_path_roundtrip(tmp_path):
     assert {n.get_content() for n in result.nodes} == {"one", "two", "three"}
 
 
+def test_failed_persist_preserves_previous_store(tmp_path):
+    # Regression test for #159: a persist that fails mid-serialization
+    # (non-JSON-serializable node metadata) must not destroy a previously
+    # persisted store at the same path, and must not leave temp files.
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([_make_node("one", seed=1), _make_node("two", seed=2)])
+    persist_path = tmp_path / "store.json"
+    store.persist(str(persist_path))
+    before = {p.name: p.read_bytes() for p in tmp_path.iterdir()}
+
+    store.add([_make_node("bad", seed=3, metadata={"bad": {1, 2, 3}})])
+    with pytest.raises(TypeError):
+        store.persist(str(persist_path))
+
+    # Exact directory equality: both files byte-identical, no strays.
+    after = {p.name: p.read_bytes() for p in tmp_path.iterdir()}
+    assert after == before
+    assert not list(tmp_path.glob("*.tmp*"))
+    loaded = TurboQuantVectorStore.from_persist_path(str(persist_path))
+    assert len(loaded._node_id_to_u64) == 2
+
+
 def test_from_persist_dir_loads_default_namespace(tmp_path):
     # StorageContext-style: a directory containing a namespaced filename.
     store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)


### PR DESCRIPTION
## Root cause

**#159 — non-atomic integration saves destroy previously-good stores.** All four JSON-sidecar integrations saved in the same unsafe order: `index.write(final_path)` first, then `open(sidecar, "w")` (truncate) + `json.dump`. `json.dump` serializes incrementally, so a document whose metadata holds a non-JSON-serializable value (a `set`, an ndarray) raises `TypeError` *after* the index has already been overwritten and the sidecar truncated to a partial prefix. A previously-good store at that path is destroyed. This is the Python analogue of #118 (Rust-side fix in PR #173); the fix mirrors that PR's temp+fsync+rename philosophy.

**#140 — `benchmarks/download_data.py` silently reuses partial downloads.** `download_glove` curl'd straight to the final path and `download_openai` `np.save`'d straight to the final path, both guarded only by `os.path.exists`. An interrupted download left a partial file the guard then treated as complete forever.

## Repro evidence (observed on unfixed `origin/main`)

LangChain: build a 2-doc store, `dump(P)`, verify `load(P)` works. Add a doc with metadata `{"bad": {1, 2, 3}}`, `dump(P)` again:

```
good store dumped and reloaded: 2 docs
on disk before bad dump: index=618B sidecar=320B
bad dump raised TypeError: Object of type set is not JSON serializable
on disk after bad dump:  index=662B sidecar=267B      <- NEW 3-vector index, TRUNCATED sidecar
load after bad dump FAILED (JSONDecodeError): Expecting value: line 1 column 268 (char 267)
```

LlamaIndex (`persist`/`from_persist_path`): same pattern —

```
bad persist raised TypeError: Object of type set is not JSON serializable
load after bad persist FAILED (JSONDecodeError): Expecting value: line 1 column 1388 (char 1387)
```

#140: planting a 15-byte garbage file at `GLOVE_PATH` and calling `download_glove()` printed `Already downloaded: ...` and left the garbage in place — no integrity check, permanent silent reuse.

After the fix, the same repros show byte-identical files at the destination after the failed save, successful `load`, and no stray temp files; the #140 demo shows a failed curl leaving nothing at the final path (guard re-downloads next run), a successful download landing atomically, and `np.save` going through an open file object so no `.npy`-suffix surprise on the temp name.

## Fix

One shared helper, `atomic_save(index, index_path, payload, sidecar_path)` in `turbovec-python/python/turbovec/_persist.py` (same family-fix shape as PR #178's load-side helper), called from all four save methods — the save methods themselves are otherwise unchanged:

1. **Serialize fully in memory first** — `json.dumps(payload)` runs before any file is touched, so bad metadata raises `TypeError` with the on-disk store untouched.
2. **Sibling temp files + `os.replace`** — both artifacts are written to `{name}.tmp.{pid}` in the destination directory (matching the naming used by the Rust-side atomic write proposed in PR #173), flushed and fsynced, then moved into place with `os.replace` (atomic on POSIX). The Rust binding owns the index file handle, so the index temp file is fsynced via a reopened read descriptor (fsync flushes the inode, not a particular fd).
3. **Cleanup on failure** — a `try/finally` unlinks both temp names (no-op after a successful replace).

`benchmarks/download_data.py`: curl downloads to `path + ".tmp"` then `os.replace`s on success; `np.save` writes to an open file object at `path + ".tmp"` (avoiding numpy's automatic `.npy` suffix append) then `os.replace`s. Existence-guard semantics unchanged; no checksum infrastructure added.

## Crash-window analysis

- Serialization failure (the #159 data-loss mode): **fully closed** — nothing on disk is touched.
- Crash while writing either temp file: destination untouched; a stray `.tmp.{pid}` may remain (ignored by loads).
- Crash **between the two `os.replace` calls** (index is replaced first): this window remains — the destination holds the new index beside the old sidecar. For **LangChain, LlamaIndex, and Haystack** this mismatch is caught at load *today* by `check_persisted_handles` (clean `ValueError` instead of silently wrong documents). For **agno** the load path on this branch has no such validation, so that manufactured state loads silently; the catch arrives with PR #178's sidecar keyset validation (verified: the same probe raises cleanly on the auto-merged 180+178 tree). **Recommendation: merge #178 before or together with this PR** so the residual window is detected across all four integrations. Closing the window entirely would require a directory-level commit protocol (or a single-file format) — out of scope here.

## Save paths covered

Every disk-writing save path in the four integrations (verified by grep for `json.dump`, `.write(`, and `open(..., "w")` — no others exist):

- `langchain.py` — `TurboQuantVectorStore.dump`
- `llama_index.py` — `TurboQuantVectorStore.persist` (the only writer; `from_persist_dir` / `from_persist_path` are load-only, `to_dict` writes no files)
- `haystack.py` — `TurboQuantDocumentStore.save_to_disk` (the only writer; `to_dict` is config-only, no bytes/stream save path exists)
- `agno.py` — `TurboQuantVectorDb.save`

## Tests

New regression tests (each verified to **fail** on unfixed sources via `git checkout origin/main -- turbovec-python/python/turbovec/`, then pass after restore):

- `test_langchain.py::test_failed_dump_preserves_previous_store`
- `test_llama_index.py::test_failed_persist_preserves_previous_store`
- `test_haystack.py::test_failed_save_preserves_previous_store`
- `test_agno.py::test_failed_save_preserves_previous_store`

Each dumps a good store, attempts a dump with a non-serializable-metadata doc over the same path, and asserts the raise happens, the directory contents are **byte-identical** to before (which also proves no stray `.tmp*` files — plus an explicit glob assertion), and the original store still loads. Happy-path save/load round-trips already existed for all four integrations (`test_dump_and_load_roundtrip`, `test_persist_and_from_persist_path_roundtrip`, `test_save_and_load_roundtrip`, `test_save_and_load_via_path_param`) and were left as-is.

`benchmarks/` has no test harness, so #140 is demonstrated by execution above rather than adding test infra.

Full suite: `python -m pytest turbovec-python/tests/` → **382 passed, 0 failures** (378 main baseline + 4 new).

## Merge checks (`git merge-tree` vs open PR branches)

| Branch | Result |
|---|---|
| `fix/langchain-add-boundary` | CHANGELOG.md only — trivial (both add Unreleased entries) |
| `fix/llamaindex-filters-and-ordering` | CHANGELOG.md only — trivial |
| `fix/haystack-agno-correctness` | CHANGELOG.md only — trivial |
| `fix/sidecar-keyset-validation` (PR #178) | CHANGELOG.md only — trivial |

An earlier draft conflicted with #178 on the `from ._persist import ...` lines and `_persist.py`'s `__all__`/docstring; the hunks were redesigned to be disjoint: `atomic_save` sits *above* `check_persisted_handles` in `_persist.py` (a region #178 doesn't touch), the module docstring and `__all__` line are left unmodified (`atomic_save` is imported explicitly; `_persist` is an internal module, so `__all__` there is documentation only), and the new import is a separate `isort:skip` line placed so it doesn't touch the import line #178 edits. All four code merges are now conflict-free.

## Docs

- `CHANGELOG.md`: Unreleased → Python package → Fixed (#159) + a Benchmarks entry (#140).
- One steady-state sentence added to the persistence section of each of `docs/integrations/{langchain,llama_index,haystack,agno}.md` describing the atomicity guarantee.

Closes #159
Closes #140

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
