### PR TITLE
fix: bindings ergonomics — __version__, FileNotFoundError on missing load, RAYON_NUM_THREADS clamp (#153, #156, #158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,8 +147,12 @@ appears under each surface it touches.
   the request to 4x the available parallelism with a `RuntimeWarning`
   naming the variable and the cap. When the variable is unset (or `0`,
   rayon's "auto"), nothing changes — rayon's lazy auto-sized pool is
-  preserved exactly, and honorable values keep producing byte-identical
-  results. (#158)
+  preserved exactly, and values at or under the cap keep producing
+  byte-identical results. Note: an explicitly-set value above the cap
+  that previously happened to work unclamped (e.g. `2000` under a
+  permissive OS thread limit) is now clamped too and emits the warning;
+  search/save results are byte-identical either way, only the thread
+  count changes. (#158)
 - **The bindings release the GIL around compute-bound core calls.**
   `TurboQuantIndex` / `IdMapIndex` `search`, `add` / `add_with_ids`,
   `prepare`, `write`, and `load` previously held the GIL for their full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,15 @@ appears under each surface it touches.
   behavior change. (#134)
 ### turbovec — Python package
 
+#### Added
+
+- **`turbovec.__version__`.** The package now exposes the standard
+  version attribute (resolved lazily via PEP 562 from the installed
+  dist metadata, so `import turbovec` stays sub-millisecond —
+  importing `importlib.metadata` eagerly would multiply the import
+  time by ~25x). Falls back to `"0.0.0.dev0"` when no dist metadata
+  is installed. (#153)
+
 #### Fixed
 
 - **Optional-dependency floors now match what the integrations actually
@@ -121,6 +130,25 @@ appears under each surface it touches.
   with `getattr` sentinels, keeping the honest `>=0.11` floor while
   still supporting `TEXT_MATCH_INSENSITIVE`/`NOT` where the installed
   version provides them. (#160)
+- **Loading a missing index file raises `FileNotFoundError`.**
+  `TurboQuantIndex.load` / `IdMapIndex.load` previously raised a bare
+  `OSError` for a nonexistent path, so `except FileNotFoundError:`
+  never matched — and the LlamaIndex `from_persist_path` was the one
+  integration load that surfaced it (the other three open their JSON
+  side-car with Python's `open()` first). The binding now maps
+  `io::ErrorKind::NotFound` to `FileNotFoundError` and appends the
+  offending path to every load error message; an existing-but-corrupt
+  file still raises the plain `OSError` family. (#156)
+- **An over-large `RAYON_NUM_THREADS` no longer makes the first
+  `add`/`search` die with an uncatchable `PanicException`.** A value
+  above the OS thread limit (`ulimit -u`) made rayon's lazy global
+  thread-pool construction fail (EAGAIN) and panic. The module now
+  builds the pool at import time when the variable is set, clamping
+  the request to 4x the available parallelism with a `RuntimeWarning`
+  naming the variable and the cap. When the variable is unset (or `0`,
+  rayon's "auto"), nothing changes — rayon's lazy auto-sized pool is
+  preserved exactly, and honorable values keep producing byte-identical
+  results. (#158)
 - **The bindings release the GIL around compute-bound core calls.**
   `TurboQuantIndex` / `IdMapIndex` `search`, `add` / `add_with_ids`,
   `prepare`, `write`, and `load` previously held the GIL for their full

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,7 @@ dependencies = [
  "numpy",
  "pyo3",
  "pyo3-build-config",
+ "rayon",
  "turbovec",
 ]
 

--- a/turbovec-python/Cargo.toml
+++ b/turbovec-python/Cargo.toml
@@ -12,6 +12,9 @@ crate-type = ["cdylib"]
 turbovec-core = { package = "turbovec", path = "../turbovec" }
 pyo3 = { version = "0.27.0", features = ["extension-module", "abi3-py39"] }
 numpy = "0.27.0"
+# Same major as the core's dep, so both resolve to one rayon-core and
+# the pool built at module init is the pool the kernels use.
+rayon = "1.10"
 
 [build-dependencies]
 pyo3-build-config = "0.27.0"

--- a/turbovec-python/python/turbovec/__init__.py
+++ b/turbovec-python/python/turbovec/__init__.py
@@ -1,3 +1,21 @@
 from ._turbovec import IdMapIndex, TurboQuantIndex
 
-__all__ = ["IdMapIndex", "TurboQuantIndex"]
+__all__ = ["IdMapIndex", "TurboQuantIndex", "__version__"]
+
+
+def __getattr__(name: str) -> str:
+    # PEP 562: resolve __version__ lazily on first access. Importing
+    # importlib.metadata costs ~20 ms — an order of magnitude more than
+    # the rest of `import turbovec` — so it must not run at import time.
+    if name == "__version__":
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            v = version("turbovec")
+        except PackageNotFoundError:
+            # Source tree without installed dist metadata (e.g. the
+            # extension built in place); an obviously-dev marker.
+            v = "0.0.0.dev0"
+        globals()["__version__"] = v  # cache: __getattr__ never fires again
+        return v
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/turbovec-python/python/turbovec/__init__.py
+++ b/turbovec-python/python/turbovec/__init__.py
@@ -19,3 +19,9 @@ def __getattr__(name: str) -> str:
         globals()["__version__"] = v  # cache: __getattr__ never fires again
         return v
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list:
+    # PEP 562 companion: advertise the lazy attribute before its first
+    # access (the set-union keeps it single once cached in globals()).
+    return sorted(set(globals()) | {"__version__"})

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -158,6 +158,21 @@ fn validate_queries(values: &[f32], dim: usize) -> PyResult<()> {
     Ok(())
 }
 
+/// Map an `io::Error` from `load` to the Python exception a plain
+/// `open()` would raise for the same failure: a missing file becomes
+/// `FileNotFoundError` (so `except FileNotFoundError:` works, matching
+/// the JSON side-car handling in the integrations), anything else stays
+/// `OSError`. The path is appended because the io::Error alone doesn't
+/// name the file.
+fn load_err(path: &str, e: std::io::Error) -> PyErr {
+    let msg = format!("{e}: {path}");
+    if e.kind() == std::io::ErrorKind::NotFound {
+        pyo3::exceptions::PyFileNotFoundError::new_err(msg)
+    } else {
+        pyo3::exceptions::PyIOError::new_err(msg)
+    }
+}
+
 /// Read-lock an index, recovering from poisoning. A panic that escaped
 /// a previous call has already surfaced to Python as a PanicException;
 /// before the GIL-release change such a panic likewise left the object
@@ -325,7 +340,7 @@ impl TurboQuantIndex {
         let inner = cls
             .py()
             .detach(|| turbovec_core::TurboQuantIndex::load(path))
-            .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))?;
+            .map_err(|e| load_err(path, e))?;
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
         })
@@ -481,9 +496,10 @@ impl IdMapIndex {
     /// Search for the top-`k` nearest external ids for each query.
     ///
     /// `allowlist`, when given, is a `uint64` array of external ids; the
-    /// returned top-`k` is restricted to ids in this list. The returned
-    /// result count per query is `min(k, len(allowlist))` (after
-    /// de-duplication).
+    /// returned top-`k` is restricted to ids in this list. The allowlist
+    /// is deduplicated: the returned result count per query is
+    /// `min(k, number of unique ids in allowlist)`, so repeated ids
+    /// don't widen the result.
     ///
     /// Returns `(scores, ids)` as `(nq, effective_k)` arrays, `ids` typed
     /// `uint64`. Raises `ValueError` for an empty allowlist and `KeyError`
@@ -625,7 +641,7 @@ impl IdMapIndex {
         let inner = cls
             .py()
             .detach(|| turbovec_core::IdMapIndex::load(path))
-            .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))?;
+            .map_err(|e| load_err(path, e))?;
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
         })
@@ -664,8 +680,79 @@ impl IdMapIndex {
     }
 }
 
+/// Cap applied to an explicit `RAYON_NUM_THREADS` request. Threads
+/// beyond a small multiple of the hardware parallelism add no
+/// throughput for turbovec's CPU-bound kernels, and a request past the
+/// OS thread limit (`ulimit -u`) makes rayon's lazy pool construction
+/// panic — surfacing as an opaque, uncatchable `PanicException` on the
+/// first `add`/`search` (issue #158). 4x leaves room for deliberate
+/// oversubscription; 1024 is the fallback when the hardware
+/// parallelism cannot be determined.
+fn rayon_thread_cap() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get().saturating_mul(4))
+        .unwrap_or(1024)
+}
+
+/// Build the global rayon pool eagerly at module init when
+/// `RAYON_NUM_THREADS` is set, clamping over-large values to
+/// [`rayon_thread_cap`] (with a `RuntimeWarning` naming the variable).
+///
+/// When the variable is unset — or holds a value rayon itself would
+/// ignore (unparseable) or treat as "auto" (`0`) — this does nothing,
+/// so rayon's lazy auto-sized initialization is preserved exactly.
+/// Values at or under the cap eagerly build the pool with the same
+/// thread count rayon's lazy path would have chosen, so results are
+/// unchanged. Pool-build failure never fails the import.
+fn init_rayon_pool(py: Python<'_>) -> PyResult<()> {
+    let Ok(raw) = std::env::var("RAYON_NUM_THREADS") else {
+        return Ok(());
+    };
+    // Mirror rayon's own parsing (plain `usize::from_str`, no trim):
+    // anything rayon would ignore, we ignore; 0 means "auto" to rayon.
+    let Ok(requested) = raw.parse::<usize>() else {
+        return Ok(());
+    };
+    if requested == 0 {
+        return Ok(());
+    }
+    let cap = rayon_thread_cap();
+    let n = requested.min(cap);
+    if n < requested {
+        let warnings = py.import("warnings")?;
+        warnings.call_method1(
+            "warn",
+            (
+                format!(
+                    "RAYON_NUM_THREADS={requested} exceeds turbovec's thread cap \
+                     of {cap} (4x available parallelism); using {cap} threads",
+                ),
+                py.get_type::<pyo3::exceptions::PyRuntimeWarning>(),
+            ),
+        )?;
+    }
+    if rayon::ThreadPoolBuilder::new()
+        .num_threads(n)
+        .build_global()
+        .is_err()
+    {
+        // Either another extension already initialized the global pool
+        // (harmless — its pool wins) or thread spawn failed even at the
+        // clamped count. Retry once at the hardware default; if that
+        // also fails, leave rayon to its lazy init. Import never fails.
+        let default_n = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
+        let _ = rayon::ThreadPoolBuilder::new()
+            .num_threads(default_n)
+            .build_global();
+    }
+    Ok(())
+}
+
 #[pymodule]
 fn _turbovec(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    init_rayon_pool(m.py())?;
     m.add_class::<TurboQuantIndex>()?;
     m.add_class::<IdMapIndex>()?;
     Ok(())

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -158,12 +158,12 @@ fn validate_queries(values: &[f32], dim: usize) -> PyResult<()> {
     Ok(())
 }
 
-/// Map an `io::Error` from `load` to the Python exception a plain
-/// `open()` would raise for the same failure: a missing file becomes
-/// `FileNotFoundError` (so `except FileNotFoundError:` works, matching
-/// the JSON side-car handling in the integrations), anything else stays
-/// `OSError`. The path is appended because the io::Error alone doesn't
-/// name the file.
+/// Map an `io::Error` from `load` to Python: `ErrorKind::NotFound`
+/// becomes `FileNotFoundError` (so `except FileNotFoundError:` works,
+/// matching what the integrations' Python-side `open()` of their JSON
+/// side-cars raises for a missing path); every other kind — including
+/// permission errors — stays plain `OSError`, as before. The path is
+/// appended because the io::Error alone doesn't name the file.
 fn load_err(path: &str, e: std::io::Error) -> PyErr {
     let msg = format!("{e}: {path}");
     if e.kind() == std::io::ErrorKind::NotFound {
@@ -725,7 +725,7 @@ fn init_rayon_pool(py: Python<'_>) -> PyResult<()> {
             (
                 format!(
                     "RAYON_NUM_THREADS={requested} exceeds turbovec's thread cap \
-                     of {cap} (4x available parallelism); using {cap} threads",
+                     of {cap} (4x available parallelism); capping at {cap} threads",
                 ),
                 py.get_type::<pyo3::exceptions::PyRuntimeWarning>(),
             ),

--- a/turbovec-python/tests/test_id_map.py
+++ b/turbovec-python/tests/test_id_map.py
@@ -109,9 +109,21 @@ def test_write_and_load_round_trip(tmp_path):
         assert got[0, 0] == id_val
 
 
-def test_load_rejects_nonexistent_file():
-    with pytest.raises(IOError):
+def test_load_missing_file_raises_file_not_found():
+    # Issue #156: a missing file must raise FileNotFoundError (as
+    # Python's open() would), not a bare OSError.
+    with pytest.raises(FileNotFoundError):
         IdMapIndex.load("/nonexistent/path/does-not-exist.tvim")
+
+
+def test_load_corrupt_file_stays_plain_oserror(tmp_path):
+    # Pin: only the missing-file case narrows to FileNotFoundError; an
+    # existing-but-corrupt file keeps raising the OSError family.
+    p = tmp_path / "corrupt.tvim"
+    p.write_bytes(b"garbage, not a tvim file")
+    with pytest.raises(OSError) as exc_info:
+        IdMapIndex.load(str(p))
+    assert not isinstance(exc_info.value, FileNotFoundError)
 
 
 @pytest.mark.parametrize("bad_bit_width", [0, 1, 5, 8])

--- a/turbovec-python/tests/test_index.py
+++ b/turbovec-python/tests/test_index.py
@@ -97,6 +97,23 @@ def test_save_load_roundtrip(tmp_path):
     np.testing.assert_allclose(s_orig, s_load, rtol=1e-5)
 
 
+def test_load_missing_file_raises_file_not_found():
+    # Issue #156: a missing file must raise FileNotFoundError (as
+    # Python's open() would), not a bare OSError.
+    with pytest.raises(FileNotFoundError):
+        TurboQuantIndex.load("/nonexistent/path/does-not-exist.tv")
+
+
+def test_load_corrupt_file_stays_plain_oserror(tmp_path):
+    # Pin: only the missing-file case narrows to FileNotFoundError; an
+    # existing-but-corrupt file keeps raising the OSError family.
+    p = tmp_path / "corrupt.tv"
+    p.write_bytes(b"garbage, not a tv file")
+    with pytest.raises(OSError) as exc_info:
+        TurboQuantIndex.load(str(p))
+    assert not isinstance(exc_info.value, FileNotFoundError)
+
+
 def test_prepare_is_idempotent():
     idx = TurboQuantIndex(dim=64, bit_width=4)
     idx.add(unit_vectors(20, 64))

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -165,6 +165,14 @@ def test_persist_and_from_persist_path_roundtrip(tmp_path):
     assert {n.get_content() for n in result.nodes} == {"one", "two", "three"}
 
 
+def test_from_persist_path_missing_raises_file_not_found(tmp_path):
+    # Issue #156: `from_persist_path` loads the `.tvim` via the binding
+    # first, so a missing persist path must raise FileNotFoundError like
+    # the other integrations (which Python-open() their JSON first do).
+    with pytest.raises(FileNotFoundError):
+        TurboQuantVectorStore.from_persist_path(str(tmp_path / "missing.json"))
+
+
 def test_failed_persist_preserves_previous_store(tmp_path):
     # Regression test for #159: a persist that fails mid-serialization
     # (non-JSON-serializable node metadata) must not destroy a previously

--- a/turbovec-python/tests/test_rayon_env.py
+++ b/turbovec-python/tests/test_rayon_env.py
@@ -1,0 +1,95 @@
+"""RAYON_NUM_THREADS handling at module init (issue #158).
+
+Before the fix, a value above the OS thread limit (``ulimit -u``) made
+rayon's lazy global-pool construction fail with EAGAIN, surfacing as an
+uncatchable ``PanicException`` ("The global thread pool has not been
+initialized") on the first ``add``/``search``. The module now clamps an
+explicit request to 4x the available parallelism at import time.
+
+The rayon pool is process-global and built at most once, so every
+scenario runs in a fresh subprocess.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+# The probe value must exceed the clamp (4x cores) for the clamp path to
+# engage; on any realistic machine/CI runner it does.
+_HUGE = "100000"
+_CAP = 4 * (os.cpu_count() or 1)
+
+_ADD_SEARCH_PROBE = """
+import numpy as np, turbovec
+rng = np.random.default_rng(7)
+idx = turbovec.TurboQuantIndex(dim=16)
+idx.add(rng.random((64, 16), dtype=np.float32))
+scores, ids = idx.search(rng.random((2, 16), dtype=np.float32), 3)
+print("OK", ids.tolist())
+"""
+
+_WARNINGS_PROBE = """
+import warnings
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    import turbovec
+print([str(w.message) for w in caught])
+"""
+
+
+def _run(probe: str, rayon_num_threads: str | None) -> subprocess.CompletedProcess:
+    env = {k: v for k, v in os.environ.items() if k != "RAYON_NUM_THREADS"}
+    if rayon_num_threads is not None:
+        env["RAYON_NUM_THREADS"] = rayon_num_threads
+    return subprocess.run(
+        [sys.executable, "-W", "ignore", "-c", probe],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+
+
+def test_huge_rayon_num_threads_does_not_panic():
+    # Clean behavior contract: either the clamped pool works, or a
+    # clear error names RAYON_NUM_THREADS — never a PanicException.
+    # (Whether the *unfixed* build panics here depends on the OS thread
+    # limit; the fixed build never attempts the oversized spawn at all.)
+    res = _run(_ADD_SEARCH_PROBE, _HUGE)
+    assert "PanicException" not in res.stderr, res.stderr
+    assert "panicked" not in res.stderr, res.stderr
+    if res.returncode == 0:
+        assert "OK" in res.stdout
+    else:
+        assert "RAYON_NUM_THREADS" in (res.stderr + res.stdout)
+
+
+@pytest.mark.skipif(
+    _CAP >= int(_HUGE),
+    reason="machine so wide the probe value is under the clamp",
+)
+def test_huge_rayon_num_threads_warns_naming_the_variable():
+    res = _run(_WARNINGS_PROBE, _HUGE)
+    assert res.returncode == 0, res.stderr
+    assert "RAYON_NUM_THREADS" in res.stdout, res.stdout
+
+
+def test_small_rayon_num_threads_matches_unset_results():
+    # Pin: values rayon could always honor stay byte-identical with the
+    # eager-init path (same thread count rayon's lazy path would pick).
+    base = _run(_ADD_SEARCH_PROBE, None)
+    two = _run(_ADD_SEARCH_PROBE, "2")
+    assert base.returncode == 0, base.stderr
+    assert two.returncode == 0, two.stderr
+    assert base.stdout == two.stdout
+
+
+def test_unset_and_zero_emit_no_warning():
+    # Pin: unset and "0" (rayon's "auto") take the untouched lazy path.
+    for value in (None, "0"):
+        res = _run(_WARNINGS_PROBE, value)
+        assert res.returncode == 0, res.stderr
+        assert "RAYON_NUM_THREADS" not in res.stdout, (value, res.stdout)

--- a/turbovec-python/tests/test_version.py
+++ b/turbovec-python/tests/test_version.py
@@ -14,8 +14,14 @@ def test_version_attribute_is_pep440_ish_string():
     assert re.match(r"^\d+(\.\d+)*", turbovec.__version__)
 
 
-def test_version_is_in_all():
+def test_version_is_in_all_and_dir():
     assert "__version__" in turbovec.__all__
+    # The PEP 562 __dir__ companion must advertise the lazy attribute,
+    # and its set-union must keep the entry single once the value is
+    # cached in module globals.
+    listing = dir(turbovec)
+    assert "__version__" in listing
+    assert listing.count("__version__") == 1
 
 
 def test_version_matches_dist_metadata():

--- a/turbovec-python/tests/test_version.py
+++ b/turbovec-python/tests/test_version.py
@@ -1,0 +1,28 @@
+"""Regression tests for ``turbovec.__version__`` (issue #153)."""
+from __future__ import annotations
+
+import re
+from importlib.metadata import PackageNotFoundError, version
+
+import turbovec
+
+
+def test_version_attribute_is_pep440_ish_string():
+    assert isinstance(turbovec.__version__, str)
+    # PEP 440 release segment: N(.N)*, optionally followed by pre/dev
+    # suffixes ("0.8.0", "0.9.0rc1", "0.0.0.dev0" all match).
+    assert re.match(r"^\d+(\.\d+)*", turbovec.__version__)
+
+
+def test_version_is_in_all():
+    assert "__version__" in turbovec.__all__
+
+
+def test_version_matches_dist_metadata():
+    try:
+        expected = version("turbovec")
+    except PackageNotFoundError:
+        # Source tree without installed dist metadata: the documented
+        # fallback marker.
+        expected = "0.0.0.dev0"
+    assert turbovec.__version__ == expected

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -197,8 +197,9 @@ impl IdMapIndex {
     /// Search restricted to the given `allowlist` of external ids.
     ///
     /// `allowlist`, when `Some`, restricts the returned top-`k` to ids in the
-    /// allowlist. The effective result count per query is
-    /// `min(k, allowlist.len())` (after de-duplication).
+    /// allowlist. The allowlist is deduplicated: the effective result count
+    /// per query is `min(k, number of unique ids in allowlist)`, so repeated
+    /// ids don't widen the result.
     ///
     /// Panics if `allowlist` is empty or contains an id not currently
     /// present in the index. Duplicate ids in the allowlist are accepted


### PR DESCRIPTION
Bindings-ergonomics lane: three issues plus one docstring correction carried over from the docs review. All four were reproduced on `main` before fixing; every behavioral claim below was verified by execution against both the pre-fix and post-fix builds.

## #153 — no `turbovec.__version__`

**Root cause:** `turbovec/__init__.py` only re-exported the two index classes; the version was reachable solely via `importlib.metadata`.

**Repro on main:** `python -c "import turbovec; turbovec.__version__"` → `AttributeError: module 'turbovec' has no attribute '__version__'`.

**Fix:** PEP 562 module-level `__getattr__` resolving `__version__` lazily from the installed dist metadata, caching in module globals, with a `"0.0.0.dev0"` fallback when no dist metadata is present. `"__version__"` added to `__all__`, and the PEP 562 companion `__dir__` advertises it, so `'__version__' in dir(turbovec)` is true before first access.

**Why lazy rather than the eager form from the issue:** measured with `-X importtime`, `import turbovec` on main is ~0.7–0.9 ms; importing `importlib.metadata` eagerly costs ~17–19 ms — a ~25x regression of the fast import the issue explicitly praised. The lane's threshold for switching to the lazy variant was ~10 ms, so the lazy variant it is. Post-fix warm import: ~0.8 ms (unchanged); first `__version__` access pays the metadata cost once.

**Noted, not addressed:** the issue's secondary observation about broad `except ImportError` in the integration import guards is lower-confidence and out of scope for this lane; left unfixed deliberately.

## #156 — `load()` raises bare `OSError` for a missing file

**Root cause:** both `load` classmethods in `turbovec-python/src/lib.rs` mapped every `std::io::Error` from the core (which returns `std::io::Result` — the `ErrorKind` survives intact) to `PyIOError`. LlamaIndex's `from_persist_path` loads the `.tvim` through the binding *before* opening its JSON side-car, so it was the one integration load surfacing the bare `OSError`; the other three `open()` their JSON first and got Python's `FileNotFoundError` for free.

**Repro on main:**
- `IdMapIndex.load("/nonexistent/nope.tvim")` → `OSError: No such file or directory (os error 2)` (same for `TurboQuantIndex.load`)
- llama `from_persist_path(<nonexistent>)` → `OSError`, while haystack / langchain / agno → `FileNotFoundError`

**Fix (at the source, no integration changes):** a small `load_err(path, e)` helper maps `io::ErrorKind::NotFound` → `FileNotFoundError`, everything else stays `PyIOError`, and the offending path is appended to the message (the io::Error alone never named the file). No core change needed — the core `load`s return `std::io::Result`, so no error information was erased.

**Verified post-fix:** both classes raise `FileNotFoundError: No such file or directory (os error 2): /nonexistent/nope.tvim`; llama `from_persist_path` now raises `FileNotFoundError` with **zero changes to `llama_index.py`**; an existing-but-corrupt file still raises plain `OSError` ("not a TVIM file: wrong magic: <path>") — pinned by test so the narrowing can't overreach.

## #158 — huge `RAYON_NUM_THREADS` → uncatchable `PanicException` on first `add`

**Root cause:** rayon builds its global pool lazily on first use, honoring `RAYON_NUM_THREADS` verbatim. A value above the OS thread limit (`ulimit -u`) makes the spawn fail with EAGAIN inside rayon, which panics — surfacing to Python as an uncatchable `pyo3_runtime.PanicException: The global thread pool has not been initialized.` on the first `add`/`search`.

**Repro on main (locally, macOS, `ulimit -u` = 6000):** `RAYON_NUM_THREADS=100000 python -c "...add..."` → `PanicException ... ThreadPoolBuildError { kind: IOError(Os { code: 35, kind: WouldBlock, ... }) }`. Same failure class as the issue's Linux box.

**Fix:** the `#[pymodule]` init eagerly builds the global pool when `RAYON_NUM_THREADS` is set, clamping the request to **4x `available_parallelism()`** (fallback 1024 if undetectable) and emitting a `RuntimeWarning` naming the variable and the cap when it clamps. Cap rationale: threads beyond a small multiple of hardware parallelism add no throughput for CPU-bound quantization/search kernels but can cross the OS thread limit; 4x preserves deliberate oversubscription. Parsing mirrors rayon's own (`usize::from_str`, no trim): unset, `0` ("auto" to rayon), and unparseable values take the untouched lazy path. Pool-build failure never fails the import (retry once at the hardware default, then leave rayon to lazy init). `rayon = "1.10"` added as a direct dependency — same requirement as the core's, resolving to the single `rayon-core` in the lockfile, so the pool built at init is the pool the kernels use.

**Behavior matrix (verified by execution; fixed-seed save-file SHA-256 + search-result hash, main wheel vs this branch):**

| `RAYON_NUM_THREADS` | main | this branch |
|---|---|---|
| unset | works | identical hashes, no warning |
| `0` | works | identical hashes, no warning |
| `1` | works | identical hashes |
| `2` | works | identical hashes |
| `2000` | works (unclamped) | identical hashes — **now clamped to 4x cores, with the RuntimeWarning** |
| `5000` | works (unclamped) | identical hashes — **now clamped to 4x cores, with the RuntimeWarning** |
| `100000` | **PanicException on first `add`** | works — clamped to 4x cores, `RuntimeWarning: RAYON_NUM_THREADS=100000 exceeds turbovec's thread cap of 56 (4x available parallelism); capping at 56 threads` |

**Behavior-change disclosure:** any explicitly-set value *above the cap* is now clamped — including mid-range values like `2000`/`5000` that previously ran unclamped when the OS thread limit allowed. Search/save results are byte-identical either way (verified above); the observable differences are the thread count and the new `RuntimeWarning`. The CHANGELOG bullet states this explicitly.

**Warnings-as-errors note:** under `python -W error::RuntimeWarning` (or pytest `filterwarnings = error`), an oversized `RAYON_NUM_THREADS` makes `import turbovec` raise the `RuntimeWarning` at import — standard import-time-warning semantics: it is a clean, catchable exception, and re-importing after suppressing/catching the warning works (verified by execution).

Composability note: this change is orthogonal to any future fork-handling work (parked D8) — it adds no fork handlers or at-fork logic, only an optional eager `build_global` at module init.

## Docstring correction (carried from the docs review)

`IdMapIndex.search`'s pyo3 docstring described the allowlist result width as ``min(k, len(allowlist))`` "(after de-duplication)". Verified by execution: a dup-heavy allowlist of length 6 with 2 unique ids and `k=5` returns shape `(nq, 2)` — the width is `min(k, number of unique ids)`, which the old wording's `len(allowlist)` (= 6 → predicts width 5) misstates. Reworded to match the actual semantics and `docs/api.md`'s phrasing from the #170/#177 docs work. The same misstatement lived one layer down in the core rustdoc (`turbovec/src/id_map.rs`, `search_with_allowlist`) — fixed there too, completing the same docstring family in one pass; that change is comment-only, no behavior. No CHANGELOG entry (docs are steady-state).

## Tests (each verified to fail on the unfixed build, except the pins)

New/changed in `turbovec-python/tests/`:

- `test_version.py::test_version_attribute_is_pep440_ish_string` — fails on main (`AttributeError`)
- `test_version.py::test_version_is_in_all_and_dir` (also checks the `__dir__` advertisement) — fails on main
- `test_version.py::test_version_matches_dist_metadata` — fails on main
- `test_index.py::test_load_missing_file_raises_file_not_found` — fails on main (bare `OSError`)
- `test_index.py::test_load_corrupt_file_stays_plain_oserror` — pin (passes on both, guards against overreach)
- `test_id_map.py::test_load_missing_file_raises_file_not_found` (tightened from the old `IOError` assertion) — fails on main
- `test_id_map.py::test_load_corrupt_file_stays_plain_oserror` — pin
- `test_llama_index.py::test_from_persist_path_missing_raises_file_not_found` — fails on main
- `test_rayon_env.py` (subprocess-based — the pool is process-global):
  - `test_huge_rayon_num_threads_does_not_panic` — fails on main wherever 100000 exceeds the OS thread limit (verified locally on macOS; Linux CI has the issue's original constraint). On the fixed build it is platform-independent: the oversized spawn is never attempted.
  - `test_huge_rayon_num_threads_warns_naming_the_variable` — fails on main on **every** platform (no warning is ever emitted there); skips cleanly on a hypothetical ≥25k-core machine where 100000 wouldn't exceed the cap.
  - `test_small_rayon_num_threads_matches_unset_results` — pin (byte-identical results for honorable values)
  - `test_unset_and_zero_emit_no_warning` — pin (lazy path untouched)

Verified locally: all 12 pass on this branch; the 8 non-pin tests fail on a wheel built from main sources.

## Suites

- `cargo test -p turbovec`: **162 passed, 0 failed**
- `cargo check -p turbovec-python`: clean, **0 warnings** (keeps the #186 standard); `cargo fmt --check` clean
- Full `pytest turbovec-python/tests/` in a scratch venv (wheel built with maturin): **477 passed, 0 failed** (466 baseline + 11 net new)

Closes #153
Closes #156
Closes #158

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
