### PR TITLE
tests: drop unused embedder import that breaks on latest haystack-ai

### DIFF
--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -1002,7 +1002,6 @@ def test_pipeline_end_to_end_retrieval():
     # store.embedding_retrieval — its job is to exercise the Pipeline
     # plumbing on top of our store, not to be a real retriever.
     from haystack import Pipeline, component
-    from haystack.components.embedders import SentenceTransformersTextEmbedder  # noqa: F401 (just an import check)
 
     @component
     class _ProbeRetriever:


### PR DESCRIPTION
## What

Deletes one dead import from `test_pipeline_end_to_end_retrieval` in `turbovec-python/tests/test_haystack.py`.

## Why

A new haystack-ai release moved `SentenceTransformersTextEmbedder` out of `haystack.components.embedders`, and CI (which installs latest haystack-ai) now fails on all three platforms with an ImportError at collection of this test — including on Rust-only merge commits, confirming it's upstream drift, not a turbovec regression.

The import was annotated `# noqa: F401 (just an import check)` and is **unused**: the test body builds its own `_ProbeRetriever` component and exercises Pipeline plumbing over `TurboQuantDocumentStore`. Nothing under test changes.

## Verification

- Full `test_haystack.py` with the fix: **82 passed** (local haystack-ai 2.31.0).
- Test-only change; no CHANGELOG entry per convention (CHANGELOG narrates package surface, not tests/CI).

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)