### PR TITLE
Release workflows: verify artifacts before publish (#163)

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -21,8 +21,13 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - name: Install openblas for cargo publish verification
+      - name: Install openblas for tests and cargo publish verification
         run: sudo apt-get update && sudo apt-get install -y libopenblas-dev pkg-config
+      # `cargo publish` only does a verification *build*; run the test
+      # suite first so a tag on a commit that compiles but fails tests
+      # cannot publish.
+      - name: Run tests before publish
+        run: cargo test -p turbovec --release
       - name: Authenticate with crates.io
         id: auth
         uses: rust-lang/crates-io-auth-action@v1

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -54,7 +54,36 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest
           python -m pip install dist/*.whl
-          python -m pytest tests/test_index.py tests/test_id_map.py tests/test_filtering.py -v
+          python -m pytest tests/ -v
+      # The wheel is abi3-py39: a single artifact claims Python 3.9-3.14,
+      # but only 3.11 is exercised above. Import-test the same wheel on
+      # the floor (3.9) and ceiling (3.14) of the claimed range, where
+      # limited-API breakage hides. Runs the smoke tests when numpy
+      # publishes wheels for the interpreter; otherwise falls back to an
+      # import-only check of the extension module.
+      - name: Set up Python 3.9 and 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: |
+            3.9
+            3.14
+      - name: Smoke test abi3 wheel on 3.9 and 3.14
+        shell: bash
+        working-directory: turbovec-python
+        run: |
+          set -euo pipefail
+          for py in 3.9 3.14; do
+            venv="${RUNNER_TEMP}/venv-${py}"
+            "python${py}" -m venv "$venv"
+            "$venv/bin/python" -m pip install --upgrade pip
+            if "$venv/bin/python" -m pip install --only-binary numpy pytest dist/*.whl; then
+              "$venv/bin/python" -m pytest tests/ -v
+            else
+              echo "numpy has no wheel for Python ${py}; falling back to import-only check"
+              "$venv/bin/python" -m pip install --no-deps dist/*.whl
+              "$venv/bin/python" -c "import turbovec; print('imported turbovec on', __import__('sys').version)"
+            fi
+          done
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -75,6 +104,17 @@ jobs:
           target: aarch64
           args: --release --out dist
           working-directory: turbovec-python
+      # Same rationale as the linux job: install the freshly-built wheel
+      # and run the test suite so linkage regressions that only surface at
+      # Python import time can't ship in the macOS wheel.
+      - name: Install wheel and smoke test
+        shell: bash
+        working-directory: turbovec-python
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install dist/*.whl
+          python -m pytest tests/ -v
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -102,7 +142,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest
           python -m pip install dist/*.whl
-          python -m pytest tests/test_index.py tests/test_id_map.py tests/test_filtering.py -v
+          python -m pytest tests/ -v
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -114,12 +154,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
           args: --out dist
           working-directory: turbovec-python
+      # Install from the tarball to prove the sdist actually builds from
+      # source — a tarball missing files (Rust sources, path deps, build
+      # scripts) would otherwise ship green and break exactly the users
+      # who have no matching wheel. Rust is preinstalled on GitHub ubuntu
+      # runners; openblas is needed for the native build.
+      - name: Install openblas for source build
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev pkg-config
+      - name: Install sdist from source and smoke test
+        shell: bash
+        working-directory: turbovec-python
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install dist/*.tar.gz
+          python -m pytest tests/ -v
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## What

Closes the five release-verification gaps from #163 in `.github/workflows/release-pypi.yml` and `release-crates.yml`:

1. **macOS wheel install+test step** — byte-for-byte the linux/windows pattern (`pip install dist/*.whl` + `pytest tests/`), placed before upload so a failure blocks publish.
2. **sdist install-from-tarball verification** — `pip install dist/*.tar.gz` exercises the full maturin PEP 517 source build under build isolation before the sdist is published.
3. **Python floor/ceiling smoke (3.9 + 3.14)** — per-version venvs on both linux matrix legs (x86_64 + aarch64) import-test the abi3 wheel at the claimed support floor and ceiling, with a verified numpy-free fallback path.
4. **crates.io publish gated on tests** — `cargo test -p turbovec --release` (identical to CI's command) runs before `cargo publish`.
5. **Full-suite widening** — the hardcoded 3-file pytest lists become `tests/` (integration test files importorskip cleanly in a bare wheel env).

## Review status

This branch was adversarially reviewed in-worktree (all five gaps verified closed; YAML validated; step wiring, artifact names, and needs: dependencies checked; the numpy-free fallback proven non-vacuous by building the extension and importing it in a numpy-less venv). Verdict: approve, 0 blocking comments, 3 optional follow-ups (stricter fallback trigger separation; extending 3.9/3.14 coverage to mac/windows wheels; running the downstream-smoke consumer check in release-crates) — deliberately not bundled per repo convention.

The push was delayed a week awaiting the `workflow` token scope; the commit has been rebased onto current main (a839453).

Note: release workflows only run on tag push, so PR CI here exercises the normal test suite, not these workflow changes themselves — the five gaps take effect on the next release tag.

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)