### PR TITLE
fix: name the embedder in errors when it returns malformed output (#154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,27 @@ appears under each surface it touches.
   into place on success, so an interrupted download no longer leaves a
   partial file at the final path that the existence guard then treats as
   complete. (#140)
+- **Misbehaving embedders now raise errors that name the embedder as the
+  cause.** (#154) Three error-quality gaps — no data corruption or desync
+  in any of them, just opaque errors:
+  - LangChain `add_texts` / `aadd_texts` validate that the embedder
+    returned one vector per text. A short batch previously surfaced as
+    `expected N ids, got M` from the index (or an `IndexError` when the
+    batch contained duplicate ids); it now raises
+    `embedder returned X vectors for Y texts`. The query path likewise
+    rejects `embed_query` returning `None` or a non-1D result with an
+    error naming the embedder instead of an opaque PyO3 boundary `TypeError`.
+  - Agno `insert` / `async_insert` no longer crash with
+    `TypeError: object of type 'NoneType' has no len()` when a batch
+    embedder returns `None` instead of the embeddings list — the
+    documents are treated as un-embedded and the existing
+    `failed to embed N document(s)` error is raised.
+  - LangChain, Haystack, and LlamaIndex stores reject batches of empty
+    (dim-0) embeddings — shape `(N, 0)` passed the 2D-batch guard and
+    died in the index kernel with `vector buffer length 0 not a multiple
+    of dim 0`; they now raise an error pointing at the embedder / embed
+    model. (Agno already caught this mode via its missing-embedding
+    check.)
 
 ### Docs
 

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -279,6 +279,16 @@ class TurboQuantVectorDb(VectorDb):
         ):
             contents = [doc.content for doc in to_embed]
             embeddings, usages = self.embedder.get_embeddings_batch_and_usage(contents)
+            # A misbehaving embedder can return None (or another non-sized
+            # object) in place of the embeddings/usages lists. Treat that as
+            # "nothing embedded": the documents keep no embedding, and
+            # insert()'s missing-embedding check raises the standard
+            # "failed to embed N document(s)" error instead of an opaque
+            # `len(None)` TypeError here.
+            if embeddings is None or not hasattr(embeddings, "__len__"):
+                embeddings = []
+            if usages is None or not hasattr(usages, "__len__"):
+                usages = []
             for j, doc in enumerate(to_embed):
                 if j < len(embeddings):
                     doc.embedding = embeddings[j]
@@ -304,6 +314,13 @@ class TurboQuantVectorDb(VectorDb):
             embeddings, usages = await self.embedder.async_get_embeddings_batch_and_usage(
                 contents
             )
+            # See _embed_missing: a None / non-sized batch return means
+            # "nothing embedded" — insert()'s missing-embedding check
+            # raises the clear "failed to embed" error.
+            if embeddings is None or not hasattr(embeddings, "__len__"):
+                embeddings = []
+            if usages is None or not hasattr(usages, "__len__"):
+                usages = []
             for j, doc in enumerate(to_embed):
                 if j < len(embeddings):
                     doc.embedding = embeddings[j]

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -228,6 +228,14 @@ class TurboQuantDocumentStore:
             raise ValueError(
                 f"expected 2D embedding batch, got {vectors.ndim}D"
             )
+        # A batch of empty per-document embeddings has shape (N, 0) — 2D,
+        # so it passes the ndim guard, then dies deep in the index kernel
+        # with an opaque buffer-length error. Name the real cause instead.
+        if vectors.shape[1] == 0:
+            raise ValueError(
+                "documents have empty embeddings (dim 0); check the "
+                "embedder that produced them"
+            )
         # IdMapIndex.add_with_ids handles both eager (dim must match) and
         # lazy (locks dim on first call) cases. Surface its mismatch
         # panic as a clean ValueError for parity with previous behaviour.

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -97,6 +97,46 @@ class TurboQuantVectorStore(VectorStore):
         # mapping to LangChain's [0, 1] relevance scale via (sim + 1) / 2.
         return lambda sim: max(0.0, min(1.0, (sim + 1.0) / 2.0))
 
+    # ---- Embedder-output validation -----------------------------------
+
+    @staticmethod
+    def _check_embedded_batch(vectors: np.ndarray, n_texts: int) -> None:
+        """Validate the shape of an embedder's document-batch output.
+
+        Only 2D outputs are inspected here — any other ndim falls through
+        to ``_store_texts_and_vectors``, whose existing guard names the bad
+        dimensionality directly. Without the row-count check, a misbehaving
+        embedder that returns fewer vectors than texts surfaces downstream
+        as an id-count mismatch (or an IndexError during intra-batch
+        dedup) that never names the embedder as the cause.
+        """
+        if vectors.ndim != 2:
+            return
+        if vectors.shape[0] != n_texts:
+            raise ValueError(
+                f"embedder returned {vectors.shape[0]} vectors for "
+                f"{n_texts} texts"
+            )
+        if vectors.shape[1] == 0:
+            raise ValueError(
+                f"embedder returned empty vectors (dim 0) for {n_texts} texts"
+            )
+
+    def _validate_query_embedding(self, embedded: Any) -> np.ndarray:
+        """Coerce an embedder's query output to a 1D float32 vector,
+        rejecting None and wrong-rank outputs with an error that names
+        the embedder (the raw values otherwise surface as opaque errors
+        from the index kernel)."""
+        if embedded is None:
+            raise ValueError("embedder returned None instead of a query embedding")
+        qvec = np.asarray(embedded, dtype=np.float32)
+        if qvec.ndim != 1:
+            raise ValueError(
+                f"embedder returned a {qvec.ndim}D query embedding; "
+                "expected a single 1D vector"
+            )
+        return qvec
+
     # ---- Write path ---------------------------------------------------
 
     def add_texts(
@@ -128,6 +168,7 @@ class TurboQuantVectorStore(VectorStore):
             raise ValueError("texts, metadatas, and ids must all have the same length")
 
         vectors = np.asarray(self._embedding.embed_documents(texts_list), dtype=np.float32)
+        self._check_embedded_batch(vectors, len(texts_list))
         return self._store_texts_and_vectors(texts_list, vectors, metadatas, ids)
 
     async def aadd_texts(
@@ -156,6 +197,7 @@ class TurboQuantVectorStore(VectorStore):
         vectors = np.asarray(
             await self._embedding.aembed_documents(texts_list), dtype=np.float32
         )
+        self._check_embedded_batch(vectors, len(texts_list))
         return self._store_texts_and_vectors(texts_list, vectors, metadatas, ids)
 
     def add_documents(
@@ -300,7 +342,7 @@ class TurboQuantVectorStore(VectorStore):
         filter: dict[str, Any] | Callable[[Document], bool] | None = None,
         **_: Any,
     ) -> list[tuple[Document, float]]:
-        qvec = np.asarray(self._embedding.embed_query(query), dtype=np.float32)
+        qvec = self._validate_query_embedding(self._embedding.embed_query(query))
         return self._search_vector(qvec, k, filter=filter)
 
     async def asimilarity_search_with_score(
@@ -310,8 +352,8 @@ class TurboQuantVectorStore(VectorStore):
         filter: dict[str, Any] | Callable[[Document], bool] | None = None,
         **_: Any,
     ) -> list[tuple[Document, float]]:
-        qvec = np.asarray(
-            await self._embedding.aembed_query(query), dtype=np.float32
+        qvec = self._validate_query_embedding(
+            await self._embedding.aembed_query(query)
         )
         return self._search_vector(qvec, k, filter=filter)
 

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -167,6 +167,14 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
             raise ValueError(
                 f"expected 2D embedding batch, got {vectors.ndim}D"
             )
+        # A batch of empty per-node embeddings has shape (N, 0) — 2D, so
+        # it passes the ndim guard, then dies deep in the index kernel
+        # with an opaque buffer-length error. Name the real cause instead.
+        if vectors.shape[1] == 0:
+            raise ValueError(
+                "nodes have empty embeddings (dim 0); check the embed "
+                "model that produced them"
+            )
         # IdMapIndex.add_with_ids handles eager (dim must match) and lazy
         # (locks dim on first add) — pre-check the eager case so we
         # surface a clean ValueError rather than a Rust panic.

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -1450,3 +1450,59 @@ def test_delete_by_metadata_only_removes_matching_on_doc_id_collision():
 
     assert db.delete_by_metadata({"k": "x"}) is True
     assert db.get_count() == 1  # the {"k": "y"} doc survives
+
+
+# ---- Embedder-output validation (issue #154) ------------------------------
+
+
+class NoneBatchEmbedder(StubEmbedder):
+    """Misbehaving batch embedder: the batch call returns (None, None)
+    instead of the embeddings/usages lists."""
+
+    enable_batch = True
+
+    def get_embeddings_batch_and_usage(self, texts):
+        return None, None
+
+    async def async_get_embeddings_batch_and_usage(self, texts):
+        return None, None
+
+
+def test_insert_batch_embedder_returning_none_raises_failed_to_embed():
+    # On main this died with `TypeError: object of type 'NoneType' has no
+    # len()` inside _embed_missing. It must fall through to the same
+    # "failed to embed" error the missing-embedding check already raises.
+    db = TurboQuantVectorDb(embedder=NoneBatchEmbedder(DIM))
+    db.create()
+    with pytest.raises(ValueError, match="failed to embed 2 document"):
+        db.insert("h", [Document(content="a"), Document(content="b")])
+    assert db.get_count() == 0
+
+
+def test_async_insert_batch_embedder_returning_none_raises_failed_to_embed():
+    import asyncio
+
+    db = TurboQuantVectorDb(embedder=NoneBatchEmbedder(DIM))
+    db.create()
+    with pytest.raises(ValueError, match="failed to embed 2 document"):
+        asyncio.run(
+            db.async_insert("h", [Document(content="a"), Document(content="b")])
+        )
+    assert db.get_count() == 0
+
+
+def test_insert_batch_embedder_empty_vectors_raises_failed_to_embed():
+    # Pins the (N, 0) mode: a batch of empty per-document embeddings is
+    # caught by the missing-embedding check (empty list == not embedded),
+    # never reaching the index kernel.
+    class EmptyBatchEmbedder(StubEmbedder):
+        enable_batch = True
+
+        def get_embeddings_batch_and_usage(self, texts):
+            return [[] for _ in texts], [None for _ in texts]
+
+    db = TurboQuantVectorDb(embedder=EmptyBatchEmbedder(DIM))
+    db.create()
+    with pytest.raises(ValueError, match="failed to embed 2 document"):
+        db.insert("h", [Document(content="a"), Document(content="b")])
+    assert db.get_count() == 0

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -1240,6 +1240,20 @@ def test_embedding_retrieval_all_results_have_finite_float_scores():
         assert math.isfinite(r.score)
 
 
+# ---- Embedder-output validation (issue #154) ------------------------------
+
+
+def test_write_documents_empty_embeddings_raise_error_naming_embedder():
+    # Documents whose embedder produced empty vectors form a (N, 0) batch —
+    # 2D, so it slipped the ndim guard and died downstream with
+    # "vector buffer length 0 not a multiple of dim 0" on main.
+    store = TurboQuantDocumentStore()
+    docs = [Document(id=f"d{i}", content=f"t{i}", embedding=[]) for i in range(3)]
+    with pytest.raises(ValueError, match=r"empty embeddings \(dim 0\).*embedder"):
+        store.write_documents(docs)
+    assert store.count_documents() == 0
+
+
 def test_load_rejects_side_car_desynced_from_index(tmp_path):
     import json
 

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -828,6 +828,106 @@ def test_aget_by_ids_preserves_order_and_returns_documents_with_id():
     assert [d.id for d in docs] == ["id-c", "id-a", "id-b"]
 
 
+# ---- Embedder-output validation (issue #154) ------------------------------
+#
+# A misbehaving embedder must produce an error that names the embedder as
+# the cause, and a failed add must leave the store untouched.
+
+
+class CountingShortEmbeddings(StubEmbeddings):
+    """Returns one vector fewer than requested from the second
+    embed_documents call onward — first call behaves normally so a store
+    can be populated before triggering the failure."""
+
+    def __init__(self, dim: int = 64) -> None:
+        super().__init__(dim)
+        self.calls = 0
+
+    def embed_documents(self, texts):
+        self.calls += 1
+        if self.calls == 1:
+            return [self._embed(t) for t in texts]
+        return [self._embed(t) for t in texts[:-1]]
+
+
+def test_add_texts_embedder_count_mismatch_raises_and_leaves_store_unchanged():
+    emb = CountingShortEmbeddings(dim=64)
+    store = TurboQuantVectorStore(embedding=emb)
+    store.add_texts(["seed-1", "seed-2"], ids=["s1", "s2"])
+    docs_before = dict(store._docs)
+    map_before = dict(store._str_to_u64)
+    count_before = len(store._index)
+
+    with pytest.raises(ValueError, match="embedder returned 2 vectors for 3 texts"):
+        store.add_texts(["a", "b", "c"], ids=["x", "y", "z"])
+
+    # No desync: the failed add must not have mutated any store state.
+    assert store._docs == docs_before
+    assert store._str_to_u64 == map_before
+    assert len(store._index) == count_before
+
+
+def test_add_texts_embedder_count_mismatch_with_duplicate_ids_names_embedder():
+    # On main this variant died with an IndexError inside the intra-batch
+    # dedup (vectors[keep] out of bounds) — it must name the embedder too.
+    emb = CountingShortEmbeddings(dim=64)
+    store = TurboQuantVectorStore(embedding=emb)
+    store.add_texts(["seed"], ids=["s"])
+    with pytest.raises(ValueError, match="embedder returned 2 vectors for 3 texts"):
+        store.add_texts(["a", "b", "c"], ids=["x", "x", "y"])
+    assert len(store._index) == 1  # unchanged
+
+
+def test_aadd_texts_embedder_count_mismatch_raises():
+    import asyncio
+
+    class AsyncShort(StubEmbeddings):
+        async def aembed_documents(self, texts):
+            return [self._embed(t) for t in texts[:-1]]
+
+    store = TurboQuantVectorStore(embedding=AsyncShort(dim=64))
+    with pytest.raises(ValueError, match="embedder returned 2 vectors for 3 texts"):
+        asyncio.run(store.aadd_texts(["a", "b", "c"]))
+    assert store._docs == {}
+    assert len(store._index) == 0
+
+
+def test_add_texts_empty_embeddings_raise_error_naming_embedder():
+    # shape (N, 0) passes an ndim==2 check; on main it died downstream with
+    # "vector buffer length 0 not a multiple of dim 0".
+    class EmptyEmbeddings(StubEmbeddings):
+        def embed_documents(self, texts):
+            return [[] for _ in texts]
+
+    store = TurboQuantVectorStore(embedding=EmptyEmbeddings())
+    with pytest.raises(ValueError, match=r"embedder returned empty vectors \(dim 0\)"):
+        store.add_texts(["a", "b", "c"])
+    assert store._docs == {}
+    assert len(store._index) == 0
+
+
+def test_similarity_search_rejects_none_and_2d_query_embeddings():
+    # embed_query returning None surfaced as an opaque PyO3 TypeError from
+    # the index kernel; a 2D batch silently searched with the first row.
+    class BadQueryEmbeddings(StubEmbeddings):
+        def __init__(self, qret, dim: int = 64) -> None:
+            super().__init__(dim)
+            self.qret = qret
+
+        def embed_query(self, text):
+            return self.qret
+
+    store = TurboQuantVectorStore(embedding=BadQueryEmbeddings(None))
+    store.add_texts(["a", "b"])
+    with pytest.raises(ValueError, match="embedder returned None"):
+        store.similarity_search("q", k=1)
+
+    store2 = TurboQuantVectorStore(embedding=BadQueryEmbeddings([[0.1] * 64] * 2))
+    store2.add_texts(["a", "b"])
+    with pytest.raises(ValueError, match="embedder returned a 2D query embedding"):
+        store2.similarity_search("q", k=1)
+
+
 def test_load_rejects_side_car_desynced_from_index(tmp_path):
     # A side-car whose handle map doesn't match the .tvim index must fail
     # cleanly at load, not with a KeyError deep inside a later query.

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -1359,6 +1359,20 @@ def test_query_returned_node_always_has_none_embedding():
         assert node.embedding is None
 
 
+# ---- Embedder-output validation (issue #154) ------------------------------
+
+
+def test_add_empty_embeddings_raise_error_naming_embed_model():
+    # Nodes whose embed model produced empty vectors form a (N, 0) batch —
+    # 2D, so it slipped the ndim guard and died downstream with
+    # "vector buffer length 0 not a multiple of dim 0" on main.
+    store = TurboQuantVectorStore()
+    nodes = [TextNode(text=f"t{i}", embedding=[]) for i in range(3)]
+    with pytest.raises(ValueError, match=r"empty embeddings \(dim 0\).*embed model"):
+        store.add(nodes)
+    assert len(store._nodes) == 0
+
+
 def test_from_persist_path_rejects_side_car_desynced_from_index(tmp_path):
     import json
 


### PR DESCRIPTION
Implements the embedder-output-validation lane from the bug-hunt: three error-quality gaps where a misbehaving embedder produced opaque errors that never named the real cause. Per the issue's severity framing, none of these involve panic, desync, or corruption — every fix is validation-only, with no behavior change for well-behaved embedders.

## Gap 1 — LangChain `add_texts` never checked vectors-per-text

**Root cause:** `add_texts` passed `embed_documents`' output straight to the store with no length check. A short batch surfaced downstream as the index kernel's id-count error; with duplicate ids in the batch, the intra-batch dedup indexed past the end of the vector array first.

**Repro on main (@1e7200c):** embedder returning 2 vectors for 3 texts →
- `add_texts(["a","b","c"])` → `ValueError: expected 2 ids, got 3` (names ids, not the embedder)
- `add_texts(..., ids=["x","x","y"])` → `IndexError: index 2 is out of bounds for axis 0 with size 2`

**Fix:** new `_check_embedded_batch` helper validates the embedder's 2D output right after `embed_documents` / `aembed_documents` (both sync and async paths embed separately, so both call it): `ValueError: embedder returned 2 vectors for 3 texts`. Non-2D outputs still fall through to the existing `expected 2D embedding batch, got ND` guard. Tests also pin the no-mutation property: a failed add leaves `_docs`, `_str_to_u64`, and the index untouched (true on main too — pinned so it stays true).

Other integrations: agno already raises `failed to embed N document(s)`; haystack/llama_index take precomputed per-doc embeddings, so the mode can't arise — LangChain was the outlier.

## Gap 2 — agno batch embedder returning `None`

**Root cause:** `_embed_missing` indexed the batch return without checking it's a sized sequence (`if j < len(embeddings)`).

**Repro on main:** batch embedder returning `(None, None)` → `TypeError: object of type 'NoneType' has no len()` at `agno.py` `_embed_missing`. (Per-doc `None` and fewer-than-N returns were already caught by the missing-embedding check.)

**Fix:** a `None`/non-sized batch return (for `embeddings` or `usages`) is normalized to `[]`, so the documents stay un-embedded and `insert()`'s existing missing-embedding check raises the established error family: `ValueError: failed to embed 2 document(s): [...]`. Applied to both `_embed_missing` and `_embed_missing_async` (covers `async_insert`).

## Gap 3 — `(N, 0)` empty-embedding batches slipped the `ndim != 2` guards

**Root cause:** a batch of empty per-item embeddings is a 2D array of shape `(N, 0)`, so it passed the `ndim != 2` guards in langchain/haystack/llama_index and died in the index kernel.

**Repro on main:** embedder returning `[[], [], []]` → `ValueError: vector buffer length 0 not a multiple of dim 0` in all three integrations.

**Fix:** each guard now rejects `shape[1] == 0` with a message naming the source:
- langchain: `embedder returned empty vectors (dim 0) for 3 texts`
- haystack: `documents have empty embeddings (dim 0); check the embedder that produced them`
- llama_index: `nodes have empty embeddings (dim 0); check the embed model that produced them`

**agno verified by execution — not affected:** both the per-doc and batch `[[], [], []]` modes already raise `failed to embed N document(s)` because an empty list is treated as "not embedded" by the missing-embedding check. A test pins this (`test_insert_batch_embedder_empty_vectors_raises_failed_to_embed` — passes on main by design; it pins existing-clean behavior). One out-of-family note: a *pre-embedded* agno `Document` whose `embedding` was manually set to an empty **numpy array** (off-contract; the field is `List[float]`) hits numpy's truth-value-ambiguous error at the missing check — that's input validation, not embedder output, and `fix/haystack-agno-correctness` already reworks that exact check (issue #135), so it's left alone here.

## Query-side sibling (probed as part of the lane)

- langchain `embed_query` returning `None` → opaque PyO3 `TypeError: argument 'queries': 'ndarray' object cannot be cast as 'ndarray'` on main. **Fixed** in the same pattern (`_validate_query_embedding` on both sync/async `similarity_search_with_score`): `embedder returned None instead of a query embedding`. Non-1D query output (e.g. a 2D batch, which on main silently searched with the first row only) now raises `embedder returned a 2D query embedding; expected a single 1D vector`. This is the one place off-contract-but-previously-functioning input (a nested `[[...]]` single-row return) becomes an error — flagged deliberately; well-behaved embedders (1D return) are unaffected.
- langchain/agno `embed_query`/`get_embedding` returning `[]` or wrong dim already raise the clear `query dim X does not match index dim Y` — unchanged.
- agno `get_embedding` returning `None` is already handled (returns `[]` results, documented) — no opaque query-side mode in agno; note-only.
- haystack/llama_index query paths take precomputed query embeddings (no embedder in the store) — out of family.

## Verified-clean list re-checked after the changes

Wrong-dim vs index, `None` top-level batch, ragged, NaN/Inf, 3D, and string embeddings all still produce their existing clean errors (run by execution against the fixed code); none are shadowed by the new guards.

## Tests

10 new tests (all except the agno pin verified to FAIL against `origin/main` sources via `git checkout origin/main -- turbovec-python/python/turbovec/`, reproducing the exact opaque errors):
- `test_langchain.py`: `test_add_texts_embedder_count_mismatch_raises_and_leaves_store_unchanged`, `test_add_texts_embedder_count_mismatch_with_duplicate_ids_names_embedder`, `test_aadd_texts_embedder_count_mismatch_raises`, `test_add_texts_empty_embeddings_raise_error_naming_embedder`, `test_similarity_search_rejects_none_and_2d_query_embeddings`
- `test_agno.py`: `test_insert_batch_embedder_returning_none_raises_failed_to_embed`, `test_async_insert_batch_embedder_returning_none_raises_failed_to_embed`, `test_insert_batch_embedder_empty_vectors_raises_failed_to_embed` (pin)
- `test_haystack.py`: `test_write_documents_empty_embeddings_raise_error_naming_embedder`
- `test_llama_index.py`: `test_add_empty_embeddings_raise_error_naming_embed_model`

Full suite: **388 passed** (378 baseline + 10 new), 0 failures.

## Merge checks (`git merge-tree` vs the five open lanes)

No source-code conflicts against any branch. Hunk placement was chosen to avoid them: the langchain checks live in `add_texts`/`aadd_texts` + new helpers (not in `_store_texts_and_vectors`, where #171 inserts its metadata validation), and the new tests were placed mid-file rather than appended at EOF (all five lanes append tests at EOF).

| branch | result |
|---|---|
| `fix/langchain-add-boundary` | CHANGELOG.md only |
| `fix/llamaindex-filters-and-ordering` | CHANGELOG.md only |
| `fix/haystack-agno-correctness` | CHANGELOG.md only |
| `fix/sidecar-keyset-validation` | CHANGELOG.md only |
| `fix/atomic-python-persist` | CHANGELOG.md only |

The CHANGELOG conflicts are the expected adjacent-bullet-under-Unreleased collisions — trivial keep-both resolutions on whichever branch rebases second.

Closes #154

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
