### PR TITLE
fix: bit_width {2,3,4} everywhere — relax agno guard, align integration docs (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,12 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **Agno's `TurboQuantVectorDb` accepts `bit_width=3`.** The constructor
+  guard rejected 3 even though the core `IdMapIndex` — and the langchain,
+  haystack, and llama_index stores built on it — fully support it; the
+  guard now accepts `{2, 3, 4}` and still raises `ValueError` for
+  anything else. The integration docs and docstrings that described the
+  contract as `{2, 4}` now state `{2, 3, 4}`, matching the core. (#138)
 - **Optional-dependency floors now match what the integrations actually
   need.** Three of the four extras declared minimums whose APIs the
   integration code relies on did not exist yet, so `pip install

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -46,7 +46,7 @@ TurboQuantVectorDb(
 | Parameter | Notes |
 |---|---|
 | `embedder` | **Required.** Source of truth for the embedding dimension — `embedder.dimensions` sizes the underlying quantized index. |
-| `bit_width` | Quantization width per coordinate; one of `{2, 4}`. |
+| `bit_width` | Quantization width per coordinate; one of `{2, 3, 4}`. |
 | `search_type` | Only `SearchType.vector` is supported. Constructing with `keyword` or `hybrid` raises `ValueError` (keyword/hybrid would require an external BM25/lexical index that turbovec doesn't ship). |
 | `distance` | Only `Distance.cosine` is supported. turbovec stores unit-normalized vectors and the kernel's raw score is cosine similarity directly. |
 | `similarity_threshold` | Optional. Scores are mapped from cosine `[-1, 1]` to relevance `[0, 1]` via `(s + 1) / 2`; results below the threshold are dropped. |

--- a/docs/integrations/haystack.md
+++ b/docs/integrations/haystack.md
@@ -41,7 +41,7 @@ TurboQuantDocumentStore(
 | Parameter | Notes |
 |---|---|
 | `dim` | Optional. When omitted the vector dimensionality is inferred from the first `write_documents` call. |
-| `bit_width` | Quantization width per coordinate; one of `{2, 4}`. |
+| `bit_width` | Quantization width per coordinate; one of `{2, 3, 4}`. |
 | `embedding_similarity_function` | Drives the `scale_score=True` formula on retrieval. Defaults to `"cosine"` (right for unit-normalized embeddings); `"dot_product"` uses Haystack's `expit(s / 100)` formula. |
 | `async_executor` | Optional `ThreadPoolExecutor` for the `*_async` methods. If omitted, a single-threaded executor is created and cleaned up with the store. |
 | `return_embedding` | Accepted for API parity with `InMemoryDocumentStore`. The full-precision embedding is never available (quantized away), so `Document.embedding` on retrieved docs is always `None` regardless of the flag. |

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -41,7 +41,7 @@ from turbovec import IdMapIndex
 store = TurboQuantVectorStore(embeddings, index=IdMapIndex(1536, 4))
 ```
 
-`bit_width` is `2` or `4` and is fixed once the index is created.
+`bit_width` is one of `{2, 3, 4}` and is fixed once the index is created.
 
 ## Adding with explicit ids
 

--- a/docs/integrations/llama_index.md
+++ b/docs/integrations/llama_index.md
@@ -37,7 +37,7 @@ from turbovec import IdMapIndex
 vector_store = TurboQuantVectorStore(index=IdMapIndex(1536, 4))
 ```
 
-`bit_width` is `2` or `4` and is fixed once the index is created.
+`bit_width` is one of `{2, 3, 4}` and is fixed once the index is created.
 
 ## The two `delete` signatures
 

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -79,7 +79,7 @@ class TurboQuantVectorDb(VectorDb):
             and queries. ``embedder.dimensions`` must be set — it's the
             sole source of truth for the underlying quantized index's
             dimensionality.
-        :param bit_width: Quantization width (2 or 4).
+        :param bit_width: Quantization width (2, 3, or 4).
         :param search_type: Only :class:`SearchType.vector` is supported;
             other values raise :class:`ValueError`. (Keyword/hybrid search
             would require an external BM25/lexical index.)
@@ -105,8 +105,8 @@ class TurboQuantVectorDb(VectorDb):
             )
         if embedder.dimensions is None:
             raise ValueError("Embedder.dimensions must be set.")
-        if bit_width not in (2, 4):
-            raise ValueError(f"bit_width must be 2 or 4, got {bit_width}")
+        if bit_width not in (2, 3, 4):
+            raise ValueError(f"bit_width must be 2, 3, or 4, got {bit_width}")
         if search_type != SearchType.vector:
             raise ValueError(
                 f"TurboQuantVectorDb only supports search_type=SearchType.vector; "

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -76,7 +76,7 @@ class TurboQuantDocumentStore:
             quantized index is created lazily by ``IdMapIndex`` itself on
             the first ``write_documents`` call — matches the no-``dim``
             ergonomics of ``InMemoryDocumentStore``.
-        :param bit_width: Quantization width per coordinate (2 or 4).
+        :param bit_width: Quantization width per coordinate (2, 3, or 4).
         :param embedding_similarity_function: ``"cosine"`` (default) or
             ``"dot_product"``. Used to choose the ``scale_score`` formula
             during retrieval. Defaults to ``"cosine"`` because turbovec

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -63,7 +63,7 @@ class TurboQuantVectorStore(VectorStore):
             a lazy ``IdMapIndex`` is created — it commits to a dim on the
             first add and lets us match the no-arg constructor pattern of
             langchain_core's ``InMemoryVectorStore``.
-        :param bit_width: Quantization width (2 or 4) used when the index
+        :param bit_width: Quantization width (2, 3, or 4) used when the index
             is created from scratch. Ignored if ``index`` is supplied.
         """
         self._embedding = embedding

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -338,9 +338,19 @@ def test_constructor_rejects_non_cosine_distance():
         TurboQuantVectorDb(embedder=StubEmbedder(), distance=Distance.l2)
 
 
-def test_constructor_rejects_invalid_bit_width():
+@pytest.mark.parametrize("bad", [1, 5, 8])
+def test_constructor_rejects_invalid_bit_width(bad):
     with pytest.raises(ValueError, match="bit_width"):
-        TurboQuantVectorDb(embedder=StubEmbedder(), bit_width=8)
+        TurboQuantVectorDb(embedder=StubEmbedder(), bit_width=bad)
+
+
+def test_constructor_accepts_bit_width_3_round_trip():
+    # bit_width contract is {2, 3, 4}, matching the core IdMapIndex.
+    db = TurboQuantVectorDb(embedder=StubEmbedder(), bit_width=3)
+    db.create()
+    db.insert("h", [_doc("alpha"), _doc("beta"), _doc("gamma")])
+    [hit] = db.search("alpha", limit=1)
+    assert hit.content == "alpha"
 
 
 def test_dim_inferred_from_embedder():

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -42,6 +42,15 @@ def test_count_documents_starts_at_zero():
     assert store.count_documents() == 0
 
 
+def test_bit_width_3_round_trip():
+    # bit_width contract is {2, 3, 4}, matching the core IdMapIndex.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=3)
+    store.write_documents(make_docs(5))
+    assert store.count_documents() == 5
+    [hit] = store.embedding_retrieval(query_embedding=unit_vector(2), top_k=1)
+    assert hit.id == "doc-2"
+
+
 # ---- Field-fidelity round-trip tests (covers the langchain-class bug
 # pattern: returned Documents must populate every field the reference
 # would, not just id/content/meta). ----

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -47,6 +47,17 @@ def test_from_texts_infers_dim_and_indexes():
     assert store._index.bit_width == 4
 
 
+def test_from_texts_accepts_bit_width_3():
+    # bit_width contract is {2, 3, 4}, matching the core IdMapIndex.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["alpha", "beta", "gamma"], emb, bit_width=3
+    )
+    assert store._index.bit_width == 3
+    results = store.similarity_search("alpha", k=1)
+    assert results[0].page_content == "alpha"
+
+
 def test_similarity_search_returns_documents():
     emb = StubEmbeddings(dim=64)
     store = TurboQuantVectorStore.from_texts(["a", "b", "c"], emb, bit_width=4)

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -41,6 +41,18 @@ def test_from_params_creates_index():
     assert store.is_embedding_query is True
 
 
+def test_bit_width_3_round_trip():
+    # bit_width contract is {2, 3, 4}, matching the core IdMapIndex.
+    store = TurboQuantVectorStore.from_params(bit_width=3)
+    nodes = [_make_node(t, seed=i) for i, t in enumerate(["a", "b", "c"])]
+    store.add(nodes)
+    assert store._index.bit_width == 3
+    result = store.query(
+        VectorStoreQuery(query_embedding=_unit_vec(1, 64), similarity_top_k=1)
+    )
+    assert result.ids == [nodes[1].node_id]
+
+
 # ---- Lazy index construction --------------------------------------------
 
 def test_constructor_no_index_is_lazy():


### PR DESCRIPTION
## Ruling

Per the maintainer ruling on #138: **`bit_width ∈ {2, 3, 4}` is the blessed contract everywhere.** The core fully supports 3-bit (`TurboQuantIndex`/`IdMapIndex` accept it and the core test matrices exercise it); the `{2, 4}` doc claims and agno's `{2, 4}` guard were the inconsistencies. This PR relaxes agno's guard and aligns every doc/docstring site — no guards added to the other three stores.

## Verified current behavior (executed on main @ fac4174)

- Core: `TurboQuantIndex(dim=64, bit_width=3)` and `IdMapIndex(dim=64, bit_width=3)` construct; 3-bit add+search round-trip returns the expected top-1 ids; 1 and 5 raise `ValueError: bit_width must be 2, 3, or 4, got N`.
- langchain / haystack / llama_index stores: accept `bit_width=3`, insert + search round-trip returns correct results.
- agno: `TurboQuantVectorDb(embedder=..., bit_width=3)` → `ValueError: bit_width must be 2 or 4, got 3`.

## Changes — per-site inventory

**Behavior (agno guard relax):**
- `turbovec-python/python/turbovec/agno.py:108-109` — `if bit_width not in (2, 4)` → `(2, 3, 4)`; message `"bit_width must be 2 or 4"` → `"bit_width must be 2, 3, or 4"` (same style as the core's error).

**Docs/docstrings (all previously claimed `{2, 4}` or "2 or 4"; now `{2, 3, 4}`):**
- `docs/integrations/langchain.md:44`
- `docs/integrations/llama_index.md:40`
- `docs/integrations/haystack.md:44`
- `docs/integrations/agno.md:49`
- `turbovec-python/python/turbovec/agno.py:82` (constructor docstring)
- `turbovec-python/python/turbovec/haystack.py:79` (constructor docstring)
- `turbovec-python/python/turbovec/langchain.py:66` (constructor docstring)

Already correct, untouched: `docs/api.md` (states `{2, 3, 4}`), README (no set claim), llama_index docstrings (no set claim).

**CHANGELOG:** bullet under Unreleased → Python package → Fixed.

## Tests

- `test_langchain.py::test_from_texts_accepts_bit_width_3`
- `test_haystack.py::test_bit_width_3_round_trip`
- `test_llama_index.py::test_bit_width_3_round_trip`
- `test_agno.py::test_constructor_accepts_bit_width_3_round_trip`
- `test_agno.py::test_constructor_rejects_invalid_bit_width[1|5|8]` (existing test parametrized so the relaxed guard still bites)

Each is a compact construction + insert + search round-trip at `bit_width=3`. The agno acceptance test was verified to **fail on unfixed sources** (with the exact old error) and pass after the fix.

## Suite

Full pytest in a scratch venv with a freshly built extension: **485 passed, 0 failed** (main baseline at fac4174: 479 passed; +6 = 4 new tests + 2 from parametrizing the agno rejection test). No Rust changes — cargo untouched.

Closes #138

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)