### PR TITLE
fix: release the GIL around compute-bound Python binding calls (issue #121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,17 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **The bindings release the GIL around compute-bound core calls.**
+  `TurboQuantIndex` / `IdMapIndex` `search`, `add` / `add_with_ids`,
+  `prepare`, `write`, and `load` previously held the GIL for their full
+  duration, stalling every other Python thread and serializing
+  concurrent searches that the core index explicitly supports. Inputs
+  borrowed from numpy arrays (queries, vectors, ids, masks, allowlists)
+  are snapshotted into owned buffers before the GIL is released, so a
+  Python thread mutating an input array mid-call cannot corrupt or
+  perturb the running operation. Long calls still cannot be interrupted
+  with Ctrl-C mid-operation (signal polling is a separate concern).
+  (#121)
 - Added the `Operating System :: Microsoft :: Windows` classifier to the
   PyPI metadata — Windows x64 wheels have shipped since 0.4.3 but the OS
   classifiers listed only Linux and macOS. (#143)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,9 +95,15 @@ appears under each surface it touches.
   `TurboQuantIndex` / `IdMapIndex` `search`, `add` / `add_with_ids`,
   `prepare`, `write`, and `load` previously held the GIL for their full
   duration, stalling every other Python thread and serializing
-  concurrent searches that the core index explicitly supports. Inputs
-  borrowed from numpy arrays (queries, vectors, ids, masks, allowlists)
-  are snapshotted into owned buffers before the GIL is released, so a
+  concurrent searches that the core index explicitly supports. The
+  concurrency contract per index object is: reads (`search`, `prepare`,
+  `write`, `contains`, `len`) may run in parallel with each other; a
+  write (`add`, `add_with_ids`, `remove`, `swap_remove`) blocks until it
+  has the index to itself and then succeeds — the same
+  serialize-then-succeed outcome writes always had, now enforced by an
+  internal reader-writer lock instead of the GIL. Inputs borrowed from
+  numpy arrays (queries, vectors, ids, masks, allowlists) are
+  snapshotted into owned buffers before the GIL is released, so a
   Python thread mutating an input array mid-call cannot corrupt or
   perturb the running operation. Long calls still cannot be interrupted
   with Ctrl-C mid-operation (signal polling is a separate concern).

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -158,9 +158,40 @@ fn validate_queries(values: &[f32], dim: usize) -> PyResult<()> {
     Ok(())
 }
 
-#[pyclass]
+/// Read-lock an index, recovering from poisoning. A panic that escaped
+/// a previous call has already surfaced to Python as a PanicException;
+/// before the GIL-release change such a panic likewise left the object
+/// reachable, so poisoning must not turn every later call into a panic.
+fn lock_read<T>(lock: &std::sync::RwLock<T>) -> std::sync::RwLockReadGuard<'_, T> {
+    lock.read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Write-lock an index; see [`lock_read`] for the poisoning rationale.
+fn lock_write<T>(lock: &std::sync::RwLock<T>) -> std::sync::RwLockWriteGuard<'_, T> {
+    lock.write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+// Locking discipline (both pyclasses): the pyclass is `frozen`, so pyo3
+// performs no runtime borrow-checking of its own and every method takes
+// `&self`; the inner index sits behind an `RwLock` instead. Concurrent
+// searches share the read lock and run in parallel; a write blocks until
+// it is alone, then succeeds — the same observable outcome as when the
+// GIL serialized every call, minus the serialization of reads.
+//
+// Long-running calls acquire the lock INSIDE `py.detach(..)` so a thread
+// blocked on the lock is never holding the GIL, and every index-dependent
+// check runs under the same guard as the core call it protects (the
+// pre-GIL-release code got that atomicity for free from the GIL).
+// Trivial O(1) calls (`__len__`, getters, `contains`) lock while holding
+// the GIL: they may wait for a concurrent writer, but a guard is only
+// ever released from code that does not need the GIL to finish, so no
+// lock/GIL deadlock cycle exists.
+
+#[pyclass(frozen)]
 struct TurboQuantIndex {
-    inner: turbovec_core::TurboQuantIndex,
+    inner: std::sync::RwLock<turbovec_core::TurboQuantIndex>,
 }
 
 #[pymethods]
@@ -181,10 +212,12 @@ impl TurboQuantIndex {
             None => turbovec_core::TurboQuantIndex::new_lazy(bit_width),
         }
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: std::sync::RwLock::new(inner),
+        })
     }
 
-    fn add(&mut self, py: Python<'_>, vectors: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn add(&self, py: Python<'_>, vectors: &Bound<'_, PyAny>) -> PyResult<()> {
         let vectors = extract_f32_2d("vectors", vectors)?;
         let arr = vectors.as_array();
         let dim = arr.ncols();
@@ -199,7 +232,7 @@ impl TurboQuantIndex {
         let owned = slice.to_vec();
         // `add_2d` handles both eager (dim must match) and lazy (locks
         // dim on first call) cases.
-        py.detach(|| self.inner.add_2d(&owned, dim))
+        py.detach(|| lock_write(&self.inner).add_2d(&owned, dim))
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
@@ -221,54 +254,55 @@ impl TurboQuantIndex {
         let mask = mask.map(|m| extract_bool_1d("mask", m)).transpose()?;
         let arr = queries.as_array();
         let nq = arr.nrows();
+        let ncols = arr.ncols();
         let q_slice = arr
             .as_slice()
             .ok_or_else(|| not_contiguous_err("queries"))?;
-        // Reject wrong-dim queries cleanly. Previously the inner
-        // `assert_eq!(queries.len(), nq * dim)` would fire as a Rust
-        // panic and surface to Python as a PanicException, not the
-        // ValueError users expect for input-shape mismatch.
-        if let Some(idx_dim) = self.inner.dim_opt() {
-            if arr.ncols() != idx_dim {
-                return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                    "query dim {} does not match index dim {}",
-                    arr.ncols(),
-                    idx_dim,
-                )));
-            }
-        }
         // Snapshot the query (and mask) buffers before releasing the
         // GIL: once released, another Python thread may write to the
         // source arrays mid-search. Validation runs on the snapshot so
         // the searched data is exactly the data that was validated.
         let q_owned = q_slice.to_vec();
-        validate_queries(&q_owned, arr.ncols())?;
-
-        let mask_arr = mask.as_ref().map(|m| m.as_array());
-        let mask_owned: Option<Vec<bool>> = match mask_arr.as_ref() {
-            Some(m_arr) => {
-                let expected = self.inner.len();
-                if m_arr.len() != expected {
-                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                        "mask length {} does not match index size {}",
-                        m_arr.len(),
-                        expected,
-                    )));
-                }
-                Some(
-                    m_arr
-                        .as_slice()
-                        .ok_or_else(|| not_contiguous_err("mask"))?
-                        .to_vec(),
-                )
-            }
+        let mask_owned: Option<Vec<bool>> = match mask.as_ref().map(|m| m.as_array()).as_ref() {
+            Some(m_arr) => Some(
+                m_arr
+                    .as_slice()
+                    .ok_or_else(|| not_contiguous_err("mask"))?
+                    .to_vec(),
+            ),
             None => None,
         };
 
+        // Index-dependent checks run under the same read guard as the
+        // kernel, so a concurrent writer cannot invalidate them between
+        // check and search (pre-GIL-release, holding the GIL made the
+        // whole call atomic).
         let results = py.detach(|| {
-            self.inner
-                .search_with_mask(&q_owned, k, mask_owned.as_deref())
-        });
+            let inner = lock_read(&self.inner);
+            // Reject wrong-dim queries cleanly. Previously the inner
+            // `assert_eq!(queries.len(), nq * dim)` would fire as a Rust
+            // panic and surface to Python as a PanicException, not the
+            // ValueError users expect for input-shape mismatch.
+            if let Some(idx_dim) = inner.dim_opt() {
+                if ncols != idx_dim {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "query dim {ncols} does not match index dim {idx_dim}",
+                    )));
+                }
+            }
+            validate_queries(&q_owned, ncols)?;
+            if let Some(m) = mask_owned.as_deref() {
+                let expected = inner.len();
+                if m.len() != expected {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "mask length {} does not match index size {}",
+                        m.len(),
+                        expected,
+                    )));
+                }
+            }
+            Ok(inner.search_with_mask(&q_owned, k, mask_owned.as_deref()))
+        })?;
         let effective_k = results.k;
 
         let scores = numpy::ndarray::Array2::from_shape_vec((nq, effective_k), results.scores)
@@ -282,7 +316,7 @@ impl TurboQuantIndex {
     }
 
     fn write(&self, py: Python<'_>, path: &str) -> PyResult<()> {
-        py.detach(|| self.inner.write(path))
+        py.detach(|| lock_read(&self.inner).write(path))
             .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))
     }
 
@@ -292,14 +326,16 @@ impl TurboQuantIndex {
             .py()
             .detach(|| turbovec_core::TurboQuantIndex::load(path))
             .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: std::sync::RwLock::new(inner),
+        })
     }
 
     /// Warm up the search caches (rotation matrix, Lloyd-Max centroids,
     /// SIMD-blocked code layout) so the first `search` call does not pay
     /// the one-time initialisation cost.
     fn prepare(&self, py: Python<'_>) {
-        py.detach(|| self.inner.prepare());
+        py.detach(|| lock_read(&self.inner).prepare());
     }
 
     /// Remove the vector at `idx` in O(1) by swapping with the last vector.
@@ -311,13 +347,30 @@ impl TurboQuantIndex {
     /// Raises ``IndexError`` if ``idx`` is out of range. Negative indices
     /// are out of range: Python-style indexing from the end is not
     /// supported.
-    fn swap_remove(&mut self, idx: &Bound<'_, PyAny>) -> PyResult<usize> {
-        let len = self.inner.len();
+    fn swap_remove(&self, py: Python<'_>, idx: &Bound<'_, PyAny>) -> PyResult<usize> {
         if let Ok(i) = idx.extract::<usize>() {
-            if i < len {
-                return Ok(self.inner.swap_remove(i));
+            // Bounds check and removal share one write guard, so a
+            // concurrent writer cannot shrink the index in between.
+            let removed = py.detach(|| {
+                let mut inner = lock_write(&self.inner);
+                let len = inner.len();
+                if i < len {
+                    Ok(inner.swap_remove(i))
+                } else {
+                    Err(len)
+                }
+            });
+            match removed {
+                Ok(moved) => return Ok(moved),
+                Err(len) => {
+                    return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                        "index {} out of range for index of length {len}",
+                        int_repr(idx),
+                    )))
+                }
             }
-        } else if !is_py_int(idx) {
+        }
+        if !is_py_int(idx) {
             return Err(pyo3::exceptions::PyTypeError::new_err(format!(
                 "idx must be an integer, got {}",
                 type_name(idx),
@@ -325,6 +378,7 @@ impl TurboQuantIndex {
         }
         // Any integer that isn't a valid slot — negative, or of any
         // magnitude past the end — is out of range.
+        let len = lock_read(&self.inner).len();
         Err(pyo3::exceptions::PyIndexError::new_err(format!(
             "index {} out of range for index of length {len}",
             int_repr(idx),
@@ -332,19 +386,19 @@ impl TurboQuantIndex {
     }
 
     fn __len__(&self) -> usize {
-        self.inner.len()
+        lock_read(&self.inner).len()
     }
 
     fn __repr__(&self) -> String {
-        let dim = self
-            .inner
+        let inner = lock_read(&self.inner);
+        let dim = inner
             .dim_opt()
             .map_or_else(|| "None".to_string(), |d| d.to_string());
         format!(
             "turbovec.TurboQuantIndex(dim={}, bit_width={}, n_vectors={})",
             dim,
-            self.inner.bit_width(),
-            self.inner.len()
+            inner.bit_width(),
+            inner.len()
         )
     }
 
@@ -353,18 +407,18 @@ impl TurboQuantIndex {
     /// otherwise an ``int``.
     #[getter]
     fn dim(&self) -> Option<usize> {
-        self.inner.dim_opt()
+        lock_read(&self.inner).dim_opt()
     }
 
     #[getter]
     fn bit_width(&self) -> usize {
-        self.inner.bit_width()
+        lock_read(&self.inner).bit_width()
     }
 }
 
-#[pyclass]
+#[pyclass(frozen)]
 struct IdMapIndex {
-    inner: turbovec_core::IdMapIndex,
+    inner: std::sync::RwLock<turbovec_core::IdMapIndex>,
 }
 
 #[pymethods]
@@ -385,7 +439,9 @@ impl IdMapIndex {
             None => turbovec_core::IdMapIndex::new_lazy(bit_width),
         }
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: std::sync::RwLock::new(inner),
+        })
     }
 
     /// Add `n = vectors.shape[0]` vectors with the given external `ids`.
@@ -395,7 +451,7 @@ impl IdMapIndex {
     /// present or if the lengths don't match. On a lazy index, this
     /// call commits the dimensionality from `vectors.shape[1]`.
     fn add_with_ids(
-        &mut self,
+        &self,
         py: Python<'_>,
         vectors: &Bound<'_, PyAny>,
         ids: &Bound<'_, PyAny>,
@@ -412,16 +468,16 @@ impl IdMapIndex {
         // then validates and quantizes the snapshot.
         let v_owned = v_slice.to_vec();
         let i_owned = i_slice.to_vec();
-        py.detach(|| self.inner.add_with_ids_2d(&v_owned, dim, &i_owned))
+        py.detach(|| lock_write(&self.inner).add_with_ids_2d(&v_owned, dim, &i_owned))
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
     /// Remove the vector with external id `id`. Returns `True` if it was
     /// present, `False` otherwise. Integers outside the `uint64` range are
     /// never present, so they return `False`.
-    fn remove(&mut self, id: &Bound<'_, PyAny>) -> PyResult<bool> {
+    fn remove(&self, py: Python<'_>, id: &Bound<'_, PyAny>) -> PyResult<bool> {
         Ok(match extract_membership_id("id", id)? {
-            Some(v) => self.inner.remove(v),
+            Some(v) => py.detach(|| lock_write(&self.inner).remove(v)),
             None => false,
         })
     }
@@ -451,24 +507,15 @@ impl IdMapIndex {
             .transpose()?;
         let arr = queries.as_array();
         let nq = arr.nrows();
+        let ncols = arr.ncols();
         let q_slice = arr
             .as_slice()
             .ok_or_else(|| not_contiguous_err("queries"))?;
-        if let Some(idx_dim) = self.inner.dim_opt() {
-            if arr.ncols() != idx_dim {
-                return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                    "query dim {} does not match index dim {}",
-                    arr.ncols(),
-                    idx_dim,
-                )));
-            }
-        }
         // Snapshot the query (and allowlist) buffers before releasing
         // the GIL: once released, another Python thread may write to the
         // source arrays mid-search. Validation runs on the snapshot so
         // the searched data is exactly the data that was validated.
         let q_owned = q_slice.to_vec();
-        validate_queries(&q_owned, arr.ncols())?;
 
         let allow_arr = allowlist.as_ref().map(|a| a.as_array());
         let allow_owned: Option<Vec<u64>> = match allow_arr.as_ref() {
@@ -478,13 +525,35 @@ impl IdMapIndex {
                         "allowlist is empty",
                     ));
                 }
-                let owned = a_arr
-                    .as_slice()
-                    .ok_or_else(|| not_contiguous_err("allowlist"))?
-                    .to_vec();
+                Some(
+                    a_arr
+                        .as_slice()
+                        .ok_or_else(|| not_contiguous_err("allowlist"))?
+                        .to_vec(),
+                )
+            }
+            None => None,
+        };
+
+        // Index-dependent checks (dim, allowlist membership) run under
+        // the same read guard as the kernel, so a concurrent writer
+        // cannot invalidate them between check and search. `len` is
+        // captured under the same guard for the nq == 0 shape contract
+        // below.
+        let (scores, ids, len_at_search) = py.detach(|| {
+            let inner = lock_read(&self.inner);
+            if let Some(idx_dim) = inner.dim_opt() {
+                if ncols != idx_dim {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "query dim {ncols} does not match index dim {idx_dim}",
+                    )));
+                }
+            }
+            validate_queries(&q_owned, ncols)?;
+            if let Some(allow) = allow_owned.as_deref() {
                 let mut unknown: Vec<u64> = Vec::new();
-                for &id in &owned {
-                    if !self.inner.contains(id) {
+                for &id in allow {
+                    if !inner.contains(id) {
                         if unknown.len() < 5 {
                             unknown.push(id);
                         } else {
@@ -501,15 +570,10 @@ impl IdMapIndex {
                         if unknown.len() > 5 { ", ..." } else { "" },
                     )));
                 }
-                Some(owned)
             }
-            None => None,
-        };
-
-        let (scores, ids) = py.detach(|| {
-            self.inner
-                .search_with_allowlist(&q_owned, k, allow_owned.as_deref())
-        });
+            let (scores, ids) = inner.search_with_allowlist(&q_owned, k, allow_owned.as_deref());
+            Ok((scores, ids, inner.len()))
+        })?;
         // For empty queries (nq=0), match TurboQuantIndex's shape
         // contract: effective_k is `min(k, n_vectors, n_allowed)`. The
         // kernel dedups the allowlist via a packed bool mask for nq>0,
@@ -523,9 +587,9 @@ impl IdMapIndex {
                         std::collections::HashSet::with_capacity(s.len());
                     s.iter().filter(|id| seen.insert(**id)).count()
                 }
-                None => self.inner.len(),
+                None => len_at_search,
             };
-            k.min(self.inner.len()).min(n_allowed)
+            k.min(len_at_search).min(n_allowed)
         } else {
             scores.len() / nq
         };
@@ -543,18 +607,18 @@ impl IdMapIndex {
     /// `uint64` range are never present, so they return `False`.
     fn contains(&self, id: &Bound<'_, PyAny>) -> PyResult<bool> {
         Ok(match extract_membership_id("id", id)? {
-            Some(v) => self.inner.contains(v),
+            Some(v) => lock_read(&self.inner).contains(v),
             None => false,
         })
     }
 
     fn prepare(&self, py: Python<'_>) {
-        py.detach(|| self.inner.prepare());
+        py.detach(|| lock_read(&self.inner).prepare());
     }
 
     /// Serialize the index and id-map side-tables to a `.tvim` file.
     fn write(&self, py: Python<'_>, path: &str) -> PyResult<()> {
-        py.detach(|| self.inner.write(path))
+        py.detach(|| lock_read(&self.inner).write(path))
             .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))
     }
 
@@ -566,29 +630,31 @@ impl IdMapIndex {
             .py()
             .detach(|| turbovec_core::IdMapIndex::load(path))
             .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: std::sync::RwLock::new(inner),
+        })
     }
 
     fn __len__(&self) -> usize {
-        self.inner.len()
+        lock_read(&self.inner).len()
     }
 
     fn __repr__(&self) -> String {
-        let dim = self
-            .inner
+        let inner = lock_read(&self.inner);
+        let dim = inner
             .dim_opt()
             .map_or_else(|| "None".to_string(), |d| d.to_string());
         format!(
             "turbovec.IdMapIndex(dim={}, bit_width={}, n_vectors={})",
             dim,
-            self.inner.bit_width(),
-            self.inner.len()
+            inner.bit_width(),
+            inner.len()
         )
     }
 
     fn __contains__(&self, id: &Bound<'_, PyAny>) -> PyResult<bool> {
         Ok(match extract_membership_id("id", id)? {
-            Some(v) => self.inner.contains(v),
+            Some(v) => lock_read(&self.inner).contains(v),
             None => false,
         })
     }
@@ -597,12 +663,12 @@ impl IdMapIndex {
     /// constructed lazily and hasn't seen an add yet; otherwise ``int``.
     #[getter]
     fn dim(&self) -> Option<usize> {
-        self.inner.dim_opt()
+        lock_read(&self.inner).dim_opt()
     }
 
     #[getter]
     fn bit_width(&self) -> usize {
-        self.inner.bit_width()
+        lock_read(&self.inner).bit_width()
     }
 }
 

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -180,14 +180,14 @@ fn lock_write<T>(lock: &std::sync::RwLock<T>) -> std::sync::RwLockWriteGuard<'_,
 // it is alone, then succeeds — the same observable outcome as when the
 // GIL serialized every call, minus the serialization of reads.
 //
-// Long-running calls acquire the lock INSIDE `py.detach(..)` so a thread
-// blocked on the lock is never holding the GIL, and every index-dependent
-// check runs under the same guard as the core call it protects (the
-// pre-GIL-release code got that atomicity for free from the GIL).
-// Trivial O(1) calls (`__len__`, getters, `contains`) lock while holding
-// the GIL: they may wait for a concurrent writer, but a guard is only
-// ever released from code that does not need the GIL to finish, so no
-// lock/GIL deadlock cycle exists.
+// Every method acquires the lock INSIDE `py.detach(..)` — even trivial
+// O(1) calls like `__len__` — so a thread blocked on the lock is never
+// holding the GIL (a GIL-held `len()` landing during an in-flight write
+// would otherwise stall every Python thread for the write's duration),
+// and every index-dependent check runs under the same guard as the core
+// call it protects (the pre-GIL-release code got that atomicity for
+// free from the GIL). A guard is only ever released from code that does
+// not need the GIL to finish, so no lock/GIL deadlock cycle exists.
 
 #[pyclass(frozen)]
 struct TurboQuantIndex {
@@ -378,41 +378,37 @@ impl TurboQuantIndex {
         }
         // Any integer that isn't a valid slot — negative, or of any
         // magnitude past the end — is out of range.
-        let len = lock_read(&self.inner).len();
+        let len = py.detach(|| lock_read(&self.inner).len());
         Err(pyo3::exceptions::PyIndexError::new_err(format!(
             "index {} out of range for index of length {len}",
             int_repr(idx),
         )))
     }
 
-    fn __len__(&self) -> usize {
-        lock_read(&self.inner).len()
+    fn __len__(&self, py: Python<'_>) -> usize {
+        py.detach(|| lock_read(&self.inner).len())
     }
 
-    fn __repr__(&self) -> String {
-        let inner = lock_read(&self.inner);
-        let dim = inner
-            .dim_opt()
-            .map_or_else(|| "None".to_string(), |d| d.to_string());
-        format!(
-            "turbovec.TurboQuantIndex(dim={}, bit_width={}, n_vectors={})",
-            dim,
-            inner.bit_width(),
-            inner.len()
-        )
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let (dim, bit_width, len) = py.detach(|| {
+            let inner = lock_read(&self.inner);
+            (inner.dim_opt(), inner.bit_width(), inner.len())
+        });
+        let dim = dim.map_or_else(|| "None".to_string(), |d| d.to_string());
+        format!("turbovec.TurboQuantIndex(dim={dim}, bit_width={bit_width}, n_vectors={len})")
     }
 
     /// Vector dimensionality. Returns ``None`` when the index was
     /// constructed lazily (no ``dim=``) and hasn't seen an add yet;
     /// otherwise an ``int``.
     #[getter]
-    fn dim(&self) -> Option<usize> {
-        lock_read(&self.inner).dim_opt()
+    fn dim(&self, py: Python<'_>) -> Option<usize> {
+        py.detach(|| lock_read(&self.inner).dim_opt())
     }
 
     #[getter]
-    fn bit_width(&self) -> usize {
-        lock_read(&self.inner).bit_width()
+    fn bit_width(&self, py: Python<'_>) -> usize {
+        py.detach(|| lock_read(&self.inner).bit_width())
     }
 }
 
@@ -605,9 +601,9 @@ impl IdMapIndex {
 
     /// Return `True` if external id `id` is present. Integers outside the
     /// `uint64` range are never present, so they return `False`.
-    fn contains(&self, id: &Bound<'_, PyAny>) -> PyResult<bool> {
+    fn contains(&self, py: Python<'_>, id: &Bound<'_, PyAny>) -> PyResult<bool> {
         Ok(match extract_membership_id("id", id)? {
-            Some(v) => lock_read(&self.inner).contains(v),
+            Some(v) => py.detach(|| lock_read(&self.inner).contains(v)),
             None => false,
         })
     }
@@ -635,26 +631,22 @@ impl IdMapIndex {
         })
     }
 
-    fn __len__(&self) -> usize {
-        lock_read(&self.inner).len()
+    fn __len__(&self, py: Python<'_>) -> usize {
+        py.detach(|| lock_read(&self.inner).len())
     }
 
-    fn __repr__(&self) -> String {
-        let inner = lock_read(&self.inner);
-        let dim = inner
-            .dim_opt()
-            .map_or_else(|| "None".to_string(), |d| d.to_string());
-        format!(
-            "turbovec.IdMapIndex(dim={}, bit_width={}, n_vectors={})",
-            dim,
-            inner.bit_width(),
-            inner.len()
-        )
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let (dim, bit_width, len) = py.detach(|| {
+            let inner = lock_read(&self.inner);
+            (inner.dim_opt(), inner.bit_width(), inner.len())
+        });
+        let dim = dim.map_or_else(|| "None".to_string(), |d| d.to_string());
+        format!("turbovec.IdMapIndex(dim={dim}, bit_width={bit_width}, n_vectors={len})")
     }
 
-    fn __contains__(&self, id: &Bound<'_, PyAny>) -> PyResult<bool> {
+    fn __contains__(&self, py: Python<'_>, id: &Bound<'_, PyAny>) -> PyResult<bool> {
         Ok(match extract_membership_id("id", id)? {
-            Some(v) => lock_read(&self.inner).contains(v),
+            Some(v) => py.detach(|| lock_read(&self.inner).contains(v)),
             None => false,
         })
     }
@@ -662,13 +654,13 @@ impl IdMapIndex {
     /// Vector dimensionality. Returns ``None`` when the index was
     /// constructed lazily and hasn't seen an add yet; otherwise ``int``.
     #[getter]
-    fn dim(&self) -> Option<usize> {
-        lock_read(&self.inner).dim_opt()
+    fn dim(&self, py: Python<'_>) -> Option<usize> {
+        py.detach(|| lock_read(&self.inner).dim_opt())
     }
 
     #[getter]
-    fn bit_width(&self) -> usize {
-        lock_read(&self.inner).bit_width()
+    fn bit_width(&self, py: Python<'_>) -> usize {
+        py.detach(|| lock_read(&self.inner).bit_width())
     }
 }
 

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -184,17 +184,22 @@ impl TurboQuantIndex {
         Ok(Self { inner })
     }
 
-    fn add(&mut self, vectors: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn add(&mut self, py: Python<'_>, vectors: &Bound<'_, PyAny>) -> PyResult<()> {
         let vectors = extract_f32_2d("vectors", vectors)?;
         let arr = vectors.as_array();
         let dim = arr.ncols();
         let slice = arr
             .as_slice()
             .ok_or_else(|| not_contiguous_err("vectors"))?;
+        // Snapshot the numpy buffer before releasing the GIL (`detach`):
+        // once released, another Python thread may write to the (possibly
+        // writable) source array, and rust-numpy's borrow flags cannot
+        // prevent Python-side writes. The copy is O(n·dim) against the
+        // quantization kernel, so it is cheap by comparison.
+        let owned = slice.to_vec();
         // `add_2d` handles both eager (dim must match) and lazy (locks
         // dim on first call) cases.
-        self.inner
-            .add_2d(slice, dim)
+        py.detach(|| self.inner.add_2d(&owned, dim))
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
@@ -232,10 +237,15 @@ impl TurboQuantIndex {
                 )));
             }
         }
-        validate_queries(q_slice, arr.ncols())?;
+        // Snapshot the query (and mask) buffers before releasing the
+        // GIL: once released, another Python thread may write to the
+        // source arrays mid-search. Validation runs on the snapshot so
+        // the searched data is exactly the data that was validated.
+        let q_owned = q_slice.to_vec();
+        validate_queries(&q_owned, arr.ncols())?;
 
         let mask_arr = mask.as_ref().map(|m| m.as_array());
-        let mask_slice: Option<&[bool]> = match mask_arr.as_ref() {
+        let mask_owned: Option<Vec<bool>> = match mask_arr.as_ref() {
             Some(m_arr) => {
                 let expected = self.inner.len();
                 if m_arr.len() != expected {
@@ -245,12 +255,20 @@ impl TurboQuantIndex {
                         expected,
                     )));
                 }
-                Some(m_arr.as_slice().ok_or_else(|| not_contiguous_err("mask"))?)
+                Some(
+                    m_arr
+                        .as_slice()
+                        .ok_or_else(|| not_contiguous_err("mask"))?
+                        .to_vec(),
+                )
             }
             None => None,
         };
 
-        let results = self.inner.search_with_mask(q_slice, k, mask_slice);
+        let results = py.detach(|| {
+            self.inner
+                .search_with_mask(&q_owned, k, mask_owned.as_deref())
+        });
         let effective_k = results.k;
 
         let scores = numpy::ndarray::Array2::from_shape_vec((nq, effective_k), results.scores)
@@ -263,15 +281,16 @@ impl TurboQuantIndex {
         Ok((scores, indices))
     }
 
-    fn write(&self, path: &str) -> PyResult<()> {
-        self.inner
-            .write(path)
+    fn write(&self, py: Python<'_>, path: &str) -> PyResult<()> {
+        py.detach(|| self.inner.write(path))
             .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))
     }
 
     #[classmethod]
-    fn load(_cls: &Bound<PyType>, path: &str) -> PyResult<Self> {
-        let inner = turbovec_core::TurboQuantIndex::load(path)
+    fn load(cls: &Bound<PyType>, path: &str) -> PyResult<Self> {
+        let inner = cls
+            .py()
+            .detach(|| turbovec_core::TurboQuantIndex::load(path))
             .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))?;
         Ok(Self { inner })
     }
@@ -279,8 +298,8 @@ impl TurboQuantIndex {
     /// Warm up the search caches (rotation matrix, Lloyd-Max centroids,
     /// SIMD-blocked code layout) so the first `search` call does not pay
     /// the one-time initialisation cost.
-    fn prepare(&self) {
-        self.inner.prepare();
+    fn prepare(&self, py: Python<'_>) {
+        py.detach(|| self.inner.prepare());
     }
 
     /// Remove the vector at `idx` in O(1) by swapping with the last vector.
@@ -375,7 +394,12 @@ impl IdMapIndex {
     /// `vectors.shape[0]`. Raises `ValueError` if any id is already
     /// present or if the lengths don't match. On a lazy index, this
     /// call commits the dimensionality from `vectors.shape[1]`.
-    fn add_with_ids(&mut self, vectors: &Bound<'_, PyAny>, ids: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn add_with_ids(
+        &mut self,
+        py: Python<'_>,
+        vectors: &Bound<'_, PyAny>,
+        ids: &Bound<'_, PyAny>,
+    ) -> PyResult<()> {
         let vectors = extract_f32_2d("vectors", vectors)?;
         let ids = extract_u64_1d("ids", ids)?;
         let v = vectors.as_array();
@@ -383,8 +407,12 @@ impl IdMapIndex {
         let v_slice = v.as_slice().ok_or_else(|| not_contiguous_err("vectors"))?;
         let i = ids.as_array();
         let i_slice = i.as_slice().ok_or_else(|| not_contiguous_err("ids"))?;
-        self.inner
-            .add_with_ids_2d(v_slice, dim, i_slice)
+        // Snapshot both numpy buffers before releasing the GIL (another
+        // Python thread may write to them once it is released); the core
+        // then validates and quantizes the snapshot.
+        let v_owned = v_slice.to_vec();
+        let i_owned = i_slice.to_vec();
+        py.detach(|| self.inner.add_with_ids_2d(&v_owned, dim, &i_owned))
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
 
@@ -435,21 +463,27 @@ impl IdMapIndex {
                 )));
             }
         }
-        validate_queries(q_slice, arr.ncols())?;
+        // Snapshot the query (and allowlist) buffers before releasing
+        // the GIL: once released, another Python thread may write to the
+        // source arrays mid-search. Validation runs on the snapshot so
+        // the searched data is exactly the data that was validated.
+        let q_owned = q_slice.to_vec();
+        validate_queries(&q_owned, arr.ncols())?;
 
         let allow_arr = allowlist.as_ref().map(|a| a.as_array());
-        let allow_slice: Option<&[u64]> = match allow_arr.as_ref() {
+        let allow_owned: Option<Vec<u64>> = match allow_arr.as_ref() {
             Some(a_arr) => {
                 if a_arr.is_empty() {
                     return Err(pyo3::exceptions::PyValueError::new_err(
                         "allowlist is empty",
                     ));
                 }
-                let slice = a_arr
+                let owned = a_arr
                     .as_slice()
-                    .ok_or_else(|| not_contiguous_err("allowlist"))?;
+                    .ok_or_else(|| not_contiguous_err("allowlist"))?
+                    .to_vec();
                 let mut unknown: Vec<u64> = Vec::new();
-                for &id in slice {
+                for &id in &owned {
                     if !self.inner.contains(id) {
                         if unknown.len() < 5 {
                             unknown.push(id);
@@ -467,12 +501,15 @@ impl IdMapIndex {
                         if unknown.len() > 5 { ", ..." } else { "" },
                     )));
                 }
-                Some(slice)
+                Some(owned)
             }
             None => None,
         };
 
-        let (scores, ids) = self.inner.search_with_allowlist(q_slice, k, allow_slice);
+        let (scores, ids) = py.detach(|| {
+            self.inner
+                .search_with_allowlist(&q_owned, k, allow_owned.as_deref())
+        });
         // For empty queries (nq=0), match TurboQuantIndex's shape
         // contract: effective_k is `min(k, n_vectors, n_allowed)`. The
         // kernel dedups the allowlist via a packed bool mask for nq>0,
@@ -480,7 +517,7 @@ impl IdMapIndex {
         // returns shape `(0, 3)` for empty queries but `(N, 1)` for
         // non-empty queries, a silent shape divergence.
         let effective_k = if nq == 0 {
-            let n_allowed = match allow_slice {
+            let n_allowed = match allow_owned.as_deref() {
                 Some(s) => {
                     let mut seen: std::collections::HashSet<u64> =
                         std::collections::HashSet::with_capacity(s.len());
@@ -511,22 +548,23 @@ impl IdMapIndex {
         })
     }
 
-    fn prepare(&self) {
-        self.inner.prepare();
+    fn prepare(&self, py: Python<'_>) {
+        py.detach(|| self.inner.prepare());
     }
 
     /// Serialize the index and id-map side-tables to a `.tvim` file.
-    fn write(&self, path: &str) -> PyResult<()> {
-        self.inner
-            .write(path)
+    fn write(&self, py: Python<'_>, path: &str) -> PyResult<()> {
+        py.detach(|| self.inner.write(path))
             .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))
     }
 
     /// Load an `IdMapIndex` from a `.tvim` file previously written by
     /// [`IdMapIndex.write`].
     #[classmethod]
-    fn load(_cls: &Bound<PyType>, path: &str) -> PyResult<Self> {
-        let inner = turbovec_core::IdMapIndex::load(path)
+    fn load(cls: &Bound<PyType>, path: &str) -> PyResult<Self> {
+        let inner = cls
+            .py()
+            .detach(|| turbovec_core::IdMapIndex::load(path))
             .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))?;
         Ok(Self { inner })
     }

--- a/turbovec-python/tests/test_gil_release.py
+++ b/turbovec-python/tests/test_gil_release.py
@@ -75,12 +75,13 @@ def _progress_during(fn):
     margin = (t1 - t0) * 0.25
     lo, hi = t0 + margin, t1 - margin
     inside = [n for (ts, n) in samples if lo < ts < hi]
-    return (inside[-1] - inside[0]) if len(inside) >= 2 else 0
+    iters = (inside[-1] - inside[0]) if len(inside) >= 2 else 0
+    return iters, t1 - t0
 
 
 def test_background_thread_progresses_during_search(index, vectors):
     queries = vectors[:4096]
-    iters = _progress_during(lambda: index.search(queries, 100))
+    iters, _ = _progress_during(lambda: index.search(queries, 100))
     assert iters > 1000, (
         f"background thread made only {iters} iterations mid-search: "
         "the binding did not release the GIL"
@@ -90,10 +91,46 @@ def test_background_thread_progresses_during_search(index, vectors):
 def test_background_thread_progresses_during_add(vectors):
     idx = IdMapIndex(dim=DIM, bit_width=4)
     ids = np.arange(N, dtype=np.uint64)
-    iters = _progress_during(lambda: idx.add_with_ids(vectors, ids))
+    iters, _ = _progress_during(lambda: idx.add_with_ids(vectors, ids))
     assert iters > 1000, (
         f"background thread made only {iters} iterations mid-add: "
         "the binding did not release the GIL"
+    )
+
+
+def test_len_blocked_on_add_does_not_hold_gil(vectors):
+    """len() landing during an in-flight add blocks until the write
+    lock frees (writes serialize), but must wait with the GIL released
+    so other Python threads keep running."""
+    idx = IdMapIndex(dim=DIM, bit_width=4)
+    ids = np.arange(N, dtype=np.uint64)
+    errors: list[BaseException] = []
+    started = threading.Event()
+
+    def adder() -> None:
+        try:
+            started.set()
+            idx.add_with_ids(vectors, ids)
+        except BaseException as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+
+    t = threading.Thread(target=adder)
+    t.start()
+    started.wait()
+    time.sleep(0.02)  # let the add reach the core kernel
+    iters, dur = _progress_during(lambda: len(idx))
+    t.join()
+
+    assert not errors, f"add raised: {errors}"
+    assert len(idx) == N
+    if dur < 0.05:
+        pytest.skip(
+            "add finished before len() could block; nothing to measure"
+        )
+    assert iters > 1000, (
+        f"background thread made only {iters} iterations while len() "
+        f"was blocked for {dur * 1000:.0f} ms: the blocked call is "
+        "holding the GIL"
     )
 
 

--- a/turbovec-python/tests/test_gil_release.py
+++ b/turbovec-python/tests/test_gil_release.py
@@ -1,0 +1,160 @@
+"""Regression tests for GIL release in the pyo3 bindings (issue #121).
+
+Long ``search`` / ``add`` / ``prepare`` / ``write`` / ``load`` calls
+detach from the Python runtime (release the GIL) around the
+compute-bound core call, so other Python threads keep running and
+concurrent searches actually overlap. The bindings snapshot
+numpy-borrowed buffers into owned Vecs *before* releasing the GIL, so a
+Python thread mutating an input array mid-call cannot affect (or
+corrupt) the running operation.
+
+Thresholds are deliberately generous for slow CI machines: the
+background-progress tests count iterations strictly inside the middle
+of the call window (excluding the GIL hand-off slices at the call
+boundaries, which occur even without the fix) and assert a small
+absolute floor, not a throughput ratio.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+import numpy as np
+import pytest
+
+from turbovec import IdMapIndex, TurboQuantIndex
+
+N = 200_000
+DIM = 256
+
+
+@pytest.fixture(scope="module")
+def vectors() -> np.ndarray:
+    rng = np.random.default_rng(0)
+    v = rng.standard_normal((N, DIM)).astype(np.float32)
+    v /= np.linalg.norm(v, axis=1, keepdims=True) + 1e-9
+    return v
+
+
+@pytest.fixture(scope="module")
+def index(vectors: np.ndarray) -> TurboQuantIndex:
+    idx = TurboQuantIndex(dim=DIM, bit_width=4)
+    idx.add(vectors)
+    idx.prepare()
+    return idx
+
+
+def _progress_during(fn):
+    """Run ``fn()`` on this thread while a counter thread runs.
+
+    Returns the number of counter iterations whose timestamps fall
+    strictly inside the middle of the call window — the call-boundary
+    GIL hand-off slices (a few ms each, present even when the callee
+    never releases the GIL) are excluded, so without GIL release this
+    is 0.
+    """
+    stop = threading.Event()
+    samples: list[tuple[float, int]] = []
+
+    def counter() -> None:
+        n = 0
+        while not stop.is_set():
+            n += 1
+            if n % 4096 == 0:
+                samples.append((time.perf_counter(), n))
+
+    t = threading.Thread(target=counter)
+    t.start()
+    time.sleep(0.05)  # let the counter thread reach its loop
+    t0 = time.perf_counter()
+    fn()
+    t1 = time.perf_counter()
+    stop.set()
+    t.join()
+
+    margin = (t1 - t0) * 0.25
+    lo, hi = t0 + margin, t1 - margin
+    inside = [n for (ts, n) in samples if lo < ts < hi]
+    return (inside[-1] - inside[0]) if len(inside) >= 2 else 0
+
+
+def test_background_thread_progresses_during_search(index, vectors):
+    queries = vectors[:4096]
+    iters = _progress_during(lambda: index.search(queries, 100))
+    assert iters > 1000, (
+        f"background thread made only {iters} iterations mid-search: "
+        "the binding did not release the GIL"
+    )
+
+
+def test_background_thread_progresses_during_add(vectors):
+    idx = IdMapIndex(dim=DIM, bit_width=4)
+    ids = np.arange(N, dtype=np.uint64)
+    iters = _progress_during(lambda: idx.add_with_ids(vectors, ids))
+    assert iters > 1000, (
+        f"background thread made only {iters} iterations mid-add: "
+        "the binding did not release the GIL"
+    )
+
+
+def test_concurrent_searches_match_serial(index, vectors):
+    queries = vectors[:512]
+    expected_scores, expected_indices = index.search(queries, 10)
+
+    results: dict[int, tuple[np.ndarray, np.ndarray]] = {}
+    errors: list[BaseException] = []
+
+    def worker(slot: int) -> None:
+        try:
+            for _ in range(5):
+                results[slot] = index.search(queries, 10)
+        except BaseException as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"concurrent search raised: {errors}"
+    for slot in range(2):
+        scores, indices = results[slot]
+        np.testing.assert_array_equal(scores, expected_scores)
+        np.testing.assert_array_equal(indices, expected_indices)
+
+
+def test_mutating_query_array_mid_search_is_safe(index, vectors):
+    """A writable query array stomped mid-search must not crash or
+    produce torn results: the binding snapshots the buffer under the
+    GIL, so the result always corresponds to one coherent version of
+    the array (whichever version the snapshot captured)."""
+    queries = vectors[:4096].copy()  # writable
+    mutant = np.ascontiguousarray(vectors[4096:8192])
+
+    expected_original = index.search(queries.copy(), 10)
+    expected_mutant = index.search(mutant.copy(), 10)
+
+    started = threading.Event()
+
+    def mutator() -> None:
+        started.wait()
+        time.sleep(0.01)  # land inside the (much longer) search
+        np.copyto(queries, mutant)
+
+    t = threading.Thread(target=mutator)
+    t.start()
+    started.set()
+    scores, indices = index.search(queries, 10)
+    t.join()
+
+    matches_original = np.array_equal(
+        scores, expected_original[0]
+    ) and np.array_equal(indices, expected_original[1])
+    matches_mutant = np.array_equal(scores, expected_mutant[0]) and np.array_equal(
+        indices, expected_mutant[1]
+    )
+    assert matches_original or matches_mutant, (
+        "search results match neither the original nor the mutated "
+        "query array: the searched buffer was torn mid-call"
+    )

--- a/turbovec-python/tests/test_gil_release.py
+++ b/turbovec-python/tests/test_gil_release.py
@@ -101,35 +101,54 @@ def test_background_thread_progresses_during_add(vectors):
 def test_len_blocked_on_add_does_not_hold_gil(vectors):
     """len() landing during an in-flight add blocks until the write
     lock frees (writes serialize), but must wait with the GIL released
-    so other Python threads keep running."""
-    idx = IdMapIndex(dim=DIM, bit_width=4)
+    so other Python threads keep running.
+
+    The probe is retried up to 3 times: the add's internal rayon
+    fan-out saturates every core, so the scheduler can starve the
+    counter thread for the whole mid-window of a single attempt (~4%
+    of runs on small machines), zeroing the measurement. A real
+    regression (the blocked call holding the GIL) shows zero progress
+    deterministically, so it fails every attempt.
+    """
     ids = np.arange(N, dtype=np.uint64)
-    errors: list[BaseException] = []
-    started = threading.Event()
+    blocked_attempts: list[tuple[int, float]] = []
 
-    def adder() -> None:
-        try:
-            started.set()
-            idx.add_with_ids(vectors, ids)
-        except BaseException as exc:  # pragma: no cover - failure path
-            errors.append(exc)
+    for _ in range(3):
+        idx = IdMapIndex(dim=DIM, bit_width=4)
+        errors: list[BaseException] = []
+        started = threading.Event()
 
-    t = threading.Thread(target=adder)
-    t.start()
-    started.wait()
-    time.sleep(0.02)  # let the add reach the core kernel
-    iters, dur = _progress_during(lambda: len(idx))
-    t.join()
+        def adder() -> None:
+            try:
+                started.set()
+                idx.add_with_ids(vectors, ids)
+            except BaseException as exc:  # pragma: no cover - failure path
+                errors.append(exc)
 
-    assert not errors, f"add raised: {errors}"
-    assert len(idx) == N
-    if dur < 0.05:
-        pytest.skip(
-            "add finished before len() could block; nothing to measure"
-        )
-    assert iters > 1000, (
-        f"background thread made only {iters} iterations while len() "
-        f"was blocked for {dur * 1000:.0f} ms: the blocked call is "
+        t = threading.Thread(target=adder)
+        t.start()
+        started.wait()
+        time.sleep(0.02)  # let the add reach the core kernel
+        iters, dur = _progress_during(lambda: len(idx))
+        t.join()
+
+        assert not errors, f"add raised: {errors}"
+        assert len(idx) == N
+        if dur < 0.05:
+            # add finished before len() could block; inconclusive
+            continue
+        if iters > 1000:
+            return
+        blocked_attempts.append((iters, dur))
+
+    if not blocked_attempts:
+        pytest.skip("add finished before len() could block; nothing to measure")
+    details = ", ".join(
+        f"{iters} iters in {dur * 1000:.0f} ms" for iters, dur in blocked_attempts
+    )
+    raise AssertionError(
+        f"background thread made no mid-window progress while len() was "
+        f"blocked, on every attempt ({details}): the blocked call is "
         "holding the GIL"
     )
 

--- a/turbovec-python/tests/test_gil_release.py
+++ b/turbovec-python/tests/test_gil_release.py
@@ -124,6 +124,71 @@ def test_concurrent_searches_match_serial(index, vectors):
         np.testing.assert_array_equal(indices, expected_indices)
 
 
+def test_search_while_add_both_succeed(vectors):
+    """A search overlapping an add on the same index must not raise:
+    the write lock serializes the add against the search (as the GIL
+    did before GIL release) instead of surfacing pyo3's 'Already
+    borrowed' RuntimeError."""
+    idx = IdMapIndex(dim=DIM, bit_width=4)
+    half = N // 2
+    idx.add_with_ids(vectors[:half], np.arange(half, dtype=np.uint64))
+    idx.prepare()
+    queries = vectors[:512]
+    errors: list[BaseException] = []
+    started = threading.Event()
+
+    def adder() -> None:
+        try:
+            started.set()
+            idx.add_with_ids(
+                vectors[half:], np.arange(half, N, dtype=np.uint64)
+            )
+        except BaseException as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+
+    t = threading.Thread(target=adder)
+    t.start()
+    started.wait()
+    scores, ids = idx.search(queries, 10)  # overlaps the ~0.2 s add
+    t.join()
+
+    assert not errors, f"concurrent add raised: {errors}"
+    assert scores.shape == (512, 10)
+    assert np.all(np.isfinite(scores))
+    assert len(idx) == N
+
+
+def test_two_concurrent_adds_both_succeed(vectors):
+    """Two adds racing on the same index must both land (writes
+    serialize), not fail with a borrow error or lose data."""
+    idx = IdMapIndex(dim=DIM, bit_width=4)
+    half = N // 2
+    errors: list[BaseException] = []
+    barrier = threading.Barrier(2)
+
+    def adder(lo: int, hi: int) -> None:
+        try:
+            barrier.wait()
+            idx.add_with_ids(
+                vectors[lo:hi], np.arange(lo, hi, dtype=np.uint64)
+            )
+        except BaseException as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=adder, args=(0, half)),
+        threading.Thread(target=adder, args=(half, N)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"concurrent adds raised: {errors}"
+    assert len(idx) == N
+    assert 0 in idx and N - 1 in idx
+
+
 def test_mutating_query_array_mid_search_is_safe(index, vectors):
     """A writable query array stomped mid-search must not crash or
     produce torn results: the binding snapshots the buffer under the


### PR DESCRIPTION
Part of #121 — this PR implements the GIL-release half (the issue's headline). The Ctrl-C/SIGINT half, raised in the issue's own follow-up analysis, is deliberately out of scope (see below), so I've used "Part of" rather than "Closes" to keep that tracked remainder from being auto-closed; if you'd rather track the signal work in a fresh issue, this PR then closes #121.

## Root cause

`turbovec-python/src/lib.rs` never released the GIL: every core call (search, add, prepare, write, load) ran with the GIL held for its full duration. Long calls therefore stalled every other Python thread, and concurrent searches from Python serialized completely — even though the core `TurboQuantIndex::search` takes `&self` and documents "safe to call concurrently from multiple threads".

## Fix

Two pieces:

**1. GIL release.** After argument extraction, the compute-bound core call is wrapped in `Python::detach` (pyo3 0.27's name for `allow_threads`, which is deprecated in favor of it).

**2. Concurrency semantics preserved via `RwLock` (frozen pyclass).** Releasing the GIL alone would expose pyo3's runtime borrow checker on overlapping calls: search-during-add raised `RuntimeError("Already mutably borrowed")` and the search was lost; two racing adds lost one add — where pre-fix everything silently serialized and succeeded. Both pyclasses are now `#[pyclass(frozen)]` (all methods take `&self`; pyo3 does no runtime borrow-checking) and hold the core index behind a `std::sync::RwLock`. Contract per index object: **reads (`search`, `prepare`, `write`, `contains`, `len`) run in parallel; a write (`add`/`add_with_ids`/`remove`/`swap_remove`) blocks until it's alone, then succeeds** — the pre-fix serialize-then-succeed outcome, minus the serialization of reads, with no new error surface and no API change.

Locking discipline: locks are acquired **inside** the `detach` closure, so a thread blocked on the lock never holds the GIL (no lock/GIL deadlock cycle: a guard is only ever released from code that doesn't need the GIL to finish). Index-dependent validation (query dim, mask length, allowlist membership, `swap_remove` bounds) moved under the same guard as the core call it protects, keeping check+kernel atomic exactly as the GIL previously made them — a concurrent writer can't invalidate a check between validation and kernel. Lock poisoning is recovered with `PoisonError::into_inner` (the panic already surfaced once as `PanicException`; pre-fix the object stayed usable after it, and still does). Every lock acquisition — including trivial O(1) calls like `__len__` — happens inside `detach`, so a call blocked behind a writer waits with the GIL released and other Python threads keep running.

**Mutation-safety analysis (the issue's caveat):** a `&[f32]` borrowed from a `PyReadonlyArray` can be mutated by another Python thread once the GIL is released — rust-numpy's borrow flags don't stop Python-side writes to a writable array. The current extraction path (post-#175) produces borrowed `PyReadonlyArray` views, not owned copies, so every numpy-borrowed buffer is snapshotted into an owned `Vec` under the GIL before `detach` (exactly one transient copy per input). Validation runs on the snapshot, so the data searched/quantized is exactly the data validated.

Per method (both `TurboQuantIndex` and `IdMapIndex`):

| Method | GIL released? | Lock | Buffer handling |
|---|---|---|---|
| `search` (incl. `mask=` / `allowlist=`) | yes | read, inside detach | queries/mask/allowlist copied to owned `Vec`s under the GIL; dim/mask-len/membership checks under the read guard |
| `add` / `add_with_ids` | yes | write, inside detach | vectors (and ids) copied to owned `Vec`s under the GIL |
| `prepare` | yes | read, inside detach | no borrowed buffers |
| `write` / `load` | yes | read / n.a. (constructor) | only a `&str` path (borrows an immutable Python `str`) |
| `remove` / `swap_remove` | GIL released around the O(1) lock+op | write, inside detach | bounds check and removal under one write guard |
| `contains` / `__contains__` / getters / `__len__` / `__repr__` | GIL released around the O(1) lock+op | read, inside detach | trivial |

## Measured (Apple Silicon, 200k × 256, bit_width=4)

Background pure-Python counter thread, iterations strictly inside the call window (free-running rate ~10k iters/ms):

| Operation | before (main) | after |
|---|---|---|
| `add` 200k×256 (~241 ms) | ~0 mid-call (only a flat ~120k boundary-slice count, invariant across op lengths) | 4,042,192 |
| `search` nq=4096 (~351 ms) | ~0 mid-call (same flat boundary count) | 4,740,129 |
| `prepare` (~144 ms) | ~0 mid-call | 2,843,185 |
| `add_with_ids` (~241 ms) | ~0 mid-call | 4,136,608 |

True concurrent search — 400 single-query searches (single-query so the core's internal rayon fan-out is idle), serial vs 2 threads:

| | serial | 2 threads | speedup |
|---|---|---|---|
| before | 407.6 ms | 412.3 ms | **0.99x** |
| after (detach + RwLock) | 410.5 ms | 210.8 ms | **1.95x** |

Uncontended RwLock overhead is noise-level: single-query search 1.02 vs 1.02 ms/call, `add` 200k×256 241 vs 252 ms, `search` nq=4096 351 vs 343 ms across builds (mixed signs, within run-to-run variance).

(Large *batched* searches show no extra 2-thread speedup in either build — the core already parallelizes across queries with rayon and saturates the machine; the win is for concurrent independent callers, e.g. serving threadpools, exactly the scenario in the issue thread.)

Overlap semantics: search-while-add and two racing adds both complete successfully with correct final `len` (previously: silent serialization on main; borrow `RuntimeError` with a naive GIL release). A thread stomping the writable query array mid-search neither crashes nor perturbs results — output matches the coherent snapshot taken at call entry.

## Tests

New `turbovec-python/tests/test_gil_release.py` (progress probes verified to fail — 0 mid-window iterations — on the unfixed build and pass on the fix; thresholds are generous absolute floors, not ratios, and boundary GIL hand-off slices are excluded so the probe is 0 without the fix even on slow CI):

- `test_background_thread_progresses_during_search`
- `test_background_thread_progresses_during_add`
- `test_concurrent_searches_match_serial`
- `test_search_while_add_both_succeed`
- `test_two_concurrent_adds_both_succeed`
- `test_len_blocked_on_add_does_not_hold_gil`
- `test_mutating_query_array_mid_search_is_safe`

Suites: `cargo test -p turbovec` 162 passed; `cargo check -p turbovec-python` clean (no deprecation warnings); full `python -m pytest turbovec-python/tests/` **466 passed, 0 failed** (459 baseline + 7 new, integration extras installed). New file adds ~3.2 s. Branch rebased onto current main (includes the #187 Windows fsync fix).

## Out of scope (deliberate)

The SIGINT half of #121: releasing the GIL does **not** make long calls Ctrl-C-responsive — the signal handler runs on the main thread, which is still inside the Rust call. Per the issue's own analysis, that requires `PyErr::check_signals` polling inside the core hot loop (a core-crate API/perf decision), which is left as a maintainer call.

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
