### PR TITLE
docs: haystack quickstart — import SentenceTransformersDocumentEmbedder from its integration package

### DIFF
--- a/docs/integrations/haystack.md
+++ b/docs/integrations/haystack.md
@@ -148,7 +148,7 @@ Document metadata must be JSON-serializable — the same constraint `InMemoryDoc
 
 `TurboQuantDocumentStore` implements `to_dict` / `from_dict` so it can be serialized as part of a Haystack `Pipeline`. `to_dict` captures the component *config* (`dim`, `bit_width`, `embedding_similarity_function`, `return_embedding`); persisting the stored documents is the job of `save_to_disk` / `load_from_disk`.
 
-Plug into a standard RAG pipeline the same way you'd use `InMemoryDocumentStore`. The sentence-transformers embedders live in their own integration package (`pip install sentence-transformers-haystack`):
+Plug into a standard RAG pipeline the same way you'd use `InMemoryDocumentStore`. The sentence-transformers embedders live in their own integration package (`pip install sentence-transformers-haystack`, which requires `haystack-ai` 2.24 or newer):
 
 ```python
 from haystack import Pipeline

--- a/docs/integrations/haystack.md
+++ b/docs/integrations/haystack.md
@@ -1,6 +1,6 @@
 # Haystack integration
 
-`turbovec.haystack.TurboQuantDocumentStore` is a Haystack 2.x [`DocumentStore`](https://docs.haystack.deepset.ai/docs/document-store) backed by an `IdMapIndex`. It implements the same public surface as `haystack.document_stores.in_memory.InMemoryDocumentStore` and can be used as a drop-in replacement wherever the in-memory store is used.
+`turbovec.haystack.TurboQuantDocumentStore` is a Haystack [`DocumentStore`](https://docs.haystack.deepset.ai/docs/document-store) backed by an `IdMapIndex`. It implements the same public surface as `haystack.document_stores.in_memory.InMemoryDocumentStore` and can be used as a drop-in replacement wherever the in-memory store is used.
 
 ## Install
 
@@ -148,12 +148,14 @@ Document metadata must be JSON-serializable — the same constraint `InMemoryDoc
 
 `TurboQuantDocumentStore` implements `to_dict` / `from_dict` so it can be serialized as part of a Haystack `Pipeline`. `to_dict` captures the component *config* (`dim`, `bit_width`, `embedding_similarity_function`, `return_embedding`); persisting the stored documents is the job of `save_to_disk` / `load_from_disk`.
 
-Plug into a standard RAG pipeline the same way you'd use `InMemoryDocumentStore`:
+Plug into a standard RAG pipeline the same way you'd use `InMemoryDocumentStore`. The sentence-transformers embedders live in their own integration package (`pip install sentence-transformers-haystack`):
 
 ```python
 from haystack import Pipeline
-from haystack.components.embedders import SentenceTransformersDocumentEmbedder
 from haystack.components.writers import DocumentWriter
+from haystack_integrations.components.embedders.sentence_transformers import (
+    SentenceTransformersDocumentEmbedder,
+)
 
 store = TurboQuantDocumentStore()                 # dim inferred from first batch
 indexing = Pipeline()


### PR DESCRIPTION
## What was broken

`docs/integrations/haystack.md` (pipeline quickstart) imported `SentenceTransformersDocumentEmbedder` from `haystack.components.embedders`. haystack-ai 3.0.0 removed the sentence-transformers embedders from that subpackage (only OpenAI/Azure/Mock variants remain), so the example failed with `ImportError` for users on latest haystack.

## What the example now uses

The sentence-transformers embedders ship in deepset's own integration package, `sentence-transformers-haystack` (requires `haystack-ai>=2.24.0`, so it spans both in-support majors):

```python
from haystack_integrations.components.embedders.sentence_transformers import (
    SentenceTransformersDocumentEmbedder,
)
```

The doc names the `pip install sentence-transformers-haystack` line right above the example, so the quickstart stays copy-pasteable. This is the 3.x-canonical form and the *same* import works on 2.x, so no version-forked example is needed.

Also drops the stale "Haystack 2.x" qualifier in the intro sentence — the `haystack` extra's floor is `haystack-ai>=2.23.0` with no upper bound, and the store (and this doc's example) works on 3.x.

## Verification (by execution)

Ran the quickstart end-to-end — embedder construction, model load, `Pipeline.run` writing into `TurboQuantDocumentStore`, then `embedding_retrieval` returning the expected top hit — in two scratch venvs with the local turbovec package:

| venv | haystack-ai | result |
|---|---|---|
| scratch + `sentence-transformers-haystack` | 2.31.0 | end-to-end OK (2 docs written, correct top-1 retrieval) |
| scratch + `sentence-transformers-haystack` | 3.0.0 | end-to-end OK (2 docs written, correct top-1 retrieval) |

The old import was also re-confirmed working on 2.31.0 and failing with `ImportError` on 3.0.0.

## Sibling sweep

Grepped docs/ and both READMEs for all other `haystack.*` module references and probed each import on 3.0.0 — all still valid, no other fixes needed:

- `haystack.document_stores.in_memory.InMemoryDocumentStore`
- `haystack.document_stores.types.DuplicatePolicy`
- `haystack.utils.filters.document_matches_filter`
- `haystack.components.writers.DocumentWriter`
- `haystack.Document`, `haystack.Pipeline`

No CHANGELOG entry (docs steady-state per repo convention — the prior docs-drift commit 16f2173 narrated only code fixes in the changelog, not docs corrections). No test changes.

Closes #185

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)