### PR TITLE
fix: agno search() dedups duplicate-content results, matching LanceDb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,17 @@ appears under each surface it touches.
   Also, `delete_by_content_id(None)` / `update_metadata(None, ...)` are
   now no-ops instead of matching every document stored without a
   `content_id`. (#169)
+- **agno: `search()` / `async_search()` deduplicate duplicate-content
+  results.** `LanceDb.search` — the drop-in reference — unconditionally
+  collapses the final result list by `md5(doc.content)`, keeping the
+  first occurrence; turbovec returned every duplicate, handing callers
+  (e.g. retrieved-chunks-to-LLM pipelines) duplicated context and a
+  different result count. Per the maintainer ruling on the issue, dedup
+  now runs as the final search step, after filtering and rerank —
+  LanceDb's exact ordering — and, like LanceDb, without over-fetching,
+  so a search returns fewer than `limit` documents when duplicate-content
+  hits exist. Duplicate-content rows are still stored and individually
+  deletable; only search results collapse. (#136)
 - **Wrong dtype/ndim array arguments raise a clear `TypeError`** that names
   the argument and states expected vs got (e.g. "vectors must be a 2-D
   float32 array, got 2-D float64") instead of pyo3's opaque "'ndarray'

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -57,7 +57,7 @@ TurboQuantVectorDb(
 
 `insert` and `upsert` follow the same `(content_hash, documents, filters)` signature as `LanceDb`. The internal `doc_id` is derived as `md5(f"{base_id}_{content_hash}")` where `base_id` is `doc.id` (or `md5(content)` when missing). The contract: the same `(base_id, content_hash)` pair always produces the same internal id, and the same `base_id` with a *different* `content_hash` is treated as a new entry — letting you keep content versions side-by-side.
 
-Because `doc_id` is derived from `base_id` + `content_hash` (not from `name`, `content_id`, or metadata), two documents can collide on the same `doc_id` — a repeated explicit `doc.id`, or two documents with identical content and no id. When that happens **both are stored and both remain individually deletable** — keep-all, matching `LanceDb`'s append-only behavior. (This differs from the LangChain store, which keeps the last write per id.)
+Because `doc_id` is derived from `base_id` + `content_hash` (not from `name`, `content_id`, or metadata), two documents can collide on the same `doc_id` — a repeated explicit `doc.id`, or two documents with identical content and no id. When that happens **both are stored and both remain individually deletable** — keep-all, matching `LanceDb`'s append-only behavior. (This differs from the LangChain store, which keeps the last write per id.) At query time, duplicate-content hits collapse to a single search result — see [Filtered search](#filtered-search).
 
 ```python
 from agno.knowledge.document import Document
@@ -84,6 +84,8 @@ results = vector_db.search(
 ```
 
 Dict filters use AND-of-exact-equality on `Document.meta_data`. List-style `FilterExpr` filters (Agno's structured filter type) are silently ignored, matching `LanceDb`'s behaviour.
+
+Search results are deduplicated by content: after filtering (and reranking, when a reranker is set), hits with identical `content` (keyed by `md5` of the text) collapse to the first occurrence, matching `LanceDb.search`. When duplicate-content documents are stored — e.g. the same text inserted under two `content_hash`es — a search can therefore return fewer than `limit` results; there is no over-fetch to refill the list.
 
 ## Existence checks
 

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -48,7 +48,11 @@ class TurboQuantVectorDb(VectorDb):
     replacement wherever a single-machine LanceDb is used. Search-time
     filtering is resolved to an allowlist *before* scoring (kernel-level)
     rather than via post-filtering, so selective filters return up to
-    ``limit`` results from the filtered set instead of fewer.
+    ``limit`` results from the filtered set instead of fewer. Search
+    results are deduplicated by content (``md5(doc.content)``, first
+    occurrence kept) as the final step, matching ``LanceDb.search`` —
+    when duplicate-content hits exist, callers receive fewer than
+    ``limit`` documents.
 
     Example::
 
@@ -561,6 +565,25 @@ class TurboQuantVectorDb(VectorDb):
         absorb the small overshoot caused by quantization noise."""
         return max(0.0, min(1.0, (raw + 1.0) / 2.0))
 
+    @staticmethod
+    def _dedup_by_content(results: List[Document]) -> List[Document]:
+        """Collapse duplicate-content hits, keeping the first occurrence.
+
+        Matches LanceDb.search's final step: after filtering and rerank,
+        the result list is deduplicated by ``md5(doc.content)``. LanceDb
+        fetches ``limit`` results and *then* dedups, so callers can
+        receive fewer than ``limit`` documents when duplicates exist —
+        we deliberately replicate that rather than over-fetching to
+        refill the result set (issue #136)."""
+        seen_hashes: Set[str] = set()
+        unique_results: List[Document] = []
+        for doc in results:
+            doc_hash = md5(doc.content.encode()).hexdigest()
+            if doc_hash not in seen_hashes:
+                seen_hashes.add(doc_hash)
+                unique_results.append(doc)
+        return unique_results
+
     def _build_results(
         self, scores: np.ndarray, handles: np.ndarray
     ) -> List[Document]:
@@ -630,7 +653,9 @@ class TurboQuantVectorDb(VectorDb):
         results = self._build_results(scores, handles)
         if self.reranker is not None and results:
             results = self.reranker.rerank(query=query, documents=results)
-        return results
+        # Dedup by content as the final step, after rerank — matching
+        # LanceDb.search's ordering exactly (issue #136).
+        return self._dedup_by_content(results)
 
     async def async_search(
         self,
@@ -668,7 +693,9 @@ class TurboQuantVectorDb(VectorDb):
         results = self._build_results(scores, handles)
         if self.reranker is not None and results:
             results = self.reranker.rerank(query=query, documents=results)
-        return results
+        # Dedup by content as the final step, after rerank — matching
+        # LanceDb.search's ordering exactly (issue #136).
+        return self._dedup_by_content(results)
 
     def get_supported_search_types(self) -> List[SearchType]:
         # Only vector. Keyword and hybrid would require an external BM25

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -262,22 +262,98 @@ def test_update_metadata_with_empty_dict_is_noop():
     assert results[0].meta_data == {"k": "v"}
 
 
-def test_search_does_not_dedupe_distinct_documents_with_identical_content():
-    # LanceDb dedupes search results by content string; turbovec
-    # intentionally does NOT — each insert produces a distinct quantized
-    # vector + id, and we return both as separate hits so callers can
-    # tell them apart via content_id. Pin this deliberate divergence so
-    # a future refactor doesn't silently start matching LanceDb.
-    embedder = StubEmbedder(DIM)
-    db = TurboQuantVectorDb(embedder=embedder)
+def test_search_dedupes_duplicate_content_keeping_first():
+    # LanceDb parity (issue #136): LanceDb.search unconditionally
+    # deduplicates the final result list by md5(doc.content), keeping
+    # the first occurrence. The realistic way an agno user hits this:
+    # the same paragraph appears in two knowledge sources, so it's
+    # inserted under two content_hashes — the derived doc_ids differ,
+    # both rows coexist in the store, and search must collapse them.
+    db = TurboQuantVectorDb(embedder=StubEmbedder(DIM))
+    db.create()
+    db.insert("hash-a", [_doc("same text here", name="n1")])
+    db.insert("hash-b", [_doc("same text here", name="n2", meta_data={"src": "b"})])
+    db.insert("hash-c", [_doc("other doc entirely", name="n3")])
+
+    results = db.search("same text here", limit=5)
+    # Hand-computed LanceDb-semantics expectation: 3 raw hits ordered by
+    # score -> md5(content)-dedup keeps the first (highest-scoring)
+    # "same text here" plus the distinct doc.
+    assert [d.content for d in results] == ["same text here", "other doc entirely"]
+    assert results[0].name == "n1"  # first occurrence kept, n2 dropped
+
+
+def test_search_dedup_can_return_fewer_than_limit():
+    # LanceDb parity (issue #136): LanceDb fetches `limit` results and
+    # THEN dedups, so callers can receive fewer than `limit` documents
+    # when duplicates exist. We deliberately replicate that — no
+    # over-fetch to refill the result set back up to `limit`.
+    db = TurboQuantVectorDb(embedder=StubEmbedder(DIM))
+    db.create()
+    db.insert("hash-a", [_doc("duplicated text", name="n1")])
+    db.insert("hash-b", [_doc("duplicated text", name="n2")])
+
+    results = db.search("duplicated text", limit=2)
+    assert len(results) == 1  # fewer than limit=2 — pinned, not a bug
+
+
+def test_search_distinct_content_unaffected_by_dedup():
+    # Dedup keys on md5(content); distinct-content docs all survive.
+    db = TurboQuantVectorDb(embedder=StubEmbedder(DIM))
     db.create()
     db.insert("h", [
-        _doc("identical text", content_id="cid-1"),
-        _doc("identical text", content_id="cid-2"),
+        _doc("alpha text", content_id="cid-1"),
+        _doc("beta text", content_id="cid-2"),
+        _doc("gamma text", content_id="cid-3"),
     ])
-    results = db.search("identical text", limit=10)
+    results = db.search("alpha text", limit=10)
+    assert len(results) == 3
+    assert {d.content_id for d in results} == {"cid-1", "cid-2", "cid-3"}
+
+
+def test_async_search_dedupes_duplicate_content():
+    # async_search has its own body (it doesn't delegate to search), so
+    # pin the same LanceDb dedup semantics on the async path too.
+    import asyncio
+
+    async def runner():
+        db = TurboQuantVectorDb(embedder=StubEmbedder(DIM))
+        db.create()
+        db.insert("hash-a", [_doc("same text here", name="n1")])
+        db.insert("hash-b", [_doc("same text here", name="n2")])
+        db.insert("hash-c", [_doc("other doc entirely", name="n3")])
+        results = await db.async_search("same text here", limit=5)
+        assert [d.content for d in results] == [
+            "same text here",
+            "other doc entirely",
+        ]
+
+    asyncio.run(runner())
+
+
+def test_search_dedup_applied_after_rerank():
+    # LanceDb's ordering is filter -> rerank -> dedup: the reranker sees
+    # the full pre-dedup hit list, and dedup collapses the *reranked*
+    # order. Pin that the reranker receives all raw hits while the
+    # caller receives the deduped list.
+    class CapturingReranker(_AgnoReranker):
+        seen: int = 0
+
+        def rerank(self, query: str, documents):
+            type(self).seen = len(documents)
+            return list(documents)
+
+    db = TurboQuantVectorDb(
+        embedder=StubEmbedder(DIM), reranker=CapturingReranker()
+    )
+    db.create()
+    db.insert("hash-a", [_doc("same text here", name="n1")])
+    db.insert("hash-b", [_doc("same text here", name="n2")])
+    db.insert("hash-c", [_doc("other doc entirely", name="n3")])
+
+    results = db.search("same text here", limit=5)
+    assert CapturingReranker.seen == 3  # reranker saw the pre-dedup list
     assert len(results) == 2
-    assert {d.content_id for d in results} == {"cid-1", "cid-2"}
 
 
 def test_upsert_replaces_previous_generation():


### PR DESCRIPTION
## Maintainer ruling (issue #136)

Adopt agno-ecosystem parity: `LanceDb` — the canonical agno `VectorDb` and this module's declared drop-in reference — dedups **every** search result set by `md5(content)` in its main `search()` method, so `TurboQuantVectorDb.search()` must do the same.

## LanceDb-source evidence

Verified in agno 2.8.2, `agno/vectordb/lancedb/lance_db.py`, `search()` (lines 544–552): after the search-type dispatch, metadata filtering, and optional rerank, the final step is

```python
seen_hashes: Set[str] = set()
unique_results: List[Document] = []
for doc in search_results:
    doc_hash = md5(doc.content.encode()).hexdigest()
    if doc_hash not in seen_hashes:
        seen_hashes.add(doc_hash)
        unique_results.append(doc)
search_results = unique_results
```

Key semantics replicated exactly:
- Dedup is the **final** step — after filtering and rerank.
- Keyed on `md5(doc.content)`, **first occurrence kept**.
- LanceDb fetches `limit` results and *then* dedups — callers can receive **fewer than `limit`** documents when duplicates exist. This PR deliberately does **not** over-fetch to compensate; drop-in parity is the ruling.
- `async_search`: LanceDb's delegates to sync `search`; ours has its own body, so the dedup is applied on both paths.

## Repro (on main @ fac4174)

Same text inserted under two `content_hash`es (how an agno user hits this: one paragraph present in two knowledge sources — derived doc_ids differ, both rows coexist):

```
db.insert("hash-a", [doc("same text here", name="n1")])
db.insert("hash-b", [doc("same text here", name="n2")])
db.insert("hash-c", [doc("other doc entirely", name="n3")])
db.search("same text here", limit=5)
# before: 3 results — ['same text here', 'same text here', 'other doc entirely']
# after:  2 results — ['same text here', 'other doc entirely'] (n1 kept, n2 dropped)
```

## Changes

- `turbovec-python/python/turbovec/agno.py`: `_dedup_by_content()` helper; applied as the final step of `search()` and `async_search()`; class docstring documents the behavior.
- `turbovec-python/tests/test_agno.py`: the prior test pinning no-dedup as an intentional divergence (`test_search_does_not_dedupe_distinct_documents_with_identical_content`) is replaced per the ruling with:
  - `test_search_dedupes_duplicate_content_keeping_first` — hand-computed LanceDb-semantics expectation, first/highest-scoring occurrence kept
  - `test_search_dedup_can_return_fewer_than_limit` — count semantics pinned explicitly (LanceDb parity, no over-fetch)
  - `test_search_distinct_content_unaffected_by_dedup`
  - `test_async_search_dedupes_duplicate_content`
  - `test_search_dedup_applied_after_rerank` — reranker sees the pre-dedup list; dedup collapses the reranked order
- `docs/integrations/agno.md`: dedup documented in steady-state voice (Filtered search section + insert-section cross-reference).
- `CHANGELOG.md`: Unreleased → Python package → Fixed.

The #144 None-filter and similarity-threshold behaviors are untouched (dedup runs strictly after both).

## Verification

- The four behavior tests **fail on unfixed sources** (verified via `git stash` of `agno.py`: 4 failed / 1 passed) and pass with the fix.
- Full Python suite in a fresh scratch venv (agno 2.8.2): **483 passed, 0 failed** (479 on main; net +4 from replacing 1 test with 5).

Closes #136

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)