### PR TITLE
fix: Haystack write_documents FAIL/NONE partial-writes like the reference (issue #167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,24 @@ appears under each surface it touches.
   time by ~25x). Falls back to `"0.0.0.dev0"` when no dist metadata
   is installed. (#153)
 
+#### Changed
+
+- **Haystack `write_documents` under `FAIL`/`NONE` now partial-writes like
+  the reference instead of being atomic.** Previously the whole batch was
+  validated up front and a `DuplicateDocumentError` left the store
+  untouched. `InMemoryDocumentStore` instead commits each document as it
+  iterates and raises on the *first* duplicate, persisting every
+  preceding non-duplicate document. Per the maintainer ruling on #167,
+  the store now matches that post-exception state exactly: documents are
+  validated and committed one at a time in batch order, so after the
+  raise everything before the first colliding id is persisted (an
+  in-batch repeat keeps its already-committed first instance). Each
+  individual document commit remains all-or-nothing, so a document
+  failing turbovec's own embedding validation mid-batch persists the
+  documents before it and leaves the index and id maps consistent.
+  `OVERWRITE`/`SKIP` semantics and all success-path return counts are
+  unchanged. (#167)
+
 #### Fixed
 
 - **Optional-dependency floors now match what the integrations actually

--- a/docs/integrations/haystack.md
+++ b/docs/integrations/haystack.md
@@ -61,6 +61,8 @@ store.write_documents(docs, policy=DuplicatePolicy.OVERWRITE) # remove-then-re-a
 
 Returns the number of documents actually written (so `SKIP` may return less than `len(docs)`).
 
+Under `FAIL` (and `NONE`), documents are committed one at a time in batch order and the `DuplicateDocumentError` is raised on the first colliding id — every non-duplicate document *before* the collision stays persisted, matching `InMemoryDocumentStore`'s post-exception state exactly.
+
 ## Delete
 
 ```python

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -177,13 +177,44 @@ class TurboQuantDocumentStore:
         if policy == DuplicatePolicy.NONE:
             policy = DuplicatePolicy.FAIL
 
-        # First pass: validate and resolve duplicates according to policy.
-        # Duplicates are resolved against the batch-so-far as well as the
-        # existing store: InMemoryDocumentStore writes into its dict as it
-        # iterates, so a repeated id *within a single call* is resolved the
-        # same way a cross-call repeat would be. Without tracking the batch,
-        # every duplicate row still gets its own vector while _str_to_u64
-        # keeps only the last handle, orphaning the earlier vectors.
+        if policy == DuplicatePolicy.FAIL:
+            # Reference parity (issue #167): InMemoryDocumentStore commits
+            # each document as it iterates and raises on the *first*
+            # duplicate, so every non-duplicate document preceding it
+            # stays persisted — a partial write. Mirror that observable
+            # state exactly: validate and commit per document, raising on
+            # the first collision. A repeated id within a single call
+            # collides with its already-committed first instance, the same
+            # way a cross-call repeat would. Each individual commit is
+            # still all-or-nothing — validation precedes any mutation, so
+            # a failing document mid-batch never leaves the index and the
+            # id maps inconsistent (#89/#139 apply per document).
+            written = 0
+            for doc in documents:
+                if doc.id in self._str_to_u64:
+                    # Checked before embedding validation: the reference
+                    # raises DuplicateDocumentError for a colliding id
+                    # regardless of the document's other fields.
+                    raise DuplicateDocumentError(
+                        f"ID '{doc.id}' already exists in the document store."
+                    )
+                if doc.embedding is None:
+                    raise ValueError(
+                        f"Document {doc.id!r} has no embedding. "
+                        "TurboQuantDocumentStore only stores documents with precomputed "
+                        "embeddings — run an embedder component before writing."
+                    )
+                self._commit_batch([doc])
+                written += 1
+            return written
+
+        # SKIP / OVERWRITE: first pass validates and resolves duplicates
+        # against the batch-so-far as well as the existing store:
+        # InMemoryDocumentStore writes into its dict as it iterates, so a
+        # repeated id *within a single call* is resolved the same way a
+        # cross-call repeat would be. Without tracking the batch, every
+        # duplicate row still gets its own vector while _str_to_u64 keeps
+        # only the last handle, orphaning the earlier vectors.
         to_write: List[Document] = []
         batch_pos: Dict[str, int] = {}  # doc.id -> index into to_write
         to_remove: List[str] = []  # existing ids to drop, deferred past add
@@ -196,14 +227,9 @@ class TurboQuantDocumentStore:
                     "embeddings — run an embedder component before writing."
                 )
             present = doc.id in self._str_to_u64 or doc.id in batch_pos
-            if policy != DuplicatePolicy.OVERWRITE and present:
-                if policy == DuplicatePolicy.FAIL:
-                    raise DuplicateDocumentError(
-                        f"ID '{doc.id}' already exists in the document store."
-                    )
-                if policy == DuplicatePolicy.SKIP:
-                    written -= 1
-                    continue
+            if policy == DuplicatePolicy.SKIP and present:
+                written -= 1
+                continue
             if policy == DuplicatePolicy.OVERWRITE:
                 if doc.id in self._str_to_u64:
                     # Defer the removal until after the add succeeds so a
@@ -218,9 +244,22 @@ class TurboQuantDocumentStore:
             batch_pos[doc.id] = len(to_write)
             to_write.append(doc)
 
-        if not to_write:
-            return written
+        if to_write:
+            self._commit_batch(to_write, to_remove)
+        return written
 
+    def _commit_batch(
+        self, to_write: List[Document], to_remove: Iterable[str] = ()
+    ) -> None:
+        """Validate ``to_write``'s embeddings, add them to the index, then
+        update the id maps (dropping ``to_remove`` ids in between).
+
+        All-or-nothing with respect to the given batch: validation
+        precedes any mutation and the id maps are only updated after the
+        index add succeeds, so a failure leaves the store exactly as it
+        was (issue #89). The FAIL path calls this with single-document
+        batches to get per-document commit semantics.
+        """
         vectors = np.asarray(
             [doc.embedding for doc in to_write], dtype=np.float32
         )
@@ -271,7 +310,6 @@ class TurboQuantDocumentStore:
                 "blob": doc.blob,
                 "sparse_embedding": doc.sparse_embedding,
             }
-        return written
 
     def delete_documents(self, document_ids: List[str]) -> None:
         # Haystack's protocol says silently ignore missing ids.

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -466,6 +466,8 @@ def test_intra_batch_duplicate_overwrite_keeps_last_no_orphan():
 
 def test_intra_batch_duplicate_fail_raises():
     # FAIL must reject a repeat within the same call, not just across calls.
+    # The first instance was already committed when the repeat is reached
+    # (reference partial-write semantics, issue #167), so it survives.
     store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
     with pytest.raises(DuplicateDocumentError):
         store.write_documents(
@@ -475,6 +477,154 @@ def test_intra_batch_duplicate_fail_raises():
             ],
             policy=DuplicatePolicy.FAIL,
         )
+    assert store.count_documents() == 1
+    assert store.filter_documents()[0].content == "a"
+
+
+# ---- Issue #167: FAIL/NONE partial-write reference parity. The
+# reference InMemoryDocumentStore commits each document as it iterates
+# and raises on the *first* duplicate, leaving every preceding
+# non-duplicate document persisted. Maintainer ruling on #167: match
+# that post-exception state exactly (reference parity over atomicity).
+# Each test runs the live reference on the same batch and asserts the
+# two stores end in identical state. ----
+
+def _final_ids(store) -> list[str]:
+    return sorted(d.id for d in store.filter_documents())
+
+
+def test_fail_partial_write_parity_in_batch_duplicate():
+    # Batch [a(fresh), b(fresh), a(dup)]: both stores raise on the third
+    # doc and keep {a, b} — with the *first* instance of `a` surviving.
+    from haystack.document_stores.in_memory import InMemoryDocumentStore
+
+    def batch() -> list[Document]:
+        return [
+            Document(id="a", content="a-first", embedding=unit_vector(0)),
+            Document(id="b", content="b", embedding=unit_vector(1)),
+            Document(id="a", content="a-second", embedding=unit_vector(2)),
+        ]
+
+    reference = InMemoryDocumentStore()
+    with pytest.raises(DuplicateDocumentError):
+        reference.write_documents(batch(), policy=DuplicatePolicy.FAIL)
+
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    with pytest.raises(DuplicateDocumentError):
+        store.write_documents(batch(), policy=DuplicatePolicy.FAIL)
+
+    assert _final_ids(store) == sorted(reference.storage.keys()) == ["a", "b"]
+    assert store.storage["a"].content == reference.storage["a"].content == "a-first"
+    # Maps stay consistent after the partial write.
+    assert len(store._str_to_u64) == len(store._u64_to_doc) == 2
+
+
+def test_fail_partial_write_parity_cross_call_duplicate():
+    # Existing x; batch [y(fresh), x(dup)]: both stores keep {x, y} with
+    # the *original* x untouched.
+    from haystack.document_stores.in_memory import InMemoryDocumentStore
+
+    def existing() -> Document:
+        return Document(id="x", content="x-orig", embedding=unit_vector(0))
+
+    def batch() -> list[Document]:
+        return [
+            Document(id="y", content="y", embedding=unit_vector(1)),
+            Document(id="x", content="x-new", embedding=unit_vector(2)),
+        ]
+
+    reference = InMemoryDocumentStore()
+    reference.write_documents([existing()])
+    with pytest.raises(DuplicateDocumentError):
+        reference.write_documents(batch(), policy=DuplicatePolicy.FAIL)
+
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents([existing()])
+    with pytest.raises(DuplicateDocumentError):
+        store.write_documents(batch(), policy=DuplicatePolicy.FAIL)
+
+    assert _final_ids(store) == sorted(reference.storage.keys()) == ["x", "y"]
+    assert store.storage["x"].content == reference.storage["x"].content == "x-orig"
+
+
+def test_none_policy_partial_write_parity_matches_fail():
+    # NONE (the default) is treated as FAIL by both stores — same
+    # partial-write state after the raise.
+    from haystack.document_stores.in_memory import InMemoryDocumentStore
+
+    def batch() -> list[Document]:
+        return [
+            Document(id="a", content="a", embedding=unit_vector(0)),
+            Document(id="b", content="b", embedding=unit_vector(1)),
+            Document(id="a", content="a2", embedding=unit_vector(2)),
+        ]
+
+    reference = InMemoryDocumentStore()
+    with pytest.raises(DuplicateDocumentError):
+        reference.write_documents(batch())  # default policy = NONE
+
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    with pytest.raises(DuplicateDocumentError):
+        store.write_documents(batch())  # default policy = NONE
+
+    assert _final_ids(store) == sorted(reference.storage.keys()) == ["a", "b"]
+
+
+def test_fail_duplicate_without_embedding_raises_duplicate_error():
+    # A colliding id raises DuplicateDocumentError even when the repeat
+    # has no embedding: the reference has no embedding validation, so the
+    # duplicate check must come first for the raise type to match.
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    store.write_documents([Document(id="a", content="a", embedding=unit_vector(0))])
+    with pytest.raises(DuplicateDocumentError):
+        store.write_documents(
+            [Document(id="a", content="no-emb")], policy=DuplicatePolicy.FAIL
+        )
+
+
+def test_fail_invalid_document_mid_batch_commits_preceding_and_stays_consistent():
+    # Per-document commit means a document that fails turbovec's own
+    # validation (no embedding — the reference imposes no such
+    # requirement) leaves the preceding good documents persisted, the
+    # failing document unwritten, and the index/id maps consistent
+    # (#89/#139 apply per document).
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+    with pytest.raises(ValueError, match="no embedding"):
+        store.write_documents(
+            [
+                Document(id="g1", content="g1", embedding=unit_vector(0)),
+                Document(id="bad", content="no-emb"),
+                Document(id="g2", content="g2", embedding=unit_vector(1)),
+            ],
+            policy=DuplicatePolicy.FAIL,
+        )
+    assert _final_ids(store) == ["g1"]
+    assert len(store._str_to_u64) == len(store._u64_to_doc) == 1
+    # The store still works after the failed write.
+    store.write_documents([Document(id="g2", content="g2", embedding=unit_vector(1))])
+    assert _final_ids(store) == ["g1", "g2"]
+
+
+def test_fail_partial_write_async_matches_sync():
+    # The async twin delegates to the sync path — same partial-write
+    # semantics on the error path.
+    import asyncio
+
+    store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
+
+    async def run() -> None:
+        with pytest.raises(DuplicateDocumentError):
+            await store.write_documents_async(
+                [
+                    Document(id="a", content="a", embedding=unit_vector(0)),
+                    Document(id="b", content="b", embedding=unit_vector(1)),
+                    Document(id="a", content="a2", embedding=unit_vector(2)),
+                ],
+                policy=DuplicatePolicy.FAIL,
+            )
+
+    asyncio.run(run())
+    assert _final_ids(store) == ["a", "b"]
 
 
 def test_intra_batch_duplicate_skip_keeps_first():


### PR DESCRIPTION
## Summary

Implements the maintainer ruling on #167: `TurboQuantDocumentStore.write_documents` under `DuplicatePolicy.FAIL` (and `NONE`, which defaults to `FAIL`) now matches the reference `InMemoryDocumentStore`'s partial-write semantics exactly, instead of turbovec's previous atomic validate-first behavior. The reference commits each document as it iterates and raises `DuplicateDocumentError` on the *first* duplicate, leaving every preceding non-duplicate document persisted; the ruling chose that reference parity over the atomic behavior.

## Before / after

Post-exception state, `FAIL` policy (verified against the live reference; `haystack-ai` reference source unchanged on this point in the installed version):

| Scenario | Reference `InMemoryDocumentStore` | turbovec on `main` (atomic) | turbovec on this branch |
|---|---|---|---|
| batch `[a(fresh), b(fresh), a(dup)]` | raises; final ids `['a', 'b']` (first `a` survives) | raises; final ids `[]` | raises; final ids `['a', 'b']` (first `a` survives) |
| existing `x`; batch `[y(fresh), x(dup)]` | raises; final ids `['x', 'y']` (original `x` intact) | raises; final ids `['x']` | raises; final ids `['x', 'y']` (original `x` intact) |
| same batches under `NONE` (default) | identical to `FAIL` | identical to `FAIL` | identical to `FAIL` |
| dup whose repeat has no embedding | raises `DuplicateDocumentError` | raised `ValueError` (embedding checked first) | raises `DuplicateDocumentError` (dup check now per-doc, first) |
| `[good, no-embedding, good]` (turbovec-only validation; reference accepts all three) | n/a — reference has no embedding requirement | raises `ValueError`; final ids `[]` | raises `ValueError`; final ids `['good1']`, index/id maps consistent |

`OVERWRITE`/`SKIP` semantics and all success-path return counts are unchanged (existing pins still pass).

## Implementation

- `write_documents` routes `FAIL`/`NONE` to a per-document loop: duplicate check (against the store, which now already contains the batch prefix — so in-batch repeats collide with their committed first instance exactly like the reference) → embedding validation → commit. The raise type is `DuplicateDocumentError` from `haystack.document_stores.errors`; the existing message style is kept.
- The batch validate+add+map block is factored into `_commit_batch`, shared by both paths. Each call is all-or-nothing: validation precedes any mutation and the id maps update only after the index add succeeds, so the #89/#139 guarantees now apply **per document** on the `FAIL` path — a bad document mid-batch fails cleanly with the store consistent at every step.
- `write_documents_async` delegates to the sync path and inherits the semantics (covered by a dedicated test).
- Docs: steady-state description of the `FAIL`/`NONE` commit order added to `docs/integrations/haystack.md` (the `save_to_disk` atomicity note is about persistence and is untouched). CHANGELOG entry under Unreleased → Python package → Changed.

## Tests

New/updated in `turbovec-python/tests/test_haystack.py` — the parity tests run the live `InMemoryDocumentStore` on the same batch in the same test and assert reference-identical final state:

- `test_fail_partial_write_parity_in_batch_duplicate`
- `test_fail_partial_write_parity_cross_call_duplicate`
- `test_none_policy_partial_write_parity_matches_fail`
- `test_fail_duplicate_without_embedding_raises_duplicate_error`
- `test_fail_invalid_document_mid_batch_commits_preceding_and_stays_consistent`
- `test_fail_partial_write_async_matches_sync`
- `test_intra_batch_duplicate_fail_raises` (extended with final-state assertions)

All 7 verified to **fail** on the unfixed sources (stash-checkout run) and pass on this branch. Full Python suite: **485 passed, 0 failed**.

Closes #167

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
