### PR TITLE
fix: Windows save failure — fsync through a writable descriptor in atomic_save

### DIFF
--- a/turbovec-python/python/turbovec/_persist.py
+++ b/turbovec-python/python/turbovec/_persist.py
@@ -70,9 +70,11 @@ def atomic_save(index, index_path, payload: Any, sidecar_path) -> None:
     sidecar_tmp = _tmp_path(sidecar_path)
     try:
         # The Rust binding owns the index file handle, so fsync via a
-        # reopened read descriptor (fsync flushes the inode, not the fd).
+        # reopened descriptor (fsync flushes the inode, not the fd). The
+        # handle must be writable: on Windows, fsync calls _commit, which
+        # rejects read-only descriptors with EBADF.
         index.write(index_tmp)
-        with open(index_tmp, "rb") as f:
+        with open(index_tmp, "rb+") as f:
             os.fsync(f.fileno())
         with open(sidecar_tmp, "w") as f:
             f.write(payload_str)


### PR DESCRIPTION
## What

One-line behavior fix in `_persist.atomic_save` (from #180): the reopened descriptor used to fsync the index temp file is now opened `rb+` instead of `rb`.

## Why

`os.fsync` on Windows calls `_commit`, which rejects read-only descriptors with `EBADF`. Every integration save on Windows failed with `OSError: [Errno 9] Bad file descriptor` at `_persist.py:76` — all agno/haystack/langchain/llama_index persistence tests are red on windows-latest CI for main (runs on the #181 and #184 merge commits). POSIX accepts fsync on read-only descriptors, which is why this passed on macOS/Linux locally and in review.

## Verification

- With the fix, all persistence-affected suites pass locally (test_agno + test_haystack + test_persist: 180 passed).
- Windows regression coverage is the existing persistence test suite on windows-latest CI — this PR's own CI run is the proof; **do not merge until Windows CI is green**.
- Note: the Rust-side `index.write` already fsyncs its own data internally since #118/#173, so this reopened fsync is inode-level defense-in-depth, not the primary durability mechanism.

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)