### PR TITLE
tests: make state_sequences second-add test actually discriminate a stale blocked cache (#191)

### DIFF
--- a/turbovec/tests/state_sequences.rs
+++ b/turbovec/tests/state_sequences.rs
@@ -52,27 +52,37 @@ fn unit_vectors(n: usize, dim: usize, seed: u64) -> Vec<f32> {
 fn second_add_after_search_lets_new_vectors_be_found() {
     // `add -> search -> add -> search`: the second add must invalidate
     // the blocked cache populated by the first search, so the new
-    // vectors are visible. Existing tests only assert that returned
-    // indices stay in range (idx < len) after the second add — a bug
-    // that excluded the new batch entirely from the blocked layout
-    // would still satisfy that bound but never surface the new vectors.
+    // vector is visible.
+    //
+    // The blocked layout packs vectors in blocks of 32 slots, padding
+    // the final partial block. To make this test discriminate a stale
+    // cache, the first add fills block 0 *exactly* (32 vectors) and the
+    // second add lands at slot 32 — the first slot of a block the stale
+    // cache does not have. A search against the stale single-block
+    // layout can therefore never return slot 32, no matter how the
+    // padding codes score. (An earlier 5+1 version of this test put the
+    // new vector inside the stale block's padded slot range, where the
+    // padding code could coincidentally win the self-query — it kept
+    // passing with the invalidation in `add` disabled; see issue #191.)
     let dim = 128;
     let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
-    let first = unit_vectors(5, dim, 0x5001);
+    let first = unit_vectors(32, dim, 0x5001);
     idx.add(&first);
-    // First search warms the blocked cache.
+    // First search warms the blocked cache (exactly one full block).
     let _ = idx.search(&first[0..dim], 5);
 
-    // Second add: distinctive vector at known position.
+    // Second add: distinctive vector at slot 32, beyond the warmed
+    // cache's block coverage.
     let second = unit_vectors(1, dim, 0x5002);
     idx.add(&second);
+    assert_eq!(idx.len(), 33);
 
     // Self-query the newly added vector — it must be top-1, proving
     // the second add invalidated the cache and rebuilt it including
-    // the new vector.
+    // the new block.
     let res = idx.search(&second, 1);
     assert_eq!(res.indices.len(), 1);
-    assert_eq!(res.indices[0] as usize, 5, "new vector not findable after second add+search");
+    assert_eq!(res.indices[0] as usize, 32, "new vector not findable after second add+search");
 }
 
 #[test]


### PR DESCRIPTION
## Mechanism (issue #191)

`state_sequences.rs::second_add_after_search_lets_new_vectors_be_found` was false-confidence at its 5+1/dim-128 scale. The blocked layout packs vectors in blocks of 32 slots, padding the final partial block. With the invalidation in `add` disabled (`self.blocked = OnceLock::new()` at `turbovec/src/lib.rs:356` commented out), the stale single-block cache from the first search still *covers* slot 5 within its padded range, and slot 5's padding code coincidentally outscored the ~0 dot products of the 5 unrelated unit vectors — so the self-query returned the right answer for the wrong reason and the test passed despite its docstring naming exactly this bug. The only real coverage was the strengthened #190 test in `concurrent_search.rs`.

## Fix chosen

Structural block-coverage fix (the issue's preferred direction), mirroring #190's insight at small scale:

- First add fills block 0 **exactly** (32 vectors, `BLOCK = 32`) — the warmed cache has no padded slot slack.
- Second add lands at **slot 32**, the first slot of a block the stale cache does not have. A search against the stale layout can never return slot 32, regardless of how padding codes score — so the discriminating property is structural, not score-dependent (score margins at 4-bit quantization were the coincidence that broke the old version).

Test stays sequential and single-threaded; docstring updated to say what it actually discriminates now (and records the history of the old shape). No src/ changes; the #190 test is untouched.

## Bite verification (both directions)

1. **Injection applied** (invalidation in `add` disabled):
   - Old test: **PASSED** (reproduced the false-confidence defect).
   - #190 control (`concurrent_search.rs::add_after_search_invalidates_blocked_cache`): **FAILED** (`left: 7, right: 1024`) — control confirms the injection works.
   - Fixed test: **FAILED** (`left: 19, right: 32 — new vector not findable after second add+search`) — the test now bites.
2. **Injection reverted**: fixed test passes; full `cargo test -p turbovec` green — **163 tests**, matching the post-#190 baseline.

Injection fully reverted before commit; the diff touches only `turbovec/tests/state_sequences.rs`.

No CHANGELOG entry — tests-only change, per repo precedent (#190).

Closes #191

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)