### PR TITLE
tests: harden two false-confidence tests and pin search(k > len) contract (#145)

### DIFF
--- a/turbovec-python/tests/test_index.py
+++ b/turbovec-python/tests/test_index.py
@@ -192,6 +192,26 @@ def test_search_on_empty_eager_index_returns_zero_effective_k():
     assert indices.shape == (1, 0)
 
 
+def test_search_k_exceeding_len_clamps_to_len():
+    # k > n with 0 < n < k: the effective k is min(k, n) = 3, so the
+    # returned arrays must have exactly n columns (this shape IS the
+    # SearchResults.k field surfaced through the binding), with every
+    # stored vector appearing exactly once, in range, per query.
+    idx = TurboQuantIndex(dim=128, bit_width=4)
+    idx.add(unit_vectors(3, 128, seed=5))
+
+    queries = unit_vectors(2, 128, seed=6)
+    scores, indices = idx.search(queries, k=10)
+
+    assert scores.shape == (2, 3)
+    assert indices.shape == (2, 3)
+    for qi in range(2):
+        row = indices[qi]
+        assert len(set(row.tolist())) == 3, f"duplicate indices for query {qi}: {row}"
+        assert ((row >= 0) & (row < 3)).all(), f"out-of-range index for query {qi}: {row}"
+    assert np.isfinite(scores).all()
+
+
 # ---- Wave 5: typed-exception hygiene at the binding layer ----
 
 def test_add_noncontiguous_vectors_raises_value_error():

--- a/turbovec/tests/concurrent_search.rs
+++ b/turbovec/tests/concurrent_search.rs
@@ -144,17 +144,37 @@ fn add_after_search_invalidates_blocked_cache() {
     // search sees the extended vector set. If we forgot to invalidate,
     // the search would still score against the pre-`add` packed codes.
     let mut index = build_index();
-    let queries = make_vectors(1, index.dim(), 3);
+    let dim = index.dim();
+    let queries = make_vectors(1, dim, 3);
     let _before = index.search(&queries, 5);
 
-    // Add 512 more vectors — roughly doubling the index.
-    let more = make_vectors(512, index.dim(), 11);
+    // Add 512 more vectors — roughly doubling the index. Unlike the
+    // small-scale sequential version in `state_sequences.rs` (5 + 1
+    // vectors), this add appends many complete BLOCKs to the blocked
+    // layout, so a rebuild that dropped or truncated the new batch at
+    // block granularity is exercised here.
+    let more = make_vectors(512, dim, 11);
     index.add(&more);
     assert_eq!(index.len(), 1_024 + 512);
 
-    // The top-5 after `add` must come from an index of `len() = 1536`.
-    // The only invariant we can check cheaply is that every returned
-    // position is in-range for the new size.
+    // Discriminating check: self-query vectors from the *new* batch and
+    // require each to be its own top-1. If `add` forgot to reset the
+    // `blocked` OnceLock, the search would still score against the
+    // pre-`add` packed codes and could never return a slot >= 1024.
+    // Probe the first, a middle, and the last new vector so a rebuild
+    // that included only part of the batch also fails.
+    for &row in &[0usize, 256, 511] {
+        let q = &more[row * dim..(row + 1) * dim];
+        let res = index.search(q, 1);
+        assert_eq!(
+            res.indices_for_query(0)[0],
+            (1_024 + row) as i64,
+            "vector added at slot {} not findable after add — stale blocked cache?",
+            1_024 + row
+        );
+    }
+
+    // The original in-range invariant still holds for an arbitrary query.
     let after = index.search(&queries, 5);
     for &idx in after.indices_for_query(0) {
         assert!(idx >= 0, "negative index");

--- a/turbovec/tests/kernel_correctness.rs
+++ b/turbovec/tests/kernel_correctness.rs
@@ -149,9 +149,25 @@ fn search_scores_are_sorted_descending() {
 
             for qi in 0..4 {
                 let scores = res.scores_for_query(qi);
+                // Every returned score must be finite: `n >= k` here, so
+                // no NEG_INFINITY heap padding may leak into the results
+                // (a heap under-fill or kernel-tail bug would surface as
+                // a non-finite score). Mirrors the finiteness checks the
+                // id_map tests already apply.
+                assert!(
+                    scores.iter().all(|s| s.is_finite()),
+                    "non-finite score leaked: bits={} n={} qi={} scores={:?}",
+                    bits,
+                    n,
+                    qi,
+                    scores
+                );
+                // Strict descending order — no escape hatch for
+                // non-finite entries, which the finiteness assertion
+                // above has already ruled out.
                 for w in scores.windows(2) {
                     assert!(
-                        w[0] >= w[1] || !w[1].is_finite(),
+                        w[0] >= w[1],
                         "scores not sorted desc: bits={} n={} qi={} window={:?}",
                         bits,
                         n,
@@ -160,6 +176,65 @@ fn search_scores_are_sorted_descending() {
                     );
                 }
             }
+        }
+    }
+}
+
+#[test]
+fn search_k_exceeding_len_clamps_to_len() {
+    // `search(k > n_vectors)` with `0 < n < k` on the unmasked path:
+    // the effective k is `min(k, n)`, so with n=3 and k=10 each query
+    // must get back exactly 3 results — distinct, in-range, finite —
+    // and `SearchResults::k` must report the clamped value 3, not the
+    // requested 10.
+    let dim = 512;
+    let n = 3;
+    let k = 10;
+    let nq = 2;
+    let data = gaussian_normalized(n, dim, 0x0EFF_EC7); // "effect(ive k)"
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+    idx.add(&data);
+    assert_eq!(idx.len(), n);
+
+    let queries = gaussian_normalized(nq, dim, 0x0EFF_EC8);
+    let res = idx.search(&queries, k);
+
+    assert_eq!(res.nq, nq);
+    assert_eq!(res.k, n, "SearchResults::k must be clamped to len()");
+    assert_eq!(res.indices.len(), nq * n);
+    assert_eq!(res.scores.len(), nq * n);
+
+    for qi in 0..nq {
+        let indices = res.indices_for_query(qi);
+        assert_eq!(indices.len(), n);
+        // All slots in 0..n, and all distinct — with k > n every stored
+        // vector appears exactly once, no duplicates or padding slots.
+        let mut seen = vec![false; n];
+        for &slot in indices {
+            assert!(
+                (0..n as i64).contains(&slot),
+                "qi={} returned out-of-range slot {}",
+                qi,
+                slot
+            );
+            assert!(
+                !std::mem::replace(&mut seen[slot as usize], true),
+                "qi={} returned duplicate slot {}",
+                qi,
+                slot
+            );
+        }
+        // Scores stay finite and sorted — no NEG_INFINITY heap padding
+        // leaks even though the heap was sized for k=10 candidates.
+        let scores = res.scores_for_query(qi);
+        assert!(
+            scores.iter().all(|s| s.is_finite()),
+            "qi={} non-finite score in {:?}",
+            qi,
+            scores
+        );
+        for w in scores.windows(2) {
+            assert!(w[0] >= w[1], "qi={} scores not sorted desc: {:?}", qi, scores);
         }
     }
 }


### PR DESCRIPTION
Test-quality hardening per #145: two false-confidence tests strengthened and one coverage gap filled. No runtime code changes — the diff touches only `turbovec/tests/concurrent_search.rs`, `turbovec/tests/kernel_correctness.rs`, and `turbovec-python/tests/test_index.py`.

All three findings were re-verified against current main (4111cd4) before fixing.

## Finding 1 — `add_after_search_invalidates_blocked_cache` never tested what it names

`turbovec/tests/concurrent_search.rs`: the docstring claims the test catches a forgotten blocked-cache invalidation after `add`, but its only assertions were index-range checks (`idx >= 0`, `idx < len()`) — the stale top-5 from the pre-`add` cache is always in range after an add, so the test passes with the exact bug it names.

**Choice: strengthened rather than deleted.** A correct sequential version exists in `state_sequences.rs` (`second_add_after_search_lets_new_vectors_be_found`), but it runs at 5+1 vectors / dim 128 — the add lands in the tail of the first BLOCK. The concurrent_search.rs test runs at 1024+512 vectors / dim 256, so its add appends many complete BLOCKs to the blocked layout; a rebuild bug at block granularity is only exercised at this scale. (The test is single-threaded despite its home file, so there was no concurrency shape to preserve.) It now self-queries the first, middle, and last vector of the added batch and requires each to be its own top-1 (slots 1024/1280/1535), so a rebuild that drops or truncates the new batch — wholly or partially — fails. The original in-range assertions are retained.

## Finding 2 — sortedness predicate's `!is_finite` escape hatch

`turbovec/tests/kernel_correctness.rs` (`search_scores_are_sorted_descending`): the predicate `w[0] >= w[1] || !w[1].is_finite()` let NEG_INFINITY heap padding (heap under-fill / kernel-tail bugs) pass unconditionally — and since `-inf` sorts last, the sortedness half alone can never catch a padding leak either. This was the only order/finiteness check on the core unmasked `TurboQuantIndex::search` path. The escape clause is dropped and `assert!(scores.iter().all(|s| s.is_finite()))` added, mirroring the id_map tests.

**The strict version passes on current main** (no latent kernel bug — verified across bits ∈ {2,3,4}, n ∈ {64..500}).

## Finding 3 — no test pinned `search(k > n_vectors)` with 0 < n < k

- Rust: `search_k_exceeding_len_clamps_to_len` in `kernel_correctness.rs` — n=3, k=10, nq=2: asserts `SearchResults::k == 3` (the #177-documented effective-k semantics), result arrays exactly `nq * 3`, per-query indices distinct and in `0..3`, scores finite and sorted descending.
- Python: `test_search_k_exceeding_len_clamps_to_len` in `test_index.py` — n=3, k=10, nq=2: asserts shapes `(2, 3)` (the binding reshapes to `results.k`, so the column count *is* the SearchResults k field surfaced through the tuple API), indices distinct and in-range per query, scores finite.

## Bite demonstrations

Each strengthened/new assertion was shown to catch its hypothetical bug via a temporary local injection. All injections are reverted — the committed diff contains none of them (`grep BITE-INJECTION` is empty; the diff vs main touches test files only).

| # | Injection (temporary, reverted) | Old test/suite under injection | Strengthened/new test under injection |
|---|---|---|---|
| 1 | Commented out `self.blocked = OnceLock::new()` in `TurboQuantIndex::add` (lib.rs) | old `add_after_search_invalidates_blocked_cache`: **PASSED** (false confidence confirmed) | **FAILED**: `vector added at slot 1024 not findable after add — stale blocked cache?` |
| 2 | Simulated heap under-fill in `search.rs` result extraction: last returned score of every query forced to `f32::NEG_INFINITY` | old `search_scores_are_sorted_descending`: **PASSED** (escape hatch + `-inf` sorts last) | **FAILED**: `non-finite score leaked: bits=2 n=64 qi=0 scores=[..., -inf]` |
| 3 | `SearchResults { k }` returned the requested k instead of `effective_k` (lib.rs) | full old `kernel_correctness.rs`: **6/6 PASSED**; old `test_index.py`: **34/34 PASSED** (gap confirmed on both surfaces) | Rust test **FAILED**: `SearchResults::k must be clamped to len()`; Python test **FAILED**: `RuntimeError: malformed search result shape` from a wheel built with the injection |

Injection 3's binding wheel was built and exercised in a scratch venv/directory only; the shared package tree was not touched.

## Suite results

- `cargo test -p turbovec`: baseline on main **162 passed, 0 failed**; with this branch **163 passed, 0 failed** (+1 new test).
- Full `pytest turbovec-python/tests/`: baseline on main **466 passed, 1 skipped, 0 failed** (measured against a freshly built binding from current main — the prebuilt `.so` in the main tree predated #186 and failed the GIL tests, so it was rebuilt in a scratch venv); with this branch **467 passed, 1 skipped, 0 failed** (+1 new test).

## CHANGELOG

No entry, following repo precedent: tests are not package surface (PR #184, tests-only, shipped without a CHANGELOG entry).

Closes #145

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
