### PR TITLE
fix: raise understated optional-dependency floors; harden llama-index filter dispatch (issue #160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,9 +108,10 @@ appears under each surface it touches.
   haystack-ai below 2.1.0 was unimportable next to our integration, below
   2.16.0 lacked `ByteStream.to_dict`/`from_dict` (blob persistence), and
   below 2.23.0 could not serialize a pipeline containing the store;
-  agno below 2.5.4 rejected the `id`/`name`/`description`/
-  `similarity_threshold` kwargs the store passes to `VectorDb.__init__`,
-  so every construction failed. (#160)
+  agno below 2.5.4 rejects the `similarity_threshold` kwarg the store
+  passes to `VectorDb.__init__` (and below 2.2.0 all of the
+  `id`/`name`/`description` kwargs too), so every construction failed.
+  (#160)
 - **LlamaIndex `ALL`/`ANY` metadata filters no longer crash on
   llama-index-core 0.11.x–0.12.5.** The operator dispatch referenced
   `FilterOperator.TEXT_MATCH_INSENSITIVE` (added in llama-index-core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,35 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **Optional-dependency floors now match what the integrations actually
+  need.** Three of the four extras declared minimums whose APIs the
+  integration code relies on did not exist yet, so `pip install
+  turbovec[haystack]`/`[agno]` could resolve to versions that crash on
+  import or construction. Empirically verified floors (lowest version
+  where the full per-integration test file passes):
+
+  | extra | old floor | new floor |
+  |---|---|---|
+  | `langchain` | `langchain-core>=0.3` | unchanged (verified honest) |
+  | `llama-index` | `llama-index-core>=0.11` | unchanged (see next bullet) |
+  | `haystack` | `haystack-ai>=2.0` | `haystack-ai>=2.23.0` |
+  | `agno` | `agno>=2.0` | `agno>=2.5.4` |
+
+  haystack-ai below 2.1.0 was unimportable next to our integration, below
+  2.16.0 lacked `ByteStream.to_dict`/`from_dict` (blob persistence), and
+  below 2.23.0 could not serialize a pipeline containing the store;
+  agno below 2.5.4 rejected the `id`/`name`/`description`/
+  `similarity_threshold` kwargs the store passes to `VectorDb.__init__`,
+  so every construction failed. (#160)
+- **LlamaIndex `ALL`/`ANY` metadata filters no longer crash on
+  llama-index-core 0.11.x–0.12.5.** The operator dispatch referenced
+  `FilterOperator.TEXT_MATCH_INSENSITIVE` (added in llama-index-core
+  0.12.6) unconditionally before the `ALL`/`ANY` branches, so on older
+  releases those queries — and the `FilterCondition.NOT` dispatch —
+  died with `AttributeError`. The newer enum members are now resolved
+  with `getattr` sentinels, keeping the honest `>=0.11` floor while
+  still supporting `TEXT_MATCH_INSENSITIVE`/`NOT` where the installed
+  version provides them. (#160)
 - **The bindings release the GIL around compute-bound core calls.**
   `TurboQuantIndex` / `IdMapIndex` `search`, `add` / `add_with_ids`,
   `prepare`, `write`, and `load` previously held the GIL for their full

--- a/turbovec-python/pyproject.toml
+++ b/turbovec-python/pyproject.toml
@@ -53,8 +53,8 @@ Issues = "https://github.com/RyanCodrai/turbovec/issues"
 [project.optional-dependencies]
 langchain = ["langchain-core>=0.3"]
 llama-index = ["llama-index-core>=0.11"]
-haystack = ["haystack-ai>=2.0"]
-agno = ["agno>=2.0"]
+haystack = ["haystack-ai>=2.23.0"]
+agno = ["agno>=2.5.4"]
 
 [tool.maturin]
 manifest-path = "Cargo.toml"

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -67,6 +67,14 @@ _DEFAULT_VECTOR_STORE = "default"
 _NODES_SCHEMA_VERSION = 2
 _NODES_SCHEMA_COMPAT = (1, 2)
 
+# Enum members added after llama-index-core 0.11.0. Resolved with getattr
+# so that comparing against them never raises AttributeError on older
+# releases where the member does not exist — queries that don't use these
+# operators must keep working there. On old versions the sentinel is None,
+# which can never equal a real FilterOperator/FilterCondition member.
+_TEXT_MATCH_INSENSITIVE = getattr(FilterOperator, "TEXT_MATCH_INSENSITIVE", None)
+_CONDITION_NOT = getattr(FilterCondition, "NOT", None)
+
 
 def _split_persist_base(persist_path: str | Path) -> Path:
     """Strip the framework-provided extension off `persist_path` so the
@@ -404,7 +412,7 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
             return all(results) if results else True
         if condition == FilterCondition.OR:
             return any(results) if results else True
-        if condition == FilterCondition.NOT:
+        if _CONDITION_NOT is not None and condition == _CONDITION_NOT:
             # Reference semantics (`build_metadata_filter_fn`,
             # `utils.py:187-189`): NOT matches when none of the inner
             # filters match. Empty inner list trivially satisfies NOT.
@@ -463,7 +471,7 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
                 "Both metadata value and filter value must be strings "
                 "for the TEXT_MATCH operator"
             )
-        if op == FilterOperator.TEXT_MATCH_INSENSITIVE:
+        if _TEXT_MATCH_INSENSITIVE is not None and op == _TEXT_MATCH_INSENSITIVE:
             if isinstance(target, str) and isinstance(value, str):
                 return target.lower() in value.lower()
             raise TypeError(

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -175,17 +175,26 @@ def test_failed_persist_preserves_previous_store(tmp_path):
     store.persist(str(persist_path))
     before = {p.name: p.read_bytes() for p in tmp_path.iterdir()}
 
+    # Older llama-index-core (roughly < 0.12.40) json-serializes node
+    # content eagerly inside node_to_metadata_dict — which our add() calls
+    # — so the mid-persist failure this test provokes is unreachable
+    # there: add() itself raises and the previously persisted store is
+    # trivially untouched. Probe the upstream helper directly (same
+    # arguments add() uses) so the gate can never swallow a TypeError
+    # raised by turbovec's own code below.
+    from llama_index.core.vector_stores.utils import node_to_metadata_dict
+
+    probe = _make_node("probe", seed=99, metadata={"bad": {1, 2, 3}})
     try:
-        store.add([_make_node("bad", seed=3, metadata={"bad": {1, 2, 3}})])
+        node_to_metadata_dict(probe, remove_text=False, flat_metadata=False)
     except TypeError:
-        # Older llama-index-core (<= 0.12.x) json-serializes node content
-        # eagerly inside add() (node_to_metadata_dict), so the mid-persist
-        # failure this test provokes is unreachable there — add() itself
-        # raises and the previously persisted store is trivially untouched.
         pytest.skip(
-            "this llama-index-core version serializes node content at "
-            "add() time; the persist-time failure cannot be provoked"
+            "this llama-index-core version serializes node content "
+            "eagerly at add() time; the persist-time failure cannot be "
+            "provoked"
         )
+
+    store.add([_make_node("bad", seed=3, metadata={"bad": {1, 2, 3}})])
     with pytest.raises(TypeError):
         store.persist(str(persist_path))
 
@@ -742,6 +751,24 @@ def test_all_any_filters_work_without_newer_enum_members(monkeypatch):
     assert TurboQuantVectorStore._filters_match(metadata, all_match) is True
     assert TurboQuantVectorStore._filters_match(metadata, any_match) is True
     assert TurboQuantVectorStore._filters_match(metadata, any_miss) is False
+
+    # Condition dispatch: on the old enum surface a NOT condition (built
+    # with the installed real enum, so only constructible where the
+    # member exists — i.e. llama-index-core >= 0.12.6, which is what CI
+    # runs) must fall through to the explicit NotImplementedError — the
+    # unfixed code instead dies with AttributeError touching the missing
+    # FilterCondition.NOT on the stub.
+    if hasattr(FilterCondition, "NOT"):
+        not_filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="tags", value=["python"], operator=FilterOperator.IN
+                )
+            ],
+            condition=FilterCondition.NOT,
+        )
+        with pytest.raises(NotImplementedError):
+            TurboQuantVectorStore._filters_match(metadata, not_filters)
 
 
 def test_query_is_empty_treats_missing_key_as_match():

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -175,7 +175,17 @@ def test_failed_persist_preserves_previous_store(tmp_path):
     store.persist(str(persist_path))
     before = {p.name: p.read_bytes() for p in tmp_path.iterdir()}
 
-    store.add([_make_node("bad", seed=3, metadata={"bad": {1, 2, 3}})])
+    try:
+        store.add([_make_node("bad", seed=3, metadata={"bad": {1, 2, 3}})])
+    except TypeError:
+        # Older llama-index-core (<= 0.12.x) json-serializes node content
+        # eagerly inside add() (node_to_metadata_dict), so the mid-persist
+        # failure this test provokes is unreachable there — add() itself
+        # raises and the previously persisted store is trivially untouched.
+        pytest.skip(
+            "this llama-index-core version serializes node content at "
+            "add() time; the persist-time failure cannot be provoked"
+        )
     with pytest.raises(TypeError):
         store.persist(str(persist_path))
 
@@ -499,7 +509,14 @@ def test_single_filter_missing_key_parity_with_reference():
     # Table-driven parity check: for a node missing the filtered key, each
     # operator must agree with llama-index-core's build_metadata_filter_fn
     # (missing key matches only the negative operators NE / NIN). (#132)
-    from llama_index.core.vector_stores.utils import build_metadata_filter_fn
+    try:
+        from llama_index.core.vector_stores.utils import build_metadata_filter_fn
+    except ImportError:
+        pytest.skip(
+            "build_metadata_filter_fn (the reference implementation this "
+            "parity test compares against) was added in llama-index-core "
+            "0.14.0"
+        )
 
     metadata: dict = {"other": 1}  # no "color" key
     cases = [
@@ -565,6 +582,10 @@ def test_query_text_match_is_case_sensitive():
     assert store.query(q).nodes == []
 
 
+@pytest.mark.skipif(
+    not hasattr(FilterOperator, "TEXT_MATCH_INSENSITIVE"),
+    reason="FilterOperator.TEXT_MATCH_INSENSITIVE requires llama-index-core >= 0.12.6",
+)
 def test_query_text_match_insensitive_folds_case():
     # TEXT_MATCH_INSENSITIVE is the explicit opt-in for case-folding,
     # matching `utils.py:145-151`.
@@ -650,6 +671,77 @@ def test_query_any_operator_matches_set_intersection():
     )
     contents = {n.get_content() for n in store.query(q).nodes}
     assert contents == {"a", "b"}
+
+
+def test_all_any_filters_work_without_newer_enum_members(monkeypatch):
+    # Regression (issue #160): the operator dispatch used to reference
+    # FilterOperator.TEXT_MATCH_INSENSITIVE (added in llama-index-core
+    # 0.12.6) unconditionally, BEFORE the ALL/ANY branches — on older
+    # releases every ALL/ANY (and unknown-operator) query died with
+    # AttributeError instead of matching. Same for FilterCondition.NOT in
+    # the condition dispatch. Simulate an old llama-index-core by swapping
+    # in stub enums that lack the newer members (str-enums compare by
+    # value, so real filter objects still match the stub's members) and
+    # check the dispatch never touches the missing attributes.
+    import enum
+
+    import turbovec.llama_index as tli
+
+    class OldFilterOperator(str, enum.Enum):  # llama-index-core 0.11.0 surface
+        EQ = "=="
+        GT = ">"
+        LT = "<"
+        NE = "!="
+        GTE = ">="
+        LTE = "<="
+        IN = "in"
+        NIN = "nin"
+        ANY = "any"
+        ALL = "all"
+        TEXT_MATCH = "text_match"
+        CONTAINS = "contains"
+        IS_EMPTY = "is_empty"
+
+    class OldFilterCondition(str, enum.Enum):  # no NOT before 0.12.6
+        AND = "and"
+        OR = "or"
+
+    monkeypatch.setattr(tli, "FilterOperator", OldFilterOperator)
+    monkeypatch.setattr(tli, "FilterCondition", OldFilterCondition)
+    monkeypatch.setattr(
+        tli,
+        "_TEXT_MATCH_INSENSITIVE",
+        getattr(OldFilterOperator, "TEXT_MATCH_INSENSITIVE", None),
+    )
+    monkeypatch.setattr(
+        tli, "_CONDITION_NOT", getattr(OldFilterCondition, "NOT", None)
+    )
+
+    metadata = {"tags": ["python", "rust", "go"]}
+    all_match = MetadataFilters(
+        filters=[
+            MetadataFilter(
+                key="tags", value=["python", "rust"], operator=FilterOperator.ALL
+            )
+        ]
+    )
+    any_match = MetadataFilters(
+        filters=[
+            MetadataFilter(
+                key="tags", value=["haskell", "go"], operator=FilterOperator.ANY
+            )
+        ]
+    )
+    any_miss = MetadataFilters(
+        filters=[
+            MetadataFilter(
+                key="tags", value=["haskell"], operator=FilterOperator.ANY
+            )
+        ]
+    )
+    assert TurboQuantVectorStore._filters_match(metadata, all_match) is True
+    assert TurboQuantVectorStore._filters_match(metadata, any_match) is True
+    assert TurboQuantVectorStore._filters_match(metadata, any_miss) is False
 
 
 def test_query_is_empty_treats_missing_key_as_match():
@@ -786,6 +878,10 @@ def test_query_returns_results_sorted_by_similarity():
     assert all(a >= b for a, b in zip(sims, sims[1:]))
 
 
+@pytest.mark.skipif(
+    not hasattr(FilterCondition, "NOT"),
+    reason="FilterCondition.NOT requires llama-index-core >= 0.12.6",
+)
 def test_query_filter_condition_not_negates_inner_match():
     # Reference (`utils.py:187-189`): NOT matches when NONE of the inner
     # filters match. With a single inner EQ filter, NOT is just negation.


### PR DESCRIPTION
## Summary

Three of the four integration extras in `turbovec-python/pyproject.toml` declared minimums whose APIs the integration code relies on did not exist yet (#160). Each true floor was found empirically: for every candidate version a throwaway venv was created with the exact pin (+ numpy + pytest + the locally built `turbovec`), and the full per-integration test file was run. The floor is the lowest version where the whole file passes.

## Per-dependency evidence

| extra | old floor | new floor | proof (exact pins tested, full per-integration file) |
|---|---|---|---|
| `langchain` | `langchain-core>=0.3` | unchanged | verified honest in the issue's bug-hunt (0.3.0: 51 passed); left alone |
| `llama-index` | `llama-index-core>=0.11` | unchanged + code fix | `0.11.0`: **74 passed, 4 skipped** with the fix (before the fix: ALL/ANY tests fail with `AttributeError`); latest `0.14.23`: full pass |
| `haystack` | `haystack-ai>=2.0` | `haystack-ai>=2.23.0` | `2.16.0` / `2.17.0` / `2.18.1` / `2.21.0` / `2.22.0`: 1 failed, 81 passed (pipeline serialization); `2.23.0` / `2.24.0` / `2.28.0`: **82 passed**; latest `3.0.0`: full pass |
| `agno` | `agno>=2.0` | `agno>=2.5.4` | `2.5.3`: **97 failed** (every construction dies in `VectorDb.__init__`); `2.5.4`: **97 passed**; latest `2.8.2`: full pass |

API-introduction bisection backing the floors (probed per version):

- **haystack-ai** — `ByteStream.to_dict`/`from_dict` (blob persistence) first exist in **2.16.0** (absent 2.15.2 and below; 2.0.0 additionally unimportable next to the integration). Component-init auto-serialization, which `Pipeline.to_dict()` needs to serialize a component holding the store (`test_pipeline_to_dict_from_dict_roundtrip`), first works in **2.23.0** — 2.22.0 still raises `SerializationError`. The floor is therefore 2.23.0, above the issue's 2.2.x estimate. Note: haystack-ai ≥2.22 requires Python ≥3.10, so `turbovec[haystack]` no longer resolves on 3.9 — pip reports this honestly instead of installing a broken combination.
- **agno** — `VectorDb.__init__` accepted no kwargs at all until 2.2.0, gained `id`/`name`/`description` in 2.2.0, and only gained `similarity_threshold` (which `TurboQuantVectorDb` passes and later reads) in **2.5.4** (2.5.3: absent).
- **llama-index-core** — `FilterOperator.TEXT_MATCH_INSENSITIVE` and `FilterCondition.NOT` first exist in **0.12.6** (absent 0.12.5 and below).

## llama-index decision: code fix + keep the honest `>=0.11` floor

The issue offered either raising the floor past `TEXT_MATCH_INSENSITIVE`'s release (0.12.6) or making the dispatch robust. Evidence favored the code fix:

- The only *integration-code* break at 0.11.0 was the reported bug: `_single_filter_match` referenced `FilterOperator.TEXT_MATCH_INSENSITIVE` unconditionally before the `ALL`/`ANY` branches, so those queries crashed with `AttributeError` on 0.11.x–0.12.5. Both newer enum members are now resolved once via `getattr(..., None)` sentinels; on old versions the sentinel is `None`, which never equals a real member. With the fix, 0.11.0 passes the full file (74 passed, 4 skipped) — more users served than a 0.12.6 floor.
- Raising the floor to 0.12.6 would **not** have bought an unmodified test file anyway: two checks depend on test-only upstream scaffolding that arrived even later, so they need version guards under either option. `test_single_filter_missing_key_parity_with_reference` imports `build_metadata_filter_fn`, which only exists from **0.14.0** (bisected: absent at 0.13.0, present at 0.14.0) — it now skips with an explicit reason where the reference helper is absent. `test_failed_persist_preserves_previous_store` needs `add()` to defer serialization to persist time, which only holds from ~0.12.40 — on older versions `add()` itself raises (fail-fast; the persist-time failure is unreachable and the previously persisted store trivially safe), so it skips there. The two feature tests for `TEXT_MATCH_INSENSITIVE`/`NOT` carry `skipif` guards on member presence.

## Tests

- New regression test `test_all_any_filters_work_without_newer_enum_members`: swaps in stub str-enums replicating the 0.11.0 `FilterOperator`/`FilterCondition` surface (no `TEXT_MATCH_INSENSITIVE`, no `NOT`) and asserts `ALL`/`ANY` matching works. Because it simulates the old enum surface, it fails on the unfixed code **even with latest llama-index-core installed** (verified: unfixed code + 0.14.23 → `AttributeError`), so CI genuinely guards this. The floor-version proof additionally lives in the venv matrix above (unfixed code + 0.11.0: `test_query_all_operator_matches_set_subset`, `test_query_any_operator_matches_set_intersection`, and the new test all fail with `AttributeError`; fixed code: all pass).
- Full suite with latest deps (`langchain-core 1.5.1`, `llama-index-core 0.14.23`, `haystack-ai 3.0.0`, `agno 2.8.2`, `numpy 2.4.6`, py3.11): **467 passed, 0 failed** (466 baseline + 1 new test).
- No Rust changes; cargo untouched (the extension was rebuilt from this branch only to run the suite locally).

## Follow-up suggestions (deliberately not in this PR)

- A CI job that installs the *floor* pins and runs the integration test files would prevent floor drift from recurring; left out per repo convention that regression-prevention infra ships separately from the fix.
- `.github/workflows/ci.yml`'s install step repeats the old floor strings (`haystack-ai>=2.0`, `agno>=2.0`). Since it installs the latest matching versions, CI behavior is unaffected, but the strings should be synced to the new floors — not included here because the available push token lacks the `workflow` scope to touch workflow files.

Closes #160

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)