### PR TITLE
fix: layered thread-safety for the four Python integration stores (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,26 @@ appears under each surface it touches.
 
 #### Changed
 
+- **All four integration stores are now safe for concurrent
+  multi-threaded use; writes serialize on a per-store lock.** The
+  LangChain, Haystack, LlamaIndex, and Agno stores adopt a layered
+  design measured in the #161 research: every mutating method
+  (add/write/insert, delete, upsert, update, clear/drop — sync and
+  async) and every save path (`dump` / `save_to_disk` / `persist` /
+  `save`) serializes on a per-store `threading.RLock`; reads take no
+  lock, so concurrent searches keep overlapping and scaling across
+  threads (#186). Adds now populate the side-car maps *before* the
+  index insert (with a failure-unwind preserving the #89
+  "a failed add never destroys existing data" guarantee) and deletes
+  remove from the index *first*, so a search can never surface a
+  handle that doesn't resolve; result translation skips handles whose
+  entries a concurrent delete removed mid-search, and filtered
+  searches retry a stale allowlist and fall back to a non-raising
+  post-filtered search under sustained churn. The resulting contract:
+  a read overlapping a write sees pre- or post-write state, and under
+  heavy concurrent churn a search may transiently return fewer than
+  `k` results. There is still no cross-call atomicity, and
+  multi-process access remains unsupported. (#161)
 - **Haystack `write_documents` under `FAIL`/`NONE` now partial-writes like
   the reference instead of being atomic.** Previously the whole batch was
   validated up front and a `DuplicateDocumentError` left the store
@@ -155,6 +175,22 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **LlamaIndex `add()` no longer loses data under concurrent calls.**
+  `_next_u64 += 1` on a pydantic `PrivateAttr` is not atomic under
+  the GIL, so two concurrent `add()` calls could issue the same
+  handle — the second batch was rejected with an opaque
+  `ValueError: id already present` and its documents silently never
+  stored (measured: 0.78% of adds under 2-thread ingest). Handle
+  issuance now happens under the store's writer lock. (#161)
+- **Concurrent search / retrieval no longer raises transient
+  `KeyError` / `RuntimeError: dictionary changed size during
+  iteration` while another thread writes.** This closes the measured
+  crash classes in all four stores, including Agno's
+  delete-vs-delete cleanup-scan crash and the misleading
+  `KeyError: allowlist contains id(s) not present in index` from a
+  delete racing a filtered search. Load-time validation is
+  unchanged: a corrupt persisted store still fails loudly at load.
+  (#161)
 - **Agno's `TurboQuantVectorDb` accepts `bit_width=3`.** The constructor
   guard rejected 3 even though the core `IdMapIndex` — and the langchain,
   haystack, and llama_index stores built on it — fully support it; the

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -139,6 +139,21 @@ Document metadata must be JSON-serializable — same constraint Agno's `LanceDb`
 
 The lifecycle, write, and read methods have async counterparts: `async_create`, `async_drop`, `async_exists`, `async_name_exists`, `async_get_count`, `async_insert`, `async_upsert`, `async_search`. The remaining methods (the `delete_by_*` family, `update_metadata`, `save`, `id_exists`, `content_hash_exists`, `optimize`) are sync-only. When the embedder exposes `async_get_embedding` / `async_get_embeddings_batch_and_usage`, the async paths use it for genuine async embedding generation.
 
+## Thread safety
+
+The store is safe for concurrent multi-threaded use:
+
+- **Reads run concurrently and scale.** `search`, the existence checks, and `get_count` take no lock; the underlying index releases the GIL during scoring, so independent searches from multiple threads overlap and scale.
+- **Writes serialize.** `insert`, `upsert`, the `delete_by_*` family, `update_metadata`, `drop`, and `save` serialize on a per-store lock. The `async_*` variants delegate to the same locked bodies.
+- **A read overlapping a write sees pre- or post-write state** — never a torn one. Under heavy concurrent churn a search may transiently return fewer than `limit` results (hits deleted mid-search are skipped).
+
+What the contract does *not* cover:
+
+- **No cross-call atomicity.** A caller-side check-then-act sequence (`id_exists` then `delete_by_id`) can interleave with other writers. Batch writes are not atomic with respect to readers: a search overlapping an `upsert` can briefly see both the old and new generation of a `content_hash`.
+- **`save` serializes with writes** (so it always snapshots a consistent store); reads may proceed during a save.
+- **The embedder and reranker are invoked outside the store's lock** and must be thread-safe themselves.
+- **Multi-process access is not supported.**
+
 ## Known limitations
 
 - **Vector search only.** `search_type=SearchType.keyword` and `SearchType.hybrid` are not supported (would require an external BM25 / lexical index). Constructor raises `ValueError` on those.

--- a/docs/integrations/haystack.md
+++ b/docs/integrations/haystack.md
@@ -170,6 +170,21 @@ indexing.connect("embedder.documents", "writer.documents")
 indexing.run({"embedder": {"documents": my_docs}})
 ```
 
+## Thread safety
+
+The store is safe for concurrent multi-threaded use:
+
+- **Reads run concurrently and scale.** `embedding_retrieval`, `filter_documents`, the count and metadata helpers, and `storage` take no lock; the underlying index releases the GIL during scoring, so independent retrievals from multiple threads overlap and scale.
+- **Writes serialize.** `write_documents`, `delete_documents` / `delete_all_documents` / `delete_by_filter`, `update_by_filter`, and `save_to_disk` serialize on a per-store lock. The `*_async` variants delegate to the same locked bodies.
+- **A read overlapping a write sees pre- or post-write state** — never a torn one. Under heavy concurrent churn a retrieval may transiently return fewer than `top_k` documents (hits deleted mid-retrieval are skipped).
+
+What the contract does *not* cover:
+
+- **No cross-call atomicity.** A caller-side check-then-act sequence (`count_documents` then `filter_documents`) can interleave with other writers. Batch writes are not atomic with respect to readers: a retrieval overlapping an `OVERWRITE` write can briefly see a document id under both its old and new entry.
+- **`save_to_disk` serializes with writes** (so it always snapshots a consistent store); reads may proceed during a save.
+- **`to_dict` / `from_dict` and the executor lifecycle** are assumed single-threaded.
+- **Multi-process access is not supported.**
+
 ## Known limitations
 
 - **Embeddings are not retained.** `embedding_retrieval(..., return_embedding=True)` is accepted for signature compatibility but `Document.embedding` is always `None` on retrieved docs — turbovec discards the full-precision vector after quantization.

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -139,6 +139,21 @@ Document metadata must be JSON-serializable — the same constraint `InMemoryVec
 
 `dump` is atomic with respect to the destination: both files are written to sibling temp files and moved into place, so a failed dump (e.g. non-JSON-serializable metadata) leaves a store previously saved at the same path intact.
 
+## Thread safety
+
+The store is safe for concurrent multi-threaded use:
+
+- **Reads run concurrently and scale.** `similarity_search*` and `get_by_ids` take no lock; the underlying index releases the GIL during scoring, so independent searches from multiple threads overlap and scale.
+- **Writes serialize.** `add_texts` / `add_documents`, `delete`, and `dump` (and their async counterparts) serialize on a per-store lock.
+- **A read overlapping a write sees pre- or post-write state** — never a torn one. Under heavy concurrent churn a search may transiently return fewer than `k` results (hits deleted mid-search are skipped).
+
+What the contract does *not* cover:
+
+- **No cross-call atomicity.** A caller-side check-then-act sequence (`get_by_ids` then `delete`, a count then a search) can interleave with other writers. Batch writes are not atomic with respect to readers: a search overlapping an upsert can briefly see a document id under both its old and new entry.
+- **`dump` serializes with writes** (so it always snapshots a consistent store); reads may proceed during a dump.
+- **The embedder is invoked outside the store's lock** and must be thread-safe itself.
+- **Multi-process access is not supported.**
+
 ## Known limitations
 
 - **Max-marginal-relevance search is not supported.** `max_marginal_relevance_search` and its variants raise `NotImplementedError` with an explanation. MMR requires the full-precision embedding of each candidate to compute pairwise diversity; turbovec discards full-precision vectors after quantization. If you need MMR, keep a parallel store with the raw embeddings and run MMR over that.

--- a/docs/integrations/llama_index.md
+++ b/docs/integrations/llama_index.md
@@ -211,6 +211,20 @@ fresh = TurboQuantVectorStore.from_dict(config)                   # empty store 
 
 `to_dict` / `from_dict` serialize only the store's configuration. Node data round-trips through `persist` / `from_persist_path`.
 
+## Thread safety
+
+The store is safe for concurrent multi-threaded use:
+
+- **Reads run concurrently and scale.** `query` and `get_nodes` take no lock; the underlying index releases the GIL during scoring, so independent queries from multiple threads overlap and scale.
+- **Writes serialize.** `add`, `delete`, `delete_nodes`, `clear`, and `persist` serialize on a per-store lock. The `async_add` / `a*` variants delegate to the same locked bodies, so concurrent adds issue unique handles — no batch is ever rejected or lost to a handle collision.
+- **A read overlapping a write sees pre- or post-write state** — never a torn one. Under heavy concurrent churn a query may transiently return fewer than `similarity_top_k` results (hits deleted mid-query are skipped).
+
+What the contract does *not* cover:
+
+- **No cross-call atomicity.** A caller-side check-then-act sequence (`get_nodes` then `delete_nodes`) can interleave with other writers. Batch writes are not atomic with respect to readers: a query overlapping a re-`add` of an existing `node_id` can briefly see that id under both its old and new entry.
+- **`persist` serializes with writes** (so it always snapshots a consistent store); reads may proceed during a persist.
+- **Multi-process access is not supported.**
+
 ## Known limitations
 
 - **MMR is not supported.** Max-marginal-relevance retrieval requires the full-precision embedding of each candidate to compute pairwise diversity; turbovec discards full-precision vectors after quantization.

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -10,6 +10,7 @@ backend) so this can be swapped in wherever ``LanceDb`` is used.
 from __future__ import annotations
 
 import json
+import threading
 from hashlib import md5
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set, Union
@@ -53,6 +54,21 @@ class TurboQuantVectorDb(VectorDb):
     occurrence kept) as the final step, matching ``LanceDb.search`` —
     when duplicate-content hits exist, callers receive fewer than
     ``limit`` documents.
+
+    **Thread safety.** The store is safe for concurrent multi-threaded
+    use. Reads (``search``, existence checks, ``get_count``) run
+    concurrently and scale across threads; writes (``insert``,
+    ``upsert``, ``delete_by_*``, ``update_metadata``, ``drop``,
+    ``save``) serialize on a per-store lock — the ``async_*`` variants
+    delegate to the same locked bodies. A read that overlaps a write
+    sees either the pre- or post-write state — never a torn one — and
+    under heavy concurrent churn a search may transiently return fewer
+    than ``limit`` results. There is no cross-call atomicity: a
+    caller-side check-then-act sequence (e.g. ``id_exists`` then
+    ``delete_by_id``) can still interleave with other writers.
+    Embedders and rerankers are invoked outside the store's lock and
+    must be thread-safe themselves. Multi-process access is not
+    supported.
 
     Example::
 
@@ -150,6 +166,13 @@ class TurboQuantVectorDb(VectorDb):
         # Auxiliary indexes for O(1) protocol queries
         self._content_hashes: Set[str] = set()
         self._name_to_ids: Dict[str, Set[str]] = {}
+        # Serializes every mutation (insert / upsert / delete / update /
+        # drop / save). Readers do NOT take this lock — search stays
+        # lock-free so concurrent reads keep scaling across threads
+        # (#186); reader safety comes from mutation ordering plus
+        # tolerant handle resolution instead. RLock: upsert nests into
+        # insert and _remove_handle.
+        self._write_lock = threading.RLock()
 
     # ---- handle allocation ------------------------------------------------
 
@@ -167,17 +190,18 @@ class TurboQuantVectorDb(VectorDb):
         under it, ``create()`` loads that save; otherwise it instantiates
         a fresh empty index sized to ``embedder.dimensions``.
         """
-        if self._index is not None:
-            return
-        # Try loading from path first if one was set; fall through to a
-        # fresh index if the path doesn't contain a previous save.
-        if self.path is not None and Path(self.path).is_dir():
-            try:
-                self._load_from(Path(self.path))
+        with self._write_lock:
+            if self._index is not None:
                 return
-            except FileNotFoundError:
-                pass
-        self._index = IdMapIndex(self.dimensions, self.bit_width)
+            # Try loading from path first if one was set; fall through to a
+            # fresh index if the path doesn't contain a previous save.
+            if self.path is not None and Path(self.path).is_dir():
+                try:
+                    self._load_from(Path(self.path))
+                    return
+                except FileNotFoundError:
+                    pass
+            self._index = IdMapIndex(self.dimensions, self.bit_width)
 
     async def async_create(self) -> None:
         self.create()
@@ -190,16 +214,17 @@ class TurboQuantVectorDb(VectorDb):
         # fresh instead of reloading — and resurrecting — the dropped
         # data (issue #169). Matches LanceDb's drop_table, which deletes
         # the on-disk table.
-        if self.path is not None:
-            folder = Path(self.path)
-            for filename in (_INDEX_FILENAME, _STORE_FILENAME):
-                (folder / filename).unlink(missing_ok=True)
-        self._index = None
-        self._str_to_u64.clear()
-        self._u64_to_doc.clear()
-        self._next_u64 = 0
-        self._content_hashes.clear()
-        self._name_to_ids.clear()
+        with self._write_lock:
+            if self.path is not None:
+                folder = Path(self.path)
+                for filename in (_INDEX_FILENAME, _STORE_FILENAME):
+                    (folder / filename).unlink(missing_ok=True)
+            self._index = None
+            self._str_to_u64.clear()
+            self._u64_to_doc.clear()
+            self._next_u64 = 0
+            self._content_hashes.clear()
+            self._name_to_ids.clear()
 
     async def async_drop(self) -> None:
         self.drop()
@@ -388,28 +413,66 @@ class TurboQuantVectorDb(VectorDb):
         if not vectors.flags["C_CONTIGUOUS"]:
             vectors = np.ascontiguousarray(vectors)
 
-        handles = np.array(
-            [self._issue_handle() for _ in documents], dtype=np.uint64
-        )
-        self._index.add_with_ids(vectors, handles)
-
-        for doc, handle in zip(documents, handles):
+        # Build every side-car payload BEFORE mutating any state (pure
+        # computation, no store reads).
+        prepared = []
+        for doc in documents:
             cleaned = doc.content.replace("\x00", "�") if doc.content else ""
             doc_id = self._derive_doc_id(doc, content_hash, cleaned)
-            h = int(handle)
-            self._str_to_u64.setdefault(doc_id, set()).add(h)
-            self._u64_to_doc[h] = {
-                "id": doc_id,
-                "name": doc.name,
-                "content": cleaned,
-                "meta_data": dict(doc.meta_data) if doc.meta_data else {},
-                "usage": doc.usage,
-                "content_id": doc.content_id,
-                "content_hash": content_hash,
-            }
-            self._content_hashes.add(content_hash)
-            if doc.name:
-                self._name_to_ids.setdefault(doc.name, set()).add(doc_id)
+            prepared.append(
+                (
+                    doc_id,
+                    doc.name,
+                    {
+                        "id": doc_id,
+                        "name": doc.name,
+                        "content": cleaned,
+                        "meta_data": dict(doc.meta_data) if doc.meta_data else {},
+                        "usage": doc.usage,
+                        "content_id": doc.content_id,
+                        "content_hash": content_hash,
+                    },
+                )
+            )
+
+        with self._write_lock:
+            # Re-check under the lock: a concurrent drop() may have nulled
+            # the index between the check at the top and here.
+            if self._index is None:
+                raise RuntimeError(
+                    "TurboQuantVectorDb not initialized — call create() before insert()."
+                )
+            handles = np.array(
+                [self._issue_handle() for _ in documents], dtype=np.uint64
+            )
+
+            # Maps BEFORE the index add: a concurrent search can only learn
+            # a handle from the index, so an entry that is resolvable but
+            # not yet searchable is invisible to readers (safe) — the
+            # reverse ordering let readers surface handles that did not
+            # resolve yet (issue #161).
+            for (doc_id, name, payload), handle in zip(prepared, handles):
+                h = int(handle)
+                self._str_to_u64.setdefault(doc_id, set()).add(h)
+                self._u64_to_doc[h] = payload
+                self._content_hashes.add(content_hash)
+                if name:
+                    self._name_to_ids.setdefault(name, set()).add(doc_id)
+            try:
+                self._index.add_with_ids(vectors, handles)
+            except BaseException:
+                # Unwind the pre-inserted entries so a failed add leaves
+                # the store exactly as it was — preserving the issue-#89
+                # guarantee under the maps-first ordering. `_unlink_payload`
+                # drops the side-index entries only where no surviving
+                # handle still needs them, so pre-existing docs sharing an
+                # id / name / content_hash keep theirs.
+                for (doc_id, _name, _payload), handle in zip(prepared, handles):
+                    h = int(handle)
+                    data = self._u64_to_doc.pop(h, None)
+                    if data is not None:
+                        self._unlink_payload(h, data)
+                raise
 
     async def async_insert(
         self,
@@ -436,17 +499,24 @@ class TurboQuantVectorDb(VectorDb):
         # stored under this content_hash with the incoming batch. Not
         # "replace by derived doc_id" — that's a different contract.
         #
+        # Embed up front so the embedder (a user component) runs outside
+        # the writer lock; insert() then finds nothing left to embed.
+        if documents:
+            self._embed_missing(documents)
         # Capture the existing generation's handles, run the insert, and
         # only then drop the old vectors — so a failed insert (dim
         # mismatch, non-finite embeddings) never destroys the data being
         # replaced (issue #89). We delete by captured handle rather than
         # re-querying by content_hash, because insert() re-derives ids
         # under the SAME content_hash and would otherwise clobber the
-        # just-inserted rows.
-        old_handles = self._handles_for_content_hash(content_hash)
-        self.insert(content_hash, documents, filters)
-        for handle in old_handles:
-            self._remove_handle(handle)
+        # just-inserted rows. The lock spans capture + insert + remove so
+        # concurrent upserts of the same content_hash stay
+        # last-writer-wins with no stale generations (issue #146).
+        with self._write_lock:
+            old_handles = self._handles_for_content_hash(content_hash)
+            self.insert(content_hash, documents, filters)
+            for handle in old_handles:
+                self._remove_handle(handle)
 
     async def async_upsert(
         self,
@@ -480,13 +550,24 @@ class TurboQuantVectorDb(VectorDb):
         handles intact — including ones that share this document's derived
         id (two distinct documents can map to the same doc_id, matching
         LanceDb). Cleans the id, name, and content_hash side-indexes only
-        where no surviving handle still needs them."""
+        where no surviving handle still needs them.
+
+        Callers hold the writer lock. Index first: the handle stops being
+        searchable before it stops resolving, so a concurrent search can
+        never surface a handle whose side-car entry is already gone."""
         if self._index is None:
             return
-        data = self._u64_to_doc.pop(handle, None)
+        data = self._u64_to_doc.get(handle)
         if data is None:
             return
         self._index.remove(handle)
+        self._u64_to_doc.pop(handle, None)
+        self._unlink_payload(handle, data)
+
+    def _unlink_payload(self, handle: int, data: Dict[str, Any]) -> None:
+        """Drop ``handle``'s entries from the id / name / content_hash
+        side-indexes, keeping any entry a surviving handle still needs.
+        ``data`` is the payload already popped from ``_u64_to_doc``."""
         doc_id = data.get("id")
         # Drop just this handle from the id's handle set; remove the id
         # entirely only once no handle remains under it.
@@ -554,9 +635,11 @@ class TurboQuantVectorDb(VectorDb):
         if not isinstance(filters, dict) or not filters:
             return None
         items = list(filters.items())
+        # list() snapshot: this runs on the (lock-free) search path, so a
+        # concurrent writer must not invalidate the iteration mid-scan.
         return [
             handle
-            for handle, data in self._u64_to_doc.items()
+            for handle, data in list(self._u64_to_doc.items())
             if self._meta_matches(data, items)
         ]
 
@@ -615,6 +698,62 @@ class TurboQuantVectorDb(VectorDb):
             )
         return results
 
+    def _retrieve(
+        self,
+        qvec: np.ndarray,
+        limit: int,
+        filters: Optional[Union[Dict[str, Any], List[Any]]],
+    ) -> List[Document]:
+        """Kernel search + tolerant result construction, shared by
+        :meth:`search` and :meth:`async_search`. Runs lock-free."""
+        # Local reference: a concurrent drop() nulls self._index, and a
+        # lock-free reader must not trip over that mid-search.
+        index = self._index
+        if index is None:
+            return []
+        allowed_handles = self._resolve_filter_to_handles(filters)
+        if allowed_handles is None:
+            # Unfiltered.
+            k = min(limit, len(index))
+            scores, handles = index.search(qvec, k)
+            return self._build_results(scores, handles)
+
+        for _attempt in range(8):
+            if not allowed_handles:
+                return []
+            allowlist = np.asarray(allowed_handles, dtype=np.uint64)
+            try:
+                scores, handles = index.search(qvec, limit, allowlist=allowlist)
+                return self._build_results(scores, handles)
+            except KeyError:
+                # The allowlist went stale: a delete landed between
+                # resolving it and the kernel's membership check. Rebuild
+                # the allowlist and retry.
+                allowed_handles = self._resolve_filter_to_handles(filters)
+                continue
+
+        # Sustained churn kept invalidating the allowlist. Fall back to an
+        # unfiltered search plus a tolerant Python-side post-filter, which
+        # cannot raise (a search overlapping heavy churn may return fewer
+        # than `limit` hits).
+        items = list(filters.items())
+        fetch_k = min(max(limit * 4, 32), len(index) or 1)
+        scores, handles = index.search(qvec, fetch_k)
+        keep_scores: List[float] = []
+        keep_handles: List[int] = []
+        for score, handle in zip(scores[0], handles[0]):
+            data = self._u64_to_doc.get(int(handle))
+            if data is None or not self._meta_matches(data, items):
+                continue
+            keep_scores.append(float(score))
+            keep_handles.append(int(handle))
+            if len(keep_handles) >= limit:
+                break
+        return self._build_results(
+            np.asarray([keep_scores], dtype=np.float32),
+            np.asarray([keep_handles], dtype=np.uint64),
+        )
+
     def search(
         self,
         query: str,
@@ -639,18 +778,7 @@ class TurboQuantVectorDb(VectorDb):
         if not qvec.flags["C_CONTIGUOUS"]:
             qvec = np.ascontiguousarray(qvec)
 
-        allowed_handles = self._resolve_filter_to_handles(filters)
-        if allowed_handles is None:
-            # Unfiltered.
-            k = min(limit, len(self._index))
-            scores, handles = self._index.search(qvec, k)
-        else:
-            if not allowed_handles:
-                return []
-            allowlist = np.asarray(allowed_handles, dtype=np.uint64)
-            scores, handles = self._index.search(qvec, limit, allowlist=allowlist)
-
-        results = self._build_results(scores, handles)
+        results = self._retrieve(qvec, limit, filters)
         if self.reranker is not None and results:
             results = self.reranker.rerank(query=query, documents=results)
         # Dedup by content as the final step, after rerank — matching
@@ -680,17 +808,7 @@ class TurboQuantVectorDb(VectorDb):
         if not qvec.flags["C_CONTIGUOUS"]:
             qvec = np.ascontiguousarray(qvec)
 
-        allowed_handles = self._resolve_filter_to_handles(filters)
-        if allowed_handles is None:
-            k = min(limit, len(self._index))
-            scores, handles = self._index.search(qvec, k)
-        else:
-            if not allowed_handles:
-                return []
-            allowlist = np.asarray(allowed_handles, dtype=np.uint64)
-            scores, handles = self._index.search(qvec, limit, allowlist=allowlist)
-
-        results = self._build_results(scores, handles)
+        results = self._retrieve(qvec, limit, filters)
         if self.reranker is not None and results:
             results = self.reranker.rerank(query=query, documents=results)
         # Dedup by content as the final step, after rerank — matching
@@ -709,15 +827,16 @@ class TurboQuantVectorDb(VectorDb):
     def delete_by_id(self, id: str) -> bool:
         if self._index is None:
             return False
-        handles = self._str_to_u64.get(id)
-        if not handles:
-            return False
-        # Remove every vector sharing this id — a non-unique derived doc_id
-        # can map to several handles. _remove_handle maintains the id, name,
-        # and content_hash side-indexes per handle.
-        for handle in list(handles):
-            self._remove_handle(handle)
-        return True
+        with self._write_lock:
+            handles = self._str_to_u64.get(id)
+            if not handles:
+                return False
+            # Remove every vector sharing this id — a non-unique derived doc_id
+            # can map to several handles. _remove_handle maintains the id, name,
+            # and content_hash side-indexes per handle.
+            for handle in list(handles):
+                self._remove_handle(handle)
+            return True
 
     def delete_by_name(self, name: str) -> bool:
         if self._index is None:
@@ -731,10 +850,11 @@ class TurboQuantVectorDb(VectorDb):
         # delete_by_id would key on the derived doc_id, which excludes `name`,
         # so it would also delete a differently-named doc that happens to
         # share the id. LanceDb deletes rows matching the predicate directly.
-        handles = [h for h, d in self._u64_to_doc.items() if d.get("name") == name]
-        for handle in handles:
-            self._remove_handle(handle)
-        return bool(handles)
+        with self._write_lock:
+            handles = [h for h, d in self._u64_to_doc.items() if d.get("name") == name]
+            for handle in handles:
+                self._remove_handle(handle)
+            return bool(handles)
 
     def delete_by_metadata(self, metadata: Dict[str, Any]) -> bool:
         """Delete every document whose ``meta_data`` has all of
@@ -752,14 +872,15 @@ class TurboQuantVectorDb(VectorDb):
         # Remove the matching handles directly (see delete_by_name): the
         # derived doc_id ignores metadata, so delete_by_id would over-delete
         # distinct docs that collide on the id.
-        handles = [
-            h
-            for h, data in self._u64_to_doc.items()
-            if self._meta_matches(data, items)
-        ]
-        for handle in handles:
-            self._remove_handle(handle)
-        return bool(handles)
+        with self._write_lock:
+            handles = [
+                h
+                for h, data in self._u64_to_doc.items()
+                if self._meta_matches(data, items)
+            ]
+            for handle in handles:
+                self._remove_handle(handle)
+            return bool(handles)
 
     def delete_by_content_id(self, content_id: str) -> bool:
         if self._index is None:
@@ -772,14 +893,15 @@ class TurboQuantVectorDb(VectorDb):
         # Remove the matching handles directly (see delete_by_name): the
         # derived doc_id ignores content_id, so delete_by_id would over-delete
         # distinct docs that collide on the id.
-        handles = [
-            h
-            for h, data in self._u64_to_doc.items()
-            if data.get("content_id") == content_id
-        ]
-        for handle in handles:
-            self._remove_handle(handle)
-        return bool(handles)
+        with self._write_lock:
+            handles = [
+                h
+                for h, data in self._u64_to_doc.items()
+                if data.get("content_id") == content_id
+            ]
+            for handle in handles:
+                self._remove_handle(handle)
+            return bool(handles)
 
     def update_metadata(self, content_id: str, metadata: Dict[str, Any]) -> None:
         """Merge ``metadata`` into both ``meta_data`` and the ``filters``
@@ -793,18 +915,19 @@ class TurboQuantVectorDb(VectorDb):
         # doc stored without one — no-op instead (issue #169).
         if content_id is None:
             return
-        for data in self._u64_to_doc.values():
-            if data.get("content_id") == content_id:
-                meta = dict(data.get("meta_data") or {})
-                meta.update(metadata)
-                data["meta_data"] = meta
-                filters = data.get("filters")
-                if isinstance(filters, dict):
-                    filters = dict(filters)
-                    filters.update(metadata)
-                    data["filters"] = filters
-                else:
-                    data["filters"] = dict(metadata)
+        with self._write_lock:
+            for data in self._u64_to_doc.values():
+                if data.get("content_id") == content_id:
+                    meta = dict(data.get("meta_data") or {})
+                    meta.update(metadata)
+                    data["meta_data"] = meta
+                    filters = data.get("filters")
+                    if isinstance(filters, dict):
+                        filters = dict(filters)
+                        filters.update(metadata)
+                        data["filters"] = filters
+                    else:
+                        data["filters"] = dict(metadata)
 
     # ---- Persistence (JSON side-car) --------------------------------------
 
@@ -831,23 +954,27 @@ class TurboQuantVectorDb(VectorDb):
             )
         folder = Path(path)
         folder.mkdir(parents=True, exist_ok=True)
-        payload = {
-            "schema_version": _DOCSTORE_SCHEMA_VERSION,
-            # Round-trip int handles via list-of-pairs (JSON keys must be
-            # strings, but our handles are ints).
-            "u64_to_doc": [[h, d] for h, d in self._u64_to_doc.items()],
-            "next_u64": self._next_u64,
-            "bit_width": self.bit_width,
-            "dimensions": self.dimensions,
-        }
-        # Atomic: serializes in memory first, then temp-file + replace,
-        # so a failed save can't destroy a previous store at this path.
-        atomic_save(
-            self._index,
-            folder / _INDEX_FILENAME,
-            payload,
-            folder / _STORE_FILENAME,
-        )
+        # Serializes with writers: snapshotting the maps and the index
+        # concurrently with a write would persist a torn store to disk.
+        # Reads may proceed while a save runs.
+        with self._write_lock:
+            payload = {
+                "schema_version": _DOCSTORE_SCHEMA_VERSION,
+                # Round-trip int handles via list-of-pairs (JSON keys must be
+                # strings, but our handles are ints).
+                "u64_to_doc": [[h, d] for h, d in self._u64_to_doc.items()],
+                "next_u64": self._next_u64,
+                "bit_width": self.bit_width,
+                "dimensions": self.dimensions,
+            }
+            # Atomic: serializes in memory first, then temp-file + replace,
+            # so a failed save can't destroy a previous store at this path.
+            atomic_save(
+                self._index,
+                folder / _INDEX_FILENAME,
+                payload,
+                folder / _STORE_FILENAME,
+            )
 
     def _load_from(self, folder: Path) -> None:
         side_car = folder / _STORE_FILENAME

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -285,14 +285,20 @@ class TurboQuantDocumentStore:
     def _commit_batch(
         self, to_write: List[Document], to_remove: Iterable[str] = ()
     ) -> None:
-        """Validate ``to_write``'s embeddings, add them to the index, then
-        update the id maps (dropping ``to_remove`` ids in between).
+        """Validate ``to_write``'s embeddings, populate the id maps, then
+        add the vectors to the index (dropping ``to_remove``'s old
+        handles last, index first).
 
-        All-or-nothing with respect to the given batch: validation
-        precedes any mutation and the id maps are only updated after the
-        index add succeeds, so a failure leaves the store exactly as it
-        was (issue #89). The FAIL path calls this with single-document
-        batches to get per-document commit semantics.
+        Maps BEFORE the index add: a concurrent retrieval can only learn
+        a handle from the index, so an entry that is resolvable but not
+        yet searchable is invisible to readers (issue #161). Still
+        all-or-nothing with respect to the given batch: validation
+        precedes any mutation, and if the index add fails the
+        pre-inserted map entries are unwound (restoring the previous
+        mapping of any overwritten id), so a failure leaves the store
+        exactly as it was (issue #89). The FAIL path calls this with
+        single-document batches to get per-document commit semantics.
+        Callers hold the writer lock.
         """
         vectors = np.asarray(
             [doc.embedding for doc in to_write], dtype=np.float32

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import json
 import math
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
@@ -48,6 +49,19 @@ class TurboQuantDocumentStore:
     embeddings are dropped after quantization — callers requesting
     ``return_embedding=True`` on retrieval will see ``None`` on the
     returned documents' ``embedding`` field regardless of the flag.
+
+    **Thread safety.** The store is safe for concurrent multi-threaded
+    use. Reads (``embedding_retrieval``, ``filter_documents``, counts and
+    metadata helpers) run concurrently and scale across threads; writes
+    (``write_documents``, ``delete_*``, ``update_by_filter``,
+    ``save_to_disk``) serialize on a per-store lock — the ``*_async``
+    variants delegate to the same locked bodies. A read that overlaps a
+    write sees either the pre- or post-write state — never a torn one —
+    and under heavy concurrent churn a retrieval may transiently return
+    fewer than ``top_k`` documents. There is no cross-call atomicity:
+    a caller-side check-then-act sequence (e.g. ``count_documents``
+    then ``filter_documents``) can still interleave with other writers.
+    Multi-process access is not supported.
 
     Example::
 
@@ -104,6 +118,13 @@ class TurboQuantDocumentStore:
         # handle is `_next_u64 + 1`, then we bump. Plain int so pickle
         # can round-trip it directly.
         self._next_u64: int = 0
+        # Serializes every mutation (write / delete / update / save).
+        # Readers do NOT take this lock — retrieval stays lock-free so
+        # concurrent reads keep scaling across threads (#186); reader
+        # safety comes from mutation ordering plus tolerant handle
+        # resolution instead. RLock: write_documents nests into
+        # _commit_batch / _remove_one.
+        self._write_lock = threading.RLock()
 
         # Executor lifecycle mirrors InMemoryDocumentStore: own one when
         # the caller didn't pass one in, and shut it down in __del__.
@@ -137,7 +158,12 @@ class TurboQuantDocumentStore:
         Documents are reconstructed on every access; the
         ``embedding`` field is always ``None``.
         """
-        return {data["id"]: self._reconstruct(data) for data in self._u64_to_doc.values()}
+        # list() snapshot: a concurrent writer must not invalidate the
+        # iteration mid-scan (single C-level op, no torn view).
+        return {
+            data["id"]: self._reconstruct(data)
+            for data in list(self._u64_to_doc.values())
+        }
 
     # ---- DocumentStore protocol ---------------------------------------
 
@@ -147,15 +173,17 @@ class TurboQuantDocumentStore:
     def filter_documents(
         self, filters: Optional[Dict[str, Any]] = None
     ) -> List[Document]:
+        # list() snapshots: reads iterate the doc table lock-free, so a
+        # concurrent writer must not invalidate the iteration mid-scan.
         if filters:
             self._validate_filters(filters)
             docs = [
                 self._reconstruct(data)
-                for data in self._u64_to_doc.values()
+                for data in list(self._u64_to_doc.values())
                 if document_matches_filter(filters=filters, document=self._reconstruct(data))
             ]
         else:
-            docs = [self._reconstruct(data) for data in self._u64_to_doc.values()]
+            docs = [self._reconstruct(data) for data in list(self._u64_to_doc.values())]
         # `return_embedding` is informational here — we never have the
         # full-precision embedding to begin with. Kept for parity.
         return docs
@@ -177,6 +205,12 @@ class TurboQuantDocumentStore:
         if policy == DuplicatePolicy.NONE:
             policy = DuplicatePolicy.FAIL
 
+        with self._write_lock:
+            return self._write_documents_locked(documents, policy)
+
+    def _write_documents_locked(
+        self, documents: List[Document], policy: DuplicatePolicy
+    ) -> int:
         if policy == DuplicatePolicy.FAIL:
             # Reference parity (issue #167): InMemoryDocumentStore commits
             # each document as it iterates and raises on the *first*
@@ -289,14 +323,23 @@ class TurboQuantDocumentStore:
         handles = np.array(
             [self._issue_handle() for _ in to_write], dtype=np.uint64
         )
-        self._index.add_with_ids(vectors, handles)
 
-        # The add succeeded — now it's safe to drop the old vectors for any
-        # overwritten ids. Done before the mapping loop below so _remove_one
-        # resolves the old handle, not the one we're about to assign.
-        for doc_id in to_remove:
-            self._remove_one(doc_id)
+        # Capture the previous handle of every overwritten id BEFORE the
+        # forward map is updated, so a failed index add can restore it and
+        # the old vectors can be dropped once the add succeeds. Dict
+        # rather than list: `to_remove` can name an id twice when a batch
+        # repeats an id that already exists in the store.
+        old_handles = {
+            doc_id: self._str_to_u64[doc_id]
+            for doc_id in to_remove
+            if doc_id in self._str_to_u64
+        }
 
+        # Maps BEFORE the index add: a concurrent retrieval can only learn
+        # a handle from the index, so an entry that is resolvable but not
+        # yet searchable is invisible to readers (safe) — the reverse
+        # ordering let readers surface handles that did not resolve yet
+        # (issue #161).
         for doc, handle in zip(to_write, handles):
             h = int(handle)
             self._str_to_u64[doc.id] = h
@@ -310,18 +353,43 @@ class TurboQuantDocumentStore:
                 "blob": doc.blob,
                 "sparse_embedding": doc.sparse_embedding,
             }
+        try:
+            self._index.add_with_ids(vectors, handles)
+        except BaseException:
+            # Unwind the pre-inserted map entries (and restore the previous
+            # mapping of any overwritten id) so a failed add leaves the
+            # store exactly as it was — preserving the issue-#89 guarantee
+            # under the maps-first ordering.
+            for doc, handle in zip(to_write, handles):
+                h = int(handle)
+                self._u64_to_doc.pop(h, None)
+                if self._str_to_u64.get(doc.id) == h:
+                    self._str_to_u64.pop(doc.id, None)
+            for doc_id, old_h in old_handles.items():
+                self._str_to_u64[doc_id] = old_h
+            raise
+
+        # The add succeeded — drop the old vectors for the overwritten ids,
+        # index first so each old handle stops being searchable before it
+        # stops resolving. The forward map already points at the new
+        # handles; the old payloads live under the old handles.
+        for old_h in old_handles.values():
+            self._index.remove(old_h)
+            self._u64_to_doc.pop(old_h, None)
 
     def delete_documents(self, document_ids: List[str]) -> None:
         # Haystack's protocol says silently ignore missing ids.
-        for doc_id in document_ids:
-            self._remove_one(doc_id)
+        with self._write_lock:
+            for doc_id in document_ids:
+                self._remove_one(doc_id)
 
     # ---- Utility methods (InMemoryDocumentStore parity) ---------------
 
     def delete_all_documents(self) -> None:
         """Delete every document in the store."""
-        for doc_id in list(self._str_to_u64.keys()):
-            self._remove_one(doc_id)
+        with self._write_lock:
+            for doc_id in list(self._str_to_u64.keys()):
+                self._remove_one(doc_id)
 
     def update_by_filter(
         self, filters: Dict[str, Any], meta: Dict[str, Any]
@@ -333,31 +401,33 @@ class TurboQuantDocumentStore:
         precision anyway. Returns the number of documents updated.
         """
         self._validate_filters(filters)
-        updated = 0
-        for data in self._u64_to_doc.values():
-            if document_matches_filter(filters=filters, document=self._reconstruct(data)):
-                data["meta"].update(meta)
-                updated += 1
-        return updated
+        with self._write_lock:
+            updated = 0
+            for data in self._u64_to_doc.values():
+                if document_matches_filter(filters=filters, document=self._reconstruct(data)):
+                    data["meta"].update(meta)
+                    updated += 1
+            return updated
 
     def delete_by_filter(self, filters: Dict[str, Any]) -> int:
         """Delete every document matching ``filters``. Returns the count."""
         self._validate_filters(filters)
-        matching_ids = [
-            data["id"]
-            for data in self._u64_to_doc.values()
-            if document_matches_filter(filters=filters, document=self._reconstruct(data))
-        ]
-        for doc_id in matching_ids:
-            self._remove_one(doc_id)
-        return len(matching_ids)
+        with self._write_lock:
+            matching_ids = [
+                data["id"]
+                for data in self._u64_to_doc.values()
+                if document_matches_filter(filters=filters, document=self._reconstruct(data))
+            ]
+            for doc_id in matching_ids:
+                self._remove_one(doc_id)
+            return len(matching_ids)
 
     def count_documents_by_filter(self, filters: Dict[str, Any]) -> int:
         if filters:
             self._validate_filters(filters)
             return sum(
                 1
-                for data in self._u64_to_doc.values()
+                for data in list(self._u64_to_doc.values())
                 if document_matches_filter(filters=filters, document=self._reconstruct(data))
             )
         return self.count_documents()
@@ -369,11 +439,11 @@ class TurboQuantDocumentStore:
             self._validate_filters(filters)
             docs_meta = [
                 data["meta"]
-                for data in self._u64_to_doc.values()
+                for data in list(self._u64_to_doc.values())
                 if document_matches_filter(filters=filters, document=self._reconstruct(data))
             ]
         else:
-            docs_meta = [data["meta"] for data in self._u64_to_doc.values()]
+            docs_meta = [data["meta"] for data in list(self._u64_to_doc.values())]
 
         result: Dict[str, int] = {}
         for field in metadata_fields:
@@ -384,8 +454,8 @@ class TurboQuantDocumentStore:
 
     def get_metadata_fields_info(self) -> Dict[str, Dict[str, str]]:
         type_map: Dict[str, str] = {}
-        for data in self._u64_to_doc.values():
-            for key, value in data["meta"].items():
+        for data in list(self._u64_to_doc.values()):
+            for key, value in list(data["meta"].items()):
                 if value is None:
                     continue
                 if isinstance(value, bool):
@@ -406,7 +476,7 @@ class TurboQuantDocumentStore:
         )
         values = [
             data["meta"][key]
-            for data in self._u64_to_doc.values()
+            for data in list(self._u64_to_doc.values())
             if key in data["meta"]
             and data["meta"][key] is not None
             and isinstance(data["meta"][key], (int, float, str))
@@ -429,7 +499,7 @@ class TurboQuantDocumentStore:
         if search_term:
             docs_data = [
                 data
-                for data in self._u64_to_doc.values()
+                for data in list(self._u64_to_doc.values())
                 if data["content"] and search_term.lower() in data["content"].lower()
             ]
         else:
@@ -505,23 +575,58 @@ class TurboQuantDocumentStore:
             scores, handles = self._index.search(qvec, fetch_k)
         else:
             self._validate_filters(filters)
-            # Resolve filter → handle allowlist by walking the in-memory
-            # doc table once. This is the same O(N) cost as the old
-            # post-filter pass, just moved upfront so the kernel can score
-            # only matching vectors.
-            allowed_handles = [
-                handle
-                for handle, data in self._u64_to_doc.items()
-                if document_matches_filter(filters, self._reconstruct(data))
-            ]
-            if not allowed_handles:
-                return []
-            allowlist = np.asarray(allowed_handles, dtype=np.uint64)
-            scores, handles = self._index.search(qvec, top_k, allowlist=allowlist)
+            for _attempt in range(8):
+                # Resolve filter → handle allowlist by walking the in-memory
+                # doc table once. This is the same O(N) cost as the old
+                # post-filter pass, just moved upfront so the kernel can
+                # score only matching vectors. list() snapshot: a concurrent
+                # writer must not invalidate the iteration mid-scan.
+                allowed_handles = [
+                    handle
+                    for handle, data in list(self._u64_to_doc.items())
+                    if document_matches_filter(filters, self._reconstruct(data))
+                ]
+                if not allowed_handles:
+                    return []
+                allowlist = np.asarray(allowed_handles, dtype=np.uint64)
+                try:
+                    scores, handles = self._index.search(qvec, top_k, allowlist=allowlist)
+                    break
+                except KeyError:
+                    # The allowlist went stale: a delete landed between the
+                    # snapshot above and the kernel's membership check.
+                    # Rebuild the allowlist and retry.
+                    continue
+            else:
+                # Sustained churn kept invalidating the allowlist. Fall back
+                # to an unfiltered search plus a tolerant Python-side
+                # post-filter, which cannot raise (a retrieval overlapping
+                # heavy churn may return fewer than top_k documents).
+                fetch_k = min(max(top_k * 4, 32), len(self._index) or 1)
+                scores, handles = self._index.search(qvec, fetch_k)
+                out: List[Document] = []
+                for score, handle in zip(scores[0], handles[0]):
+                    data = self._u64_to_doc.get(int(handle))
+                    if data is None:
+                        continue
+                    if not document_matches_filter(filters, self._reconstruct(data)):
+                        continue
+                    out.append(
+                        self._reconstruct(data, score=float(score), scale_score=scale_score)
+                    )
+                    if len(out) >= top_k:
+                        break
+                return out
 
-        out: List[Document] = []
+        out = []
         for score, handle in zip(scores[0], handles[0]):
-            data = self._u64_to_doc[int(handle)]
+            # Tolerant translation: a handle surfaced by the index can stop
+            # resolving if a delete completes between the kernel search and
+            # this loop (the reader-straddle). Skip it — the document is
+            # gone either way — rather than raising KeyError mid-retrieval.
+            data = self._u64_to_doc.get(int(handle))
+            if data is None:
+                continue
             out.append(self._reconstruct(data, score=float(score), scale_score=scale_score))
         return out
 
@@ -664,27 +769,31 @@ class TurboQuantDocumentStore:
         """
         folder = Path(folder_path)
         folder.mkdir(parents=True, exist_ok=True)
-        # Keys in `_u64_to_doc` are ints (u64 handles); JSON object keys
-        # must be strings. Serialize as a list of [handle, data] pairs
-        # so we don't lose type fidelity on the round-trip.
-        payload = {
-            "schema_version": self._DOCSTORE_SCHEMA_VERSION,
-            "u64_to_doc": [
-                [h, self._serialize_doc_data(d)] for h, d in self._u64_to_doc.items()
-            ],
-            "next_u64": self._next_u64,
-            "bit_width": self._bit_width,
-            "embedding_similarity_function": self.embedding_similarity_function,
-            "return_embedding": self.return_embedding,
-        }
-        # Atomic: serializes in memory first, then temp-file + replace,
-        # so a failed save can't destroy a previous store at this path.
-        atomic_save(
-            self._index,
-            folder / "index.tvim",
-            payload,
-            folder / "docstore.json",
-        )
+        # Serializes with writers: snapshotting the maps and the index
+        # concurrently with a write would persist a torn store to disk.
+        # Reads may proceed while a save runs.
+        with self._write_lock:
+            # Keys in `_u64_to_doc` are ints (u64 handles); JSON object keys
+            # must be strings. Serialize as a list of [handle, data] pairs
+            # so we don't lose type fidelity on the round-trip.
+            payload = {
+                "schema_version": self._DOCSTORE_SCHEMA_VERSION,
+                "u64_to_doc": [
+                    [h, self._serialize_doc_data(d)] for h, d in self._u64_to_doc.items()
+                ],
+                "next_u64": self._next_u64,
+                "bit_width": self._bit_width,
+                "embedding_similarity_function": self.embedding_similarity_function,
+                "return_embedding": self.return_embedding,
+            }
+            # Atomic: serializes in memory first, then temp-file + replace,
+            # so a failed save can't destroy a previous store at this path.
+            atomic_save(
+                self._index,
+                folder / "index.tvim",
+                payload,
+                folder / "docstore.json",
+            )
 
     @classmethod
     def load_from_disk(
@@ -740,11 +849,16 @@ class TurboQuantDocumentStore:
     # ---- Internals ----------------------------------------------------
 
     def _remove_one(self, doc_id: str) -> bool:
-        handle = self._str_to_u64.pop(doc_id, None)
+        # Callers hold the writer lock. Index first: the handle stops
+        # being searchable before it stops resolving, so a concurrent
+        # retrieval can never surface a handle whose side-car entry is
+        # already gone.
+        handle = self._str_to_u64.get(doc_id)
         if handle is None:
             return False
-        del self._u64_to_doc[handle]
         self._index.remove(handle)
+        self._str_to_u64.pop(doc_id, None)
+        self._u64_to_doc.pop(handle, None)
         return True
 
     def _reconstruct(

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -9,6 +9,7 @@ so this store can be swapped in wherever the in-memory store is used.
 from __future__ import annotations
 
 import json
+import threading
 import uuid
 from pathlib import Path
 from typing import Any, Callable, Iterable, Sequence
@@ -44,6 +45,17 @@ class TurboQuantVectorStore(VectorStore):
     Vectors are quantized to 2–4 bits per dimension. A side-car dictionary
     holds the original text and metadata keyed by document id. Deletion
     is supported in O(1) per id via the underlying :class:`IdMapIndex`.
+
+    **Thread safety.** The store is safe for concurrent multi-threaded
+    use. Reads (``similarity_search*``, ``get_by_ids``) run concurrently
+    and scale across threads; writes (``add_*``, ``delete``, ``dump``)
+    serialize on a per-store lock. A read that overlaps a write sees
+    either the pre- or post-write state — never a torn one — and under
+    heavy concurrent churn a search may transiently return fewer than
+    ``k`` results. There is no cross-call atomicity: a caller-side
+    check-then-act sequence (e.g. ``get_by_ids`` then ``delete``) can
+    still interleave with other writers. Multi-process access is not
+    supported.
     """
 
     def __init__(
@@ -79,6 +91,12 @@ class TurboQuantVectorStore(VectorStore):
             handle: sid for sid, handle in self._str_to_u64.items()
         }
         self._next_u64: int = next_u64
+        # Serializes every mutation (add / delete / dump). Readers do NOT
+        # take this lock — search stays lock-free so concurrent reads keep
+        # scaling across threads (#186); reader safety comes from mutation
+        # ordering plus tolerant handle resolution instead. RLock because
+        # the add path may nest into delete-style cleanup.
+        self._write_lock = threading.RLock()
 
     def _issue_handle(self) -> int:
         self._next_u64 += 1
@@ -271,40 +289,68 @@ class TurboQuantVectorStore(VectorStore):
             metadatas = [metadatas[i] for i in keep]
             vectors = vectors[keep]
 
-        # Validate before mutating any existing data. IdMapIndex.add_with_ids
-        # handles both eager (dim must match) and lazy (locks dim on first
-        # call) cases. Pre-check the eager case so we surface a clean
-        # ValueError rather than a Rust panic.
-        existing_dim = self._index.dim
-        if existing_dim is not None and vectors.shape[1] != existing_dim:
-            raise ValueError(
-                f"embedding dimension {vectors.shape[1]} does not match index dim {existing_dim}"
+        with self._write_lock:
+            # Validate before mutating any existing data. IdMapIndex.add_with_ids
+            # handles both eager (dim must match) and lazy (locks dim on first
+            # call) cases. Pre-check the eager case so we surface a clean
+            # ValueError rather than a Rust panic.
+            existing_dim = self._index.dim
+            if existing_dim is not None and vectors.shape[1] != existing_dim:
+                raise ValueError(
+                    f"embedding dimension {vectors.shape[1]} does not match index dim {existing_dim}"
+                )
+            if not vectors.flags["C_CONTIGUOUS"]:
+                vectors = np.ascontiguousarray(vectors)
+
+            handles = np.array(
+                [self._issue_handle() for _ in texts_list], dtype=np.uint64
             )
-        if not vectors.flags["C_CONTIGUOUS"]:
-            vectors = np.ascontiguousarray(vectors)
 
-        handles = np.array(
-            [self._issue_handle() for _ in texts_list], dtype=np.uint64
-        )
-        # Add first; if encoding rejects the batch (e.g. non-finite values)
-        # this raises before any existing data is touched. Only once the add
-        # has succeeded do we remove the old vectors for colliding ids, so a
-        # failed upsert never destroys existing data (issue #89). Handles are
-        # freshly issued, so the old and new vectors coexist until the delete.
-        self._index.add_with_ids(vectors, handles)
+            # Capture the previous state of any upserted id BEFORE the maps
+            # are overwritten, so a failed index add can restore it and the
+            # old vectors can be dropped once the add succeeds.
+            old = [
+                (i, self._str_to_u64[i], self._docs[i])
+                for i in ids
+                if i in self._str_to_u64
+            ]
 
-        # Upsert: any id that already existed is removed so the re-added
-        # vector wins. Matches LangChain user expectation that `add_texts`
-        # with an existing id updates in place.
-        duplicates = [i for i in ids if i in self._str_to_u64]
-        if duplicates:
-            self.delete(duplicates)
+            # Maps BEFORE the index add: a concurrent search can only learn
+            # a handle from the index, so an entry that is resolvable but
+            # not yet searchable is invisible to readers (safe) — the
+            # reverse ordering let readers surface handles that did not
+            # resolve yet (issue #161).
+            for id_, text, meta, handle in zip(ids, texts_list, metadatas, handles):
+                h = int(handle)
+                self._str_to_u64[id_] = h
+                self._u64_to_str[h] = id_
+                self._docs[id_] = (text, dict(meta))
+            try:
+                self._index.add_with_ids(vectors, handles)
+            except BaseException:
+                # Unwind the pre-inserted map entries (and restore the
+                # previous mapping of any upserted id) so a failed add
+                # never destroys existing data — preserving the issue-#89
+                # guarantee under the maps-first ordering.
+                for id_, handle in zip(ids, handles):
+                    h = int(handle)
+                    self._u64_to_str.pop(h, None)
+                    if self._str_to_u64.get(id_) == h:
+                        self._str_to_u64.pop(id_, None)
+                        self._docs.pop(id_, None)
+                for id_, old_h, old_doc in old:
+                    self._str_to_u64[id_] = old_h
+                    self._u64_to_str[old_h] = id_
+                    self._docs[id_] = old_doc
+                raise
 
-        for id_, text, meta, handle in zip(ids, texts_list, metadatas, handles):
-            h = int(handle)
-            self._str_to_u64[id_] = h
-            self._u64_to_str[h] = id_
-            self._docs[id_] = (text, dict(meta))
+            # Upsert: drop the replaced vectors, index first so the old
+            # handle stops being searchable before it stops resolving. The
+            # forward maps already hold the new entries, so only the old
+            # handle and its reverse-map entry remain to clean up.
+            for _id, old_h, _old_doc in old:
+                self._index.remove(old_h)
+                self._u64_to_str.pop(old_h, None)
         return result_ids
 
     # ---- Read path (similarity search) --------------------------------
@@ -398,20 +444,67 @@ class TurboQuantVectorStore(VectorStore):
             scores, handles = self._index.search(qvec, search_k)
         else:
             predicate = self._compile_filter(filter)
-            allowed_handles = [
-                self._str_to_u64[sid]
-                for sid, (text, meta) in self._docs.items()
-                if predicate(Document(id=sid, page_content=text, metadata=dict(meta)))
-            ]
-            if not allowed_handles:
-                return []
-            allowlist = np.asarray(allowed_handles, dtype=np.uint64)
-            scores, handles = self._index.search(qvec, k, allowlist=allowlist)
+            for _attempt in range(8):
+                # Snapshot the docstore before iterating: list() of the
+                # items view is a single C-level operation, so a concurrent
+                # writer can't invalidate the iteration mid-scan.
+                snapshot = list(self._docs.items())
+                allowed_handles = []
+                for sid, (text, meta) in snapshot:
+                    h = self._str_to_u64.get(sid)
+                    if h is None:
+                        # The id vanished between the snapshot and here
+                        # (concurrent delete) — skip rather than raise.
+                        continue
+                    if predicate(Document(id=sid, page_content=text, metadata=dict(meta))):
+                        allowed_handles.append(h)
+                if not allowed_handles:
+                    return []
+                allowlist = np.asarray(allowed_handles, dtype=np.uint64)
+                try:
+                    scores, handles = self._index.search(qvec, k, allowlist=allowlist)
+                    break
+                except KeyError:
+                    # The allowlist went stale: a delete landed between the
+                    # snapshot above and the kernel's membership check.
+                    # Rebuild the allowlist and retry.
+                    continue
+            else:
+                # Sustained churn kept invalidating the allowlist. Fall
+                # back to an unfiltered search plus a tolerant Python-side
+                # post-filter, which cannot raise (a search overlapping
+                # heavy churn may return fewer than k hits).
+                search_k = min(max(k * 4, 32), len(self._index) or 1)
+                scores, handles = self._index.search(qvec, search_k)
+                results: list[tuple[Document, float]] = []
+                for score, handle in zip(scores[0], handles[0]):
+                    sid = self._u64_to_str.get(int(handle))
+                    if sid is None:
+                        continue
+                    entry = self._docs.get(sid)
+                    if entry is None:
+                        continue
+                    text, meta = entry
+                    doc = Document(id=sid, page_content=text, metadata=dict(meta))
+                    if predicate(doc):
+                        results.append((doc, float(score)))
+                    if len(results) >= k:
+                        break
+                return results
 
-        results: list[tuple[Document, float]] = []
+        results = []
         for score, handle in zip(scores[0], handles[0]):
-            sid = self._u64_to_str[int(handle)]
-            text, meta = self._docs[sid]
+            # Tolerant translation: a handle surfaced by the index can stop
+            # resolving if a delete completes between the kernel search and
+            # this loop (the reader-straddle). Skip it — the document is
+            # gone either way — rather than raising KeyError mid-search.
+            sid = self._u64_to_str.get(int(handle))
+            if sid is None:
+                continue
+            entry = self._docs.get(sid)
+            if entry is None:
+                continue
+            text, meta = entry
             results.append(
                 (Document(id=sid, page_content=text, metadata=dict(meta)), float(score))
             )
@@ -491,8 +584,12 @@ class TurboQuantVectorStore(VectorStore):
         (matches the InMemoryVectorStore reference)."""
         out: list[Document] = []
         for sid in ids:
-            if sid in self._docs:
-                text, meta = self._docs[sid]
+            # Single .get instead of check-then-read: a concurrent delete
+            # between `in` and `[]` would raise KeyError; a missing id is
+            # skipped either way.
+            entry = self._docs.get(sid)
+            if entry is not None:
+                text, meta = entry
                 out.append(Document(id=sid, page_content=text, metadata=dict(meta)))
         return out
 
@@ -510,13 +607,18 @@ class TurboQuantVectorStore(VectorStore):
         ids = list(ids)
         if len(ids) == 0:
             return
-        for sid in ids:
-            handle = self._str_to_u64.pop(sid, None)
-            if handle is None:
-                continue
-            self._u64_to_str.pop(handle, None)
-            self._docs.pop(sid, None)
-            self._index.remove(handle)
+        with self._write_lock:
+            for sid in ids:
+                handle = self._str_to_u64.get(sid)
+                if handle is None:
+                    continue
+                # Index first: the handle stops being searchable before it
+                # stops resolving, so a concurrent search can never surface
+                # a handle whose side-car entries are already gone.
+                self._index.remove(handle)
+                self._str_to_u64.pop(sid, None)
+                self._u64_to_str.pop(handle, None)
+                self._docs.pop(sid, None)
 
     async def adelete(self, ids: list[str] | None = None, **_: Any) -> None:
         self.delete(ids)
@@ -582,30 +684,34 @@ class TurboQuantVectorStore(VectorStore):
         """
         folder = Path(folder_path)
         folder.mkdir(parents=True, exist_ok=True)
-        # `_docs` stores tuples `(text, metadata)` — JSON would drop the
-        # tuple-ness on round-trip, so serialize each entry as an explicit
-        # `{"text": ..., "metadata": ...}` dict.
-        docs_payload = {
-            sid: {"text": text, "metadata": meta}
-            for sid, (text, meta) in self._docs.items()
-        }
-        payload = {
-            "schema_version": _DOCSTORE_SCHEMA_VERSION,
-            "docs": docs_payload,
-            "str_to_u64": self._str_to_u64,
-            "next_u64": self._next_u64,
-            # Pull bit_width off the live index — same value whether
-            # the index was constructed eagerly or lazily.
-            "bit_width": self._index.bit_width,
-        }
-        # Atomic: serializes in memory first, then temp-file + replace,
-        # so a failed dump can't destroy a previous store at this path.
-        atomic_save(
-            self._index,
-            folder / _INDEX_FILENAME,
-            payload,
-            folder / _STORE_FILENAME,
-        )
+        # Serializes with writers: snapshotting the maps and the index
+        # concurrently with a write would persist a torn store to disk.
+        # Reads may proceed while a dump runs.
+        with self._write_lock:
+            # `_docs` stores tuples `(text, metadata)` — JSON would drop the
+            # tuple-ness on round-trip, so serialize each entry as an explicit
+            # `{"text": ..., "metadata": ...}` dict.
+            docs_payload = {
+                sid: {"text": text, "metadata": meta}
+                for sid, (text, meta) in self._docs.items()
+            }
+            payload = {
+                "schema_version": _DOCSTORE_SCHEMA_VERSION,
+                "docs": docs_payload,
+                "str_to_u64": dict(self._str_to_u64),
+                "next_u64": self._next_u64,
+                # Pull bit_width off the live index — same value whether
+                # the index was constructed eagerly or lazily.
+                "bit_width": self._index.bit_width,
+            }
+            # Atomic: serializes in memory first, then temp-file + replace,
+            # so a failed dump can't destroy a previous store at this path.
+            atomic_save(
+                self._index,
+                folder / _INDEX_FILENAME,
+                payload,
+                folder / _STORE_FILENAME,
+            )
 
     @classmethod
     def load(

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 from pathlib import Path
 from typing import Any, List, Optional, Sequence
 
@@ -125,6 +126,18 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
     holds node text and metadata keyed by ``node_id``. Supports ``delete``
     (by ``ref_doc_id``, removing every node with that ref) and
     ``delete_nodes`` (by ``node_id``) — both O(1) per node.
+
+    **Thread safety.** The store is safe for concurrent multi-threaded
+    use. Reads (``query``, ``get_nodes``) run concurrently and scale
+    across threads; writes (``add``, ``delete``, ``delete_nodes``,
+    ``clear``, ``persist``) serialize on a per-store lock — the ``a*`` /
+    ``async_*`` variants delegate to the same locked bodies. A read that
+    overlaps a write sees either the pre- or post-write state — never a
+    torn one — and under heavy concurrent churn a query may transiently
+    return fewer than ``similarity_top_k`` results. There is no
+    cross-call atomicity: a caller-side check-then-act sequence (e.g.
+    ``get_nodes`` then ``delete_nodes``) can still interleave with other
+    writers. Multi-process access is not supported.
     """
 
     stores_text: bool = True
@@ -136,6 +149,7 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
     _node_id_to_u64: dict[str, int] = PrivateAttr()
     _u64_to_node_id: dict[int, str] = PrivateAttr()
     _next_u64: int = PrivateAttr()
+    _write_lock: Any = PrivateAttr()
 
     def __init__(self, index: IdMapIndex | None = None, *, bit_width: int = 4, **kwargs: Any) -> None:
         """Construct the vector store.
@@ -156,6 +170,15 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         self._node_id_to_u64 = {}
         self._u64_to_node_id = {}
         self._next_u64 = 0
+        # Serializes every mutation (add / delete / clear / persist).
+        # Readers do NOT take this lock — query stays lock-free so
+        # concurrent reads keep scaling across threads (#186); reader
+        # safety comes from mutation ordering plus tolerant handle
+        # resolution instead. The lock also makes `_next_u64 += 1` atomic
+        # w.r.t. other writers: pydantic's PrivateAttr machinery makes the
+        # bare increment tearable, which issued duplicate handles (and
+        # silently rejected whole batches) under concurrent add (#161).
+        self._write_lock = threading.RLock()
 
     def _issue_handle(self) -> int:
         self._next_u64 += 1
@@ -214,66 +237,103 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
                 "nodes have empty embeddings (dim 0); check the embed "
                 "model that produced them"
             )
-        # IdMapIndex.add_with_ids handles eager (dim must match) and lazy
-        # (locks dim on first add) — pre-check the eager case so we
-        # surface a clean ValueError rather than a Rust panic.
-        existing_dim = self._index.dim
-        if existing_dim is not None and vectors.shape[1] != existing_dim:
-            raise ValueError(
-                f"node embedding dim {vectors.shape[1]} does not match index dim {existing_dim}"
-            )
-        if not vectors.flags["C_CONTIGUOUS"]:
-            vectors = np.ascontiguousarray(vectors)
-
-        handles = np.array([self._issue_handle() for _ in nodes], dtype=np.uint64)
-        # Add first; if validation above or encoding here (e.g. non-finite
-        # values) rejects the batch, it raises before any existing data is
-        # touched. Only after the add succeeds do we remove the old entries
-        # for colliding node_ids, so a failed upsert never destroys existing
-        # data (issue #89). Handles are freshly issued, so the old and new
-        # vectors coexist until the delete.
-        self._index.add_with_ids(vectors, handles)
-
-        # Upsert-like: if a node_id is already present in the STORE, remove
-        # the old entry so the new embedding wins.
-        duplicates = [n.node_id for n in nodes if n.node_id in self._node_id_to_u64]
-        for node_id in duplicates:
-            self._remove_node_by_id(node_id)
-
-        ids: list[str] = []
-        for node, handle in zip(nodes, handles):
-            h = int(handle)
-            nid = node.node_id
-            self._node_id_to_u64[nid] = h
-            self._u64_to_node_id[h] = nid
-            # `metadata` and `ref_doc_id` are kept at top level for fast
-            # filter / doc-id lookup (queries hit these on every hit;
-            # parsing _node_content per hit would be wasteful). `node_dict`
-            # is the framework's canonical metadata representation
-            # (`_node_content` + `_node_type` + original metadata keys),
-            # which `metadata_dict_to_node` reconstructs into a full
-            # BaseNode — preserving relationships (PREVIOUS / NEXT /
-            # PARENT / CHILD), excluded_*_metadata_keys, template fields,
-            # start/end_char_idx and mimetype on retrieval. The narrow
-            # `{text, metadata, ref_doc_id}` schema we used to keep lost
-            # all of those silently.
-            self._nodes[nid] = {
+        # Build every side-car payload BEFORE mutating any state, so a
+        # payload failure (e.g. non-serializable metadata) leaves the
+        # store untouched. `metadata` and `ref_doc_id` are kept at top
+        # level for fast filter / doc-id lookup (queries hit these on
+        # every hit; parsing _node_content per hit would be wasteful).
+        # `node_dict` is the framework's canonical metadata representation
+        # (`_node_content` + `_node_type` + original metadata keys),
+        # which `metadata_dict_to_node` reconstructs into a full
+        # BaseNode — preserving relationships (PREVIOUS / NEXT /
+        # PARENT / CHILD), excluded_*_metadata_keys, template fields,
+        # start/end_char_idx and mimetype on retrieval. The narrow
+        # `{text, metadata, ref_doc_id}` schema we used to keep lost
+        # all of those silently.
+        payloads = [
+            {
                 "metadata": dict(node.metadata),
                 "ref_doc_id": node.ref_doc_id,
                 "node_dict": node_to_metadata_dict(
                     node, remove_text=False, flat_metadata=False
                 ),
             }
-            ids.append(nid)
+            for node in nodes
+        ]
+
+        with self._write_lock:
+            # IdMapIndex.add_with_ids handles eager (dim must match) and lazy
+            # (locks dim on first add) — pre-check the eager case so we
+            # surface a clean ValueError rather than a Rust panic.
+            existing_dim = self._index.dim
+            if existing_dim is not None and vectors.shape[1] != existing_dim:
+                raise ValueError(
+                    f"node embedding dim {vectors.shape[1]} does not match index dim {existing_dim}"
+                )
+            if not vectors.flags["C_CONTIGUOUS"]:
+                vectors = np.ascontiguousarray(vectors)
+
+            handles = np.array([self._issue_handle() for _ in nodes], dtype=np.uint64)
+
+            # Capture the previous state of any upserted node_id BEFORE the
+            # maps are overwritten, so a failed index add can restore it and
+            # the old vectors can be dropped once the add succeeds.
+            old = [
+                (nid, self._node_id_to_u64[nid], self._nodes[nid])
+                for nid in node_ids
+                if nid in self._node_id_to_u64
+            ]
+
+            # Maps BEFORE the index add: a concurrent query can only learn
+            # a handle from the index, so an entry that is resolvable but
+            # not yet searchable is invisible to readers (safe) — the
+            # reverse ordering let readers surface handles that did not
+            # resolve yet (issue #161).
+            ids: list[str] = []
+            for node, payload, handle in zip(nodes, payloads, handles):
+                h = int(handle)
+                nid = node.node_id
+                self._node_id_to_u64[nid] = h
+                self._u64_to_node_id[h] = nid
+                self._nodes[nid] = payload
+                ids.append(nid)
+            try:
+                self._index.add_with_ids(vectors, handles)
+            except BaseException:
+                # Unwind the pre-inserted map entries (and restore the
+                # previous state of any upserted node_id) so a failed add
+                # never destroys existing data — preserving the issue-#89
+                # guarantee under the maps-first ordering.
+                for node, handle in zip(nodes, handles):
+                    h = int(handle)
+                    nid = node.node_id
+                    self._u64_to_node_id.pop(h, None)
+                    if self._node_id_to_u64.get(nid) == h:
+                        self._node_id_to_u64.pop(nid, None)
+                        self._nodes.pop(nid, None)
+                for nid, old_h, old_data in old:
+                    self._node_id_to_u64[nid] = old_h
+                    self._u64_to_node_id[old_h] = nid
+                    self._nodes[nid] = old_data
+                raise
+
+            # Upsert-like: drop the replaced vectors, index first so each
+            # old handle stops being searchable before it stops resolving.
+            # The forward maps already hold the new entries, so only the
+            # old handle and its reverse-map entry remain to clean up.
+            for _nid, old_h, _old_data in old:
+                self._index.remove(old_h)
+                self._u64_to_node_id.pop(old_h, None)
         return ids
 
     def delete(self, ref_doc_id: str, **_: Any) -> None:
         """Delete every node whose ``ref_doc_id`` matches."""
-        matching = [
-            nid for nid, data in self._nodes.items() if data.get("ref_doc_id") == ref_doc_id
-        ]
-        for nid in matching:
-            self._remove_node_by_id(nid)
+        with self._write_lock:
+            matching = [
+                nid for nid, data in self._nodes.items() if data.get("ref_doc_id") == ref_doc_id
+            ]
+            for nid in matching:
+                self._remove_node_by_id(nid)
 
     def delete_nodes(
         self,
@@ -287,18 +347,19 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         """
         if not node_ids and filters is None:
             return
-        candidates = list(self._nodes.items())
-        if node_ids is not None:
-            node_id_set = set(node_ids)
-            candidates = [(nid, data) for nid, data in candidates if nid in node_id_set]
-        if filters is not None:
-            candidates = [
-                (nid, data)
-                for nid, data in candidates
-                if self._filters_match(data["metadata"], filters)
-            ]
-        for nid, _data in candidates:
-            self._remove_node_by_id(nid)
+        with self._write_lock:
+            candidates = list(self._nodes.items())
+            if node_ids is not None:
+                node_id_set = set(node_ids)
+                candidates = [(nid, data) for nid, data in candidates if nid in node_id_set]
+            if filters is not None:
+                candidates = [
+                    (nid, data)
+                    for nid, data in candidates
+                    if self._filters_match(data["metadata"], filters)
+                ]
+            for nid, _data in candidates:
+                self._remove_node_by_id(nid)
 
     def clear(self) -> None:
         """Drop every node from the store and reset to a fresh lazy index.
@@ -306,12 +367,13 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         The new index keeps the same ``bit_width`` so subsequent adds
         commit a new ``dim`` lazily.
         """
-        bw = self._index.bit_width
-        self._index = IdMapIndex(bit_width=bw)
-        self._nodes = {}
-        self._node_id_to_u64 = {}
-        self._u64_to_node_id = {}
-        self._next_u64 = 0
+        with self._write_lock:
+            bw = self._index.bit_width
+            self._index = IdMapIndex(bit_width=bw)
+            self._nodes = {}
+            self._node_id_to_u64 = {}
+            self._u64_to_node_id = {}
+            self._next_u64 = 0
 
     def get(self, text_id: str) -> List[float]:
         """LlamaIndex's protocol expects this to return the full-precision
@@ -345,10 +407,17 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         otherwise in storage order.
         """
         if node_ids is not None:
-            candidates = [
-                (nid, self._nodes[nid]) for nid in node_ids if nid in self._nodes
-            ]
+            # Single .get instead of check-then-read: a concurrent delete
+            # between `in` and `[]` would raise KeyError; a missing id is
+            # skipped either way.
+            candidates = []
+            for nid in node_ids:
+                data = self._nodes.get(nid)
+                if data is not None:
+                    candidates.append((nid, data))
         else:
+            # list() snapshot: a concurrent writer must not invalidate the
+            # iteration mid-scan (single C-level op, no torn view).
             candidates = list(self._nodes.items())
         if filters is not None:
             candidates = [
@@ -381,12 +450,17 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         return node
 
     def _remove_node_by_id(self, node_id: str) -> bool:
-        handle = self._node_id_to_u64.pop(node_id, None)
+        # Callers hold the writer lock. Index first: the handle stops
+        # being searchable before it stops resolving, so a concurrent
+        # query can never surface a handle whose side-car entries are
+        # already gone.
+        handle = self._node_id_to_u64.get(node_id)
         if handle is None:
             return False
+        self._index.remove(handle)
+        self._node_id_to_u64.pop(node_id, None)
         self._u64_to_node_id.pop(handle, None)
         self._nodes.pop(node_id, None)
-        self._index.remove(handle)
         return True
 
     def _resolve_allowed_handles(
@@ -405,7 +479,9 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
           - ``filters``: apply metadata filters.
         All three intersect when more than one is supplied.
         """
-        candidates = self._nodes.items()
+        # list() snapshot: this runs on the (lock-free) query path, so a
+        # concurrent writer must not invalidate the iteration mid-scan.
+        candidates = list(self._nodes.items())
 
         if node_ids:
             node_id_set = set(node_ids)
@@ -419,14 +495,16 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
                 if data.get("ref_doc_id") in doc_id_set
             ]
 
-        if filters is None:
-            return [self._node_id_to_u64[nid] for nid, _ in candidates]
-
-        return [
-            self._node_id_to_u64[nid]
-            for nid, data in candidates
-            if self._filters_match(data["metadata"], filters)
-        ]
+        out: list[int] = []
+        for nid, data in candidates:
+            if filters is not None and not self._filters_match(data["metadata"], filters):
+                continue
+            # Tolerant resolution: the node can vanish between the snapshot
+            # above and here (concurrent delete) — skip rather than raise.
+            handle = self._node_id_to_u64.get(nid)
+            if handle is not None:
+                out.append(handle)
+        return out
 
     @classmethod
     def _filters_match(
@@ -565,22 +643,74 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
             k = min(query.similarity_top_k, len(self._index))
             scores, handles = self._index.search(qvec, k)
         else:
-            allowed_handles = self._resolve_allowed_handles(
-                query.filters, query.node_ids, query.doc_ids
-            )
-            if not allowed_handles:
-                return VectorStoreQueryResult(nodes=[], similarities=[], ids=[])
-            allowlist = np.asarray(allowed_handles, dtype=np.uint64)
-            scores, handles = self._index.search(
-                qvec, query.similarity_top_k, allowlist=allowlist
-            )
+            for _attempt in range(8):
+                allowed_handles = self._resolve_allowed_handles(
+                    query.filters, query.node_ids, query.doc_ids
+                )
+                if not allowed_handles:
+                    return VectorStoreQueryResult(nodes=[], similarities=[], ids=[])
+                allowlist = np.asarray(allowed_handles, dtype=np.uint64)
+                try:
+                    scores, handles = self._index.search(
+                        qvec, query.similarity_top_k, allowlist=allowlist
+                    )
+                    break
+                except KeyError:
+                    # The allowlist went stale: a delete landed between
+                    # resolving it and the kernel's membership check.
+                    # Rebuild the allowlist and retry.
+                    continue
+            else:
+                # Sustained churn kept invalidating the allowlist. Fall
+                # back to an unfiltered search plus a tolerant Python-side
+                # post-filter, which cannot raise (a query overlapping
+                # heavy churn may return fewer than similarity_top_k hits).
+                k = query.similarity_top_k
+                fetch_k = min(max(k * 4, 32), len(self._index) or 1)
+                scores, handles = self._index.search(qvec, fetch_k)
+                node_id_set = set(query.node_ids) if query.node_ids else None
+                doc_id_set = set(query.doc_ids) if query.doc_ids else None
+                result_nodes: list[TextNode] = []
+                similarities: list[float] = []
+                ids: list[str] = []
+                for score, handle in zip(scores[0], handles[0]):
+                    nid = self._u64_to_node_id.get(int(handle))
+                    if nid is None:
+                        continue
+                    data = self._nodes.get(nid)
+                    if data is None:
+                        continue
+                    if node_id_set is not None and nid not in node_id_set:
+                        continue
+                    if doc_id_set is not None and data.get("ref_doc_id") not in doc_id_set:
+                        continue
+                    if query.filters is not None and not self._filters_match(
+                        data["metadata"], query.filters
+                    ):
+                        continue
+                    result_nodes.append(self._reconstruct_node(nid, data))
+                    similarities.append(float(score))
+                    ids.append(nid)
+                    if len(ids) >= k:
+                        break
+                return VectorStoreQueryResult(
+                    nodes=result_nodes, similarities=similarities, ids=ids
+                )
 
-        result_nodes: list[TextNode] = []
-        similarities: list[float] = []
-        ids: list[str] = []
+        result_nodes = []
+        similarities = []
+        ids = []
         for score, handle in zip(scores[0], handles[0]):
-            nid = self._u64_to_node_id[int(handle)]
-            data = self._nodes[nid]
+            # Tolerant translation: a handle surfaced by the index can stop
+            # resolving if a delete completes between the kernel search and
+            # this loop (the reader-straddle). Skip it — the node is gone
+            # either way — rather than raising KeyError mid-query.
+            nid = self._u64_to_node_id.get(int(handle))
+            if nid is None:
+                continue
+            data = self._nodes.get(nid)
+            if data is None:
+                continue
             result_nodes.append(self._reconstruct_node(nid, data))
             similarities.append(float(score))
             ids.append(nid)
@@ -666,23 +796,27 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
             )
         base = _split_persist_base(persist_path)
         base.parent.mkdir(parents=True, exist_ok=True)
-        payload = {
-            "schema_version": _NODES_SCHEMA_VERSION,
-            "nodes": self._nodes,
-            # JSON object keys must be strings; round-trip int keys via
-            # an explicit list of [node_id, handle] pairs to preserve
-            # type fidelity.
-            "node_id_to_u64": list(self._node_id_to_u64.items()),
-            "next_u64": self._next_u64,
-        }
-        # Atomic: serializes in memory first, then temp-file + replace,
-        # so a failed persist can't destroy a previous store at this path.
-        atomic_save(
-            self._index,
-            base.with_suffix(_INDEX_EXT),
-            payload,
-            base.with_suffix(_STORE_EXT),
-        )
+        # Serializes with writers: snapshotting the maps and the index
+        # concurrently with a write would persist a torn store to disk.
+        # Reads may proceed while a persist runs.
+        with self._write_lock:
+            payload = {
+                "schema_version": _NODES_SCHEMA_VERSION,
+                "nodes": self._nodes,
+                # JSON object keys must be strings; round-trip int keys via
+                # an explicit list of [node_id, handle] pairs to preserve
+                # type fidelity.
+                "node_id_to_u64": list(self._node_id_to_u64.items()),
+                "next_u64": self._next_u64,
+            }
+            # Atomic: serializes in memory first, then temp-file + replace,
+            # so a failed persist can't destroy a previous store at this path.
+            atomic_save(
+                self._index,
+                base.with_suffix(_INDEX_EXT),
+                payload,
+                base.with_suffix(_STORE_EXT),
+            )
 
     @classmethod
     def from_persist_path(

--- a/turbovec-python/tests/conftest.py
+++ b/turbovec-python/tests/conftest.py
@@ -1,0 +1,5 @@
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "slow: long-running thread-safety stress cells (~1.5 s each)",
+    )

--- a/turbovec-python/tests/test_store_thread_safety.py
+++ b/turbovec-python/tests/test_store_thread_safety.py
@@ -1,0 +1,802 @@
+"""Thread-safety tests for the four integration stores (issue #161).
+
+Two halves:
+
+1. **Stress matrix** (marked ``slow``): a port of the issue-#161 research
+   harness. Every store runs 7 concurrency scenarios (add-vs-search,
+   churn-vs-search, filtered-search-vs-churn, add-vs-add,
+   delete-vs-delete, add-vs-delete, get-vs-churn) with plain threads,
+   ``sys.setswitchinterval(1e-7)`` and batched adds (batch 64 widens the
+   searchable-before-resolvable window). Each cell asserts zero
+   exceptions in every role plus the final-state invariants
+   ``len(index) == len(each side-car map)`` — and, for add-vs-add, an
+   exact ``_next_u64`` (which is what catches lost increments /
+   duplicate handles, the LlamaIndex data-loss race).
+
+2. **Deterministic units**: mutation ordering (maps populated before the
+   index add; index removal precedes map pops) observed via a spy index;
+   preservation of the issue-#89 no-partial-mutation guarantee through
+   the failure-unwind path; tolerant skip of a handle deleted mid-search
+   (the reader-straddle); and the non-raising fallback when a filtered
+   search's allowlist keeps going stale.
+"""
+from __future__ import annotations
+
+import itertools
+import re
+import sys
+import threading
+import time
+import traceback
+from collections import Counter
+from dataclasses import dataclass, field
+
+import numpy as np
+import pytest
+
+DIM = 32
+POOL = 4096
+_rng = np.random.default_rng(0)
+VECPOOL = _rng.standard_normal((POOL, DIM)).astype(np.float32)
+VECPOOL /= np.linalg.norm(VECPOOL, axis=1, keepdims=True) + 1e-9
+
+BATCH = 64
+N_READERS = 3
+DUR = 1.5  # seconds per stress cell; every issue-#161 race reproduced <1 s
+
+
+def vec_for(n: int) -> np.ndarray:
+    return VECPOOL[n % POOL]
+
+
+# ---------------------------------------------------------------------------
+# Stress-harness core (threads + classified exceptions)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ScenarioResult:
+    ops: Counter = field(default_factory=Counter)      # role -> completed ops
+    errors: Counter = field(default_factory=Counter)   # (role, exc, msg) -> n
+    first_tb: dict = field(default_factory=dict)
+
+
+def _msg_head(exc: BaseException) -> str:
+    s = str(exc).splitlines()[0] if str(exc) else ""
+    return re.sub(r"\d+", "#", s)[:90]
+
+
+def run_roles(roles, duration=DUR):
+    """roles: list of (role_name, fn); each fn is called in a loop on its
+    own thread until the duration elapses (or it returns StopIteration).
+    Every exception is recorded, never raised."""
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-7)
+    res = ScenarioResult()
+    stop = threading.Event()
+    lock = threading.Lock()  # protects the result counters only
+
+    def wrap(role, fn):
+        def runner():
+            while not stop.is_set():
+                try:
+                    step = fn()
+                    with lock:
+                        res.ops[role] += 1
+                    if step is StopIteration:
+                        break
+                except BaseException as exc:
+                    key = (role, type(exc).__name__, _msg_head(exc))
+                    with lock:
+                        res.errors[key] += 1
+                        tbkey = (role, type(exc).__name__)
+                        if tbkey not in res.first_tb:
+                            res.first_tb[tbkey] = traceback.format_exc()
+        return runner
+
+    threads = [threading.Thread(target=wrap(r, f), daemon=True) for r, f in roles]
+    try:
+        for t in threads:
+            t.start()
+        time.sleep(duration)
+    finally:
+        stop.set()
+        for t in threads:
+            t.join(timeout=30)
+        sys.setswitchinterval(old_interval)
+    return res
+
+
+def assert_clean(res: ScenarioResult, counts: dict, extra: dict | None = None):
+    """Zero exceptions in every role + all side-car maps agree with the
+    index (+ any extra exact invariants)."""
+    if res.errors:
+        lines = [f"  {role}: {exc}: {msg!r} x{n}" for (role, exc, msg), n in res.errors.items()]
+        tb = next(iter(res.first_tb.values()), "")
+        pytest.fail(
+            "concurrent ops raised:\n" + "\n".join(lines) + "\nfirst traceback:\n" + tb
+        )
+    index_len = counts.pop("index")
+    for name, value in counts.items():
+        assert value == index_len, (
+            f"final-state desync: len(index)={index_len} but {name}={value}"
+        )
+    for name, (got, want) in (extra or {}).items():
+        assert got == want, f"invariant {name}: got {got}, want {want}"
+
+
+# ---------------------------------------------------------------------------
+# Store adapters (uniform add/delete/search/... over the four stores)
+# ---------------------------------------------------------------------------
+
+
+class LangChainAdapter:
+    name = "langchain"
+
+    def __init__(self):
+        pytest.importorskip("langchain_core")
+        from langchain_core.embeddings import Embeddings
+
+        class FakeEmb(Embeddings):
+            def embed_documents(self, texts):
+                return [vec_for(hash(t)).tolist() for t in texts]
+
+            def embed_query(self, text):
+                return vec_for(hash(text)).tolist()
+
+        from turbovec.langchain import TurboQuantVectorStore
+
+        self._emb = FakeEmb()
+        self._cls = TurboQuantVectorStore
+
+    def make(self):
+        return self._cls(embedding=self._emb)
+
+    def add(self, s, ids, texts, metas):
+        s.add_texts(texts, metadatas=metas, ids=ids)
+
+    def delete(self, s, ids):
+        s.delete(list(ids))
+
+    def search(self, s, q, k=10):
+        return s.similarity_search_by_vector(list(map(float, q)), k=k)
+
+    def search_filtered(self, s, q, k=10):
+        return s._search_vector(np.asarray(q, dtype=np.float32), k, filter={"g": 1})
+
+    def get(self, s, ids):
+        return s.get_by_ids(list(ids))
+
+    def counts(self, s):
+        return {
+            "index": len(s._index),
+            "docs": len(s._docs),
+            "str_to_u64": len(s._str_to_u64),
+            "u64_to_str": len(s._u64_to_str),
+        }
+
+    def next_u64(self, s):
+        return s._next_u64
+
+
+class HaystackAdapter:
+    name = "haystack"
+
+    def __init__(self):
+        pytest.importorskip("haystack")
+        from haystack import Document
+        from haystack.document_stores.types import DuplicatePolicy
+
+        from turbovec.haystack import TurboQuantDocumentStore
+
+        self.Document = Document
+        self.OVERWRITE = DuplicatePolicy.OVERWRITE
+        self._cls = TurboQuantDocumentStore
+
+    def make(self):
+        return self._cls(dim=DIM)
+
+    def add(self, s, ids, texts, metas):
+        docs = [
+            self.Document(id=i, content=t, meta=m, embedding=vec_for(hash(t)).tolist())
+            for i, t, m in zip(ids, texts, metas)
+        ]
+        s.write_documents(docs, policy=self.OVERWRITE)
+
+    def delete(self, s, ids):
+        s.delete_documents(list(ids))
+
+    def search(self, s, q, k=10):
+        return s.embedding_retrieval(list(map(float, q)), top_k=k)
+
+    def search_filtered(self, s, q, k=10):
+        return s.embedding_retrieval(
+            list(map(float, q)),
+            top_k=k,
+            filters={"field": "meta.g", "operator": "==", "value": 1},
+        )
+
+    def get(self, s, ids):
+        # Nearest read-by-id analogue: filter_documents full scan.
+        return s.filter_documents()
+
+    def counts(self, s):
+        return {
+            "index": len(s._index),
+            "u64_to_doc": len(s._u64_to_doc),
+            "str_to_u64": len(s._str_to_u64),
+        }
+
+    def next_u64(self, s):
+        return s._next_u64
+
+
+class LlamaIndexAdapter:
+    name = "llama_index"
+
+    def __init__(self):
+        pytest.importorskip("llama_index.core")
+        from llama_index.core.schema import TextNode
+        from llama_index.core.vector_stores.types import (
+            MetadataFilter,
+            MetadataFilters,
+            VectorStoreQuery,
+        )
+
+        from turbovec.llama_index import TurboQuantVectorStore
+
+        self.TextNode = TextNode
+        self.VectorStoreQuery = VectorStoreQuery
+        self._filters = MetadataFilters(filters=[MetadataFilter(key="g", value=1)])
+        self._cls = TurboQuantVectorStore
+
+    def make(self):
+        return self._cls()
+
+    def add(self, s, ids, texts, metas):
+        nodes = [
+            self.TextNode(id_=i, text=t, metadata=m, embedding=vec_for(hash(t)).tolist())
+            for i, t, m in zip(ids, texts, metas)
+        ]
+        s.add(nodes)
+
+    def delete(self, s, ids):
+        s.delete_nodes(node_ids=list(ids))
+
+    def search(self, s, q, k=10):
+        return s.query(
+            self.VectorStoreQuery(query_embedding=list(map(float, q)), similarity_top_k=k)
+        )
+
+    def search_filtered(self, s, q, k=10):
+        return s.query(
+            self.VectorStoreQuery(
+                query_embedding=list(map(float, q)),
+                similarity_top_k=k,
+                filters=self._filters,
+            )
+        )
+
+    def get(self, s, ids):
+        return s.get_nodes(node_ids=list(ids))
+
+    def counts(self, s):
+        return {
+            "index": len(s._index),
+            "nodes": len(s._nodes),
+            "node_id_to_u64": len(s._node_id_to_u64),
+            "u64_to_node_id": len(s._u64_to_node_id),
+        }
+
+    def next_u64(self, s):
+        return s._next_u64
+
+
+class AgnoAdapter:
+    name = "agno"
+
+    def __init__(self):
+        pytest.importorskip("agno")
+        from agno.knowledge.document import Document
+        from agno.knowledge.embedder import Embedder
+
+        class FakeAgnoEmb(Embedder):
+            dimensions: int = DIM
+
+            def get_embedding(self, text):
+                return vec_for(hash(text)).tolist()
+
+            def get_embedding_and_usage(self, text):
+                return self.get_embedding(text), None
+
+        from turbovec.agno import TurboQuantVectorDb
+
+        self.Document = Document
+        self._emb = FakeAgnoEmb()
+        self._emb.dimensions = DIM
+        self._cls = TurboQuantVectorDb
+
+    def make(self):
+        s = self._cls(embedder=self._emb)
+        s.create()
+        return s
+
+    def add(self, s, ids, texts, metas):
+        docs = [
+            self.Document(
+                id=i, name=f"name-{i}", content=t, meta_data=m,
+                embedding=vec_for(hash(t)).tolist(),
+            )
+            for i, t, m in zip(ids, texts, metas)
+        ]
+        s.insert(content_hash=f"ch-{ids[0]}", documents=docs)
+
+    def delete(self, s, ids):
+        # agno keys deletes on the *derived* doc_id; callers sample live
+        # derived ids via live_ids().
+        for did in ids:
+            s.delete_by_id(did)
+
+    def live_ids(self, s, n):
+        return list(s._str_to_u64.keys())[:n]
+
+    def search(self, s, q, k=10):
+        # agno search embeds a query string; rotate the text per call.
+        return s.search(f"q-{int(q[0] * 1e6)}", limit=k)
+
+    def search_filtered(self, s, q, k=10):
+        return s.search(f"q-{int(q[0] * 1e6)}", limit=k, filters={"g": 1})
+
+    def get(self, s, ids):
+        return [s.id_exists(i) for i in ids]
+
+    def counts(self, s):
+        return {
+            "index": len(s._index),
+            "u64_to_doc": len(s._u64_to_doc),
+            "str_to_u64_handles": sum(len(hs) for hs in s._str_to_u64.values()),
+        }
+
+    def next_u64(self, s):
+        return s._next_u64
+
+
+ADAPTERS = {
+    "langchain": LangChainAdapter,
+    "haystack": HaystackAdapter,
+    "llama_index": LlamaIndexAdapter,
+    "agno": AgnoAdapter,
+}
+
+
+@pytest.fixture(params=list(ADAPTERS), ids=list(ADAPTERS))
+def adapter(request):
+    return ADAPTERS[request.param]()
+
+
+# ---------------------------------------------------------------------------
+# Scenario helpers
+# ---------------------------------------------------------------------------
+
+
+class IdGen:
+    def __init__(self, prefix):
+        self._c = itertools.count()
+        self._lock = threading.Lock()
+        self.prefix = prefix
+
+    def batch(self, n):
+        with self._lock:
+            ks = [next(self._c) for _ in range(n)]
+        return [f"{self.prefix}-{k}" for k in ks]
+
+
+def _mk_batch(gen, tag):
+    ids = gen.batch(BATCH)
+    texts = [f"text-{tag}-{i}" for i in ids]
+    metas = [{"g": j % 2, "t": tag} for j in range(len(ids))]
+    return ids, texts, metas
+
+
+# ---------------------------------------------------------------------------
+# Stress matrix: 4 stores x 7 scenarios
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_add_vs_search(adapter):
+    s = adapter.make()
+    gen = IdGen("a")
+    qit = itertools.count()
+
+    def writer():
+        ids, texts, metas = _mk_batch(gen, "w")
+        adapter.add(s, ids, texts, metas)
+
+    def reader():
+        adapter.search(s, vec_for(next(qit)))
+
+    roles = [("add", writer)] + [(f"search{i}", reader) for i in range(N_READERS)]
+    res = run_roles(roles)
+    assert res.ops["add"] > 0 and res.ops["search0"] > 0
+    assert_clean(res, adapter.counts(s))
+
+
+def _churn_cell(adapter, filtered):
+    s = adapter.make()
+    gen = IdGen("c")
+    qit = itertools.count()
+
+    def writer():
+        ids, texts, metas = _mk_batch(gen, "w")
+        adapter.add(s, ids, texts, metas)
+        if isinstance(adapter, AgnoAdapter):
+            adapter.delete(s, adapter.live_ids(s, BATCH))
+        else:
+            adapter.delete(s, ids)
+
+    search = adapter.search_filtered if filtered else adapter.search
+
+    def reader():
+        search(s, vec_for(next(qit)))
+
+    roles = [("churn", writer)] + [(f"search{i}", reader) for i in range(N_READERS)]
+    res = run_roles(roles)
+    assert res.ops["churn"] > 0 and res.ops["search0"] > 0
+    assert_clean(res, adapter.counts(s))
+
+
+@pytest.mark.slow
+def test_churn_vs_search(adapter):
+    _churn_cell(adapter, filtered=False)
+
+
+@pytest.mark.slow
+def test_filtered_search_vs_churn(adapter):
+    _churn_cell(adapter, filtered=True)
+
+
+@pytest.mark.slow
+def test_add_vs_add(adapter):
+    """Two concurrent writers; the exact `_next_u64` invariant is what
+    catches lost increments / duplicate handles (the LlamaIndex
+    data-loss race — batches rejected with 'id already present')."""
+    s = adapter.make()
+    gens = [IdGen("x"), IdGen("y")]
+    total = [0, 0]
+
+    def writer(slot):
+        def step():
+            ids, texts, metas = _mk_batch(gens[slot], f"w{slot}")
+            adapter.add(s, ids, texts, metas)
+            total[slot] += len(ids)
+        return step
+
+    res = run_roles([("add0", writer(0)), ("add1", writer(1))])
+    docs_added = sum(total)
+    assert docs_added > 0
+    counts = adapter.counts(s)
+    assert_clean(
+        res,
+        counts,
+        extra={
+            "index holds every added doc": (len(s._index), docs_added),
+            "_next_u64 == docs added (no lost increments / dup handles)": (
+                adapter.next_u64(s), docs_added,
+            ),
+        },
+    )
+
+
+@pytest.mark.slow
+def test_delete_vs_delete(adapter):
+    s = adapter.make()
+    gen = IdGen("d")
+    all_ids = []
+    for _ in range(60):
+        ids, texts, metas = _mk_batch(gen, "pre")
+        adapter.add(s, ids, texts, metas)
+        all_ids.extend(ids)
+    if isinstance(adapter, AgnoAdapter):
+        all_ids = list(s._str_to_u64.keys())
+    orders = [list(all_ids), list(reversed(all_ids))]
+    pos = [0, 0]
+
+    def deleter(slot):
+        def step():
+            p = pos[slot]
+            if p >= len(orders[slot]):
+                return StopIteration
+            adapter.delete(s, orders[slot][p : p + 16])
+            pos[slot] = p + 16
+        return step
+
+    res = run_roles([("del0", deleter(0)), ("del1", deleter(1))])
+    counts = adapter.counts(s)
+    assert_clean(res, counts, extra={"store fully emptied": (len(s._index), 0)})
+
+
+@pytest.mark.slow
+def test_add_vs_delete(adapter):
+    import collections
+
+    s = adapter.make()
+    gen = IdGen("m")
+    q = collections.deque()
+    qlock = threading.Lock()
+
+    def writer():
+        ids, texts, metas = _mk_batch(gen, "w")
+        adapter.add(s, ids, texts, metas)
+        with qlock:
+            q.append(ids)
+
+    def deleter():
+        with qlock:
+            ids = q.popleft() if q else None
+        if ids is None:
+            return
+        if isinstance(adapter, AgnoAdapter):
+            adapter.delete(s, adapter.live_ids(s, len(ids)))
+        else:
+            adapter.delete(s, ids)
+
+    res = run_roles([("add", writer), ("delete", deleter)])
+    assert res.ops["add"] > 0 and res.ops["delete"] > 0
+    assert_clean(res, adapter.counts(s))
+
+
+@pytest.mark.slow
+def test_get_vs_churn(adapter):
+    s = adapter.make()
+    gen = IdGen("g")
+
+    def writer():
+        ids, texts, metas = _mk_batch(gen, "w")
+        adapter.add(s, ids, texts, metas)
+        if isinstance(adapter, AgnoAdapter):
+            adapter.delete(s, adapter.live_ids(s, BATCH))
+        else:
+            adapter.delete(s, ids)
+
+    kit = itertools.count()
+
+    def getter():
+        n = next(kit)
+        ids = [f"g-{(n + d) % 2000}" for d in range(8)]
+        if isinstance(adapter, AgnoAdapter):
+            ids = adapter.live_ids(s, 8)
+        adapter.get(s, ids)
+
+    roles = [("churn", writer)] + [(f"get{i}", getter) for i in range(2)]
+    res = run_roles(roles)
+    assert res.ops["churn"] > 0 and res.ops["get0"] > 0
+    assert_clean(res, adapter.counts(s))
+
+
+# ---------------------------------------------------------------------------
+# Deterministic units
+# ---------------------------------------------------------------------------
+
+
+class SpyIndex:
+    """Wraps a store's IdMapIndex; hooks fire inside add_with_ids /
+    remove / search so tests can observe (or perturb) side-car state at
+    the exact moment the index mutates."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.on_add = None      # fn(handles) called BEFORE the real add
+        self.on_remove = None   # fn(handle) called BEFORE the real remove
+        self.on_search = None   # fn() called AFTER the real search returns
+        self.raise_on_allowlist = False
+
+    # --- passthrough surface the stores use ---
+    @property
+    def dim(self):
+        return self._inner.dim
+
+    @property
+    def bit_width(self):
+        return self._inner.bit_width
+
+    def __len__(self):
+        return len(self._inner)
+
+    def add_with_ids(self, vectors, handles):
+        if self.on_add is not None:
+            self.on_add(handles)
+        return self._inner.add_with_ids(vectors, handles)
+
+    def remove(self, handle):
+        if self.on_remove is not None:
+            self.on_remove(handle)
+        return self._inner.remove(handle)
+
+    def search(self, qvec, k, allowlist=None):
+        if allowlist is not None and self.raise_on_allowlist:
+            raise KeyError("allowlist contains id(s) not present in index")
+        if allowlist is not None:
+            out = self._inner.search(qvec, k, allowlist=allowlist)
+        else:
+            out = self._inner.search(qvec, k)
+        if self.on_search is not None:
+            self.on_search()
+        return out
+
+
+def _install_spy(store, adapter):
+    spy = SpyIndex(store._index)
+    if isinstance(adapter, LlamaIndexAdapter):
+        object.__setattr__(store, "_index", spy)
+    else:
+        store._index = spy
+    return spy
+
+
+def _seed(adapter, s, n=8, prefix="seed"):
+    ids = [f"{prefix}-{j}" for j in range(n)]
+    texts = [f"text-{prefix}-{j}" for j in range(n)]
+    metas = [{"g": j % 2} for j in range(n)]
+    adapter.add(s, ids, texts, metas)
+    return ids
+
+
+def test_ordering_maps_before_index_add(adapter):
+    """Layer (b), add side: every issued handle must already resolve
+    through the side-car maps at the moment the index add runs."""
+    s = adapter.make()
+    spy = _install_spy(s, adapter)
+    resolved_at_add = []
+
+    if isinstance(adapter, LangChainAdapter):
+        resolve = lambda h: s._u64_to_str.get(int(h)) in s._docs
+    elif isinstance(adapter, HaystackAdapter):
+        resolve = lambda h: int(h) in s._u64_to_doc
+    elif isinstance(adapter, LlamaIndexAdapter):
+        resolve = lambda h: s._u64_to_node_id.get(int(h)) in s._nodes
+    else:  # agno
+        resolve = lambda h: int(h) in s._u64_to_doc
+
+    spy.on_add = lambda handles: resolved_at_add.append(
+        all(resolve(h) for h in handles)
+    )
+    _seed(adapter, s)
+    assert resolved_at_add == [True], (
+        "side-car maps must be populated before the index add — otherwise a "
+        "concurrent search can surface a handle that does not resolve yet"
+    )
+
+
+def test_ordering_index_removed_before_map_pop(adapter):
+    """Layer (b), delete side: at the moment the index removal runs, the
+    side-car maps must still resolve the handle (index first, maps
+    second)."""
+    s = adapter.make()
+    ids = _seed(adapter, s)
+    spy = _install_spy(s, adapter)
+    still_resolved = []
+
+    if isinstance(adapter, LangChainAdapter):
+        resolve = lambda h: s._u64_to_str.get(int(h)) in s._docs
+    elif isinstance(adapter, HaystackAdapter):
+        resolve = lambda h: int(h) in s._u64_to_doc
+    elif isinstance(adapter, LlamaIndexAdapter):
+        resolve = lambda h: s._u64_to_node_id.get(int(h)) in s._nodes
+    else:  # agno
+        resolve = lambda h: int(h) in s._u64_to_doc
+
+    spy.on_remove = lambda handle: still_resolved.append(resolve(handle))
+
+    if isinstance(adapter, AgnoAdapter):
+        adapter.delete(s, adapter.live_ids(s, len(ids)))
+    else:
+        adapter.delete(s, ids)
+    assert still_resolved and all(still_resolved), (
+        "the index removal must precede the side-car map pops — otherwise a "
+        "concurrent search can surface a handle whose entry is already gone"
+    )
+    assert len(s._index) == 0
+
+
+def test_failed_add_unwinds_cleanly(adapter):
+    """Issue-#89 preservation under the maps-first ordering: an add whose
+    index insert fails (non-finite embedding) must leave every map and
+    the index exactly as they were — including restoring the previous
+    entry of an upserted id."""
+    s = adapter.make()
+    _seed(adapter, s, n=4)
+    before = adapter.counts(s)
+    before_next = adapter.next_u64(s)
+
+    bad_ids = ["seed-0", "fresh-0"]  # one upsert collision + one new id
+    texts = ["bad-a", "bad-b"]
+    metas = [{"g": 0}, {"g": 1}]
+    if isinstance(adapter, LangChainAdapter):
+        bad = np.full((2, DIM), np.nan, dtype=np.float32)
+        with pytest.raises(Exception):
+            s._store_texts_and_vectors(texts, bad, metas, bad_ids)
+        assert s._docs["seed-0"][0] == "text-seed-0"  # old payload restored
+    elif isinstance(adapter, HaystackAdapter):
+        docs = [
+            adapter.Document(id=i, content=t, meta=m, embedding=[float("nan")] * DIM)
+            for i, t, m in zip(bad_ids, texts, metas)
+        ]
+        with pytest.raises(Exception):
+            s.write_documents(docs, policy=adapter.OVERWRITE)
+        assert s._u64_to_doc[s._str_to_u64["seed-0"]]["content"] == "text-seed-0"
+    elif isinstance(adapter, LlamaIndexAdapter):
+        nodes = [
+            adapter.TextNode(id_=i, text=t, metadata=m, embedding=[float("nan")] * DIM)
+            for i, t, m in zip(bad_ids, texts, metas)
+        ]
+        with pytest.raises(Exception):
+            s.add(nodes)
+        assert s._nodes["seed-0"]["node_dict"]["_node_content"]  # old node kept
+    else:  # agno: append semantics, no by-id upsert in insert
+        docs = [
+            adapter.Document(
+                id=i, name=f"n-{i}", content=t, meta_data=m,
+                embedding=[float("nan")] * DIM,
+            )
+            for i, t, m in zip(bad_ids, texts, metas)
+        ]
+        with pytest.raises(Exception):
+            s.insert(content_hash="ch-bad", documents=docs)
+        assert "ch-bad" not in s._content_hashes
+
+    assert adapter.counts(s) == before, "failed add must not change any map"
+    # Handles issued for the failed batch may stay consumed (gaps are
+    # fine); the counter must never go backwards.
+    assert adapter.next_u64(s) >= before_next
+
+
+def test_search_skips_handle_deleted_mid_flight(adapter):
+    """Layer (c): a delete that completes between the kernel search and
+    result translation (the reader-straddle) must be skipped, not raise."""
+    s = adapter.make()
+    ids = _seed(adapter, s, n=6)
+    spy = _install_spy(s, adapter)
+
+    def straddle():
+        # Runs after index.search returned its handles, before the store
+        # translates them — delete one of the seeded entries.
+        spy.on_search = None  # once
+        if isinstance(adapter, AgnoAdapter):
+            adapter.delete(s, adapter.live_ids(s, 1))
+        else:
+            adapter.delete(s, [ids[0]])
+
+    spy.on_search = straddle
+    out = adapter.search(s, vec_for(0), k=6)
+    if isinstance(adapter, LlamaIndexAdapter):
+        n = len(out.ids)
+    else:
+        n = len(out)
+    assert n == 5, f"expected the deleted handle to be skipped, got {n} results"
+
+
+def test_filtered_search_stale_allowlist_fallback(adapter):
+    """Layer (c): when every allowlist attempt hits the kernel's
+    'not present in index' KeyError (sustained churn), the filtered
+    search must fall back to a non-raising post-filtered result instead
+    of surfacing the misleading KeyError."""
+    s = adapter.make()
+    _seed(adapter, s, n=8)
+    spy = _install_spy(s, adapter)
+    spy.raise_on_allowlist = True
+
+    out = adapter.search_filtered(s, vec_for(0), k=8)
+    if isinstance(adapter, LlamaIndexAdapter):
+        nodes = out.nodes
+        assert len(nodes) == 4
+        assert all(node.metadata["g"] == 1 for node in nodes)
+    elif isinstance(adapter, LangChainAdapter):
+        assert len(out) == 4
+        assert all(doc.metadata["g"] == 1 for doc, _score in out)
+    elif isinstance(adapter, HaystackAdapter):
+        assert len(out) == 4
+        assert all(doc.meta["g"] == 1 for doc in out)
+    else:  # agno
+        assert len(out) == 4
+        assert all(doc.meta_data["g"] == 1 for doc in out)


### PR DESCRIPTION
Implements the maintainer-ruled design from the #161 thread-safety research (D7): layered thread-safety — (d) writer-only mutex + (b) reader-safe mutation ordering + (c) tolerant readers — in all four Python integration stores (LangChain, Haystack, LlamaIndex, Agno). Full credit to the empirical research report for the design and the measured evidence; the stress suite here is a port of its harness.

## Design (per the research's measured ruling)

1. **(d) Per-store writer-only mutex** — a `threading.RLock` taken by every mutating method (add/write/insert, delete, upsert, update, clear/drop; sync and async bodies) and by every save path (`dump` / `save_to_disk` / `persist` / `save`, so a save always snapshots a consistent store). **Readers take no lock**, preserving the #186 concurrent-read scaling — the research's plain-mutex foil measured 0.97x (a 3.9x regression), which this design avoids. The lock is the only fix for LlamaIndex's *data-losing* duplicate-handle race (pydantic `PrivateAttr` makes `_next_u64 += 1` tearable — 832 docs silently lost in a 4 s 2-writer run) and Agno's 86.5% delete-vs-delete cleanup-scan crash.
2. **(b) Reader-safe mutation ordering** — adds populate the side-car maps **before** the index insert (a search can only learn a handle from the index, so no reachable handle is ever unmapped), with a per-store failure-unwind that rolls back the pre-inserted map entries (and restores upserted entries) so the #89 "a failed add never destroys existing data" guarantee is preserved; deletes remove from the index **first**, maps second. Validation still precedes any mutation (#89/#139 orderings intact).
3. **(c) Tolerant readers** — result translation uses `.get`-and-skip for handles that vanish mid-flight (the delete-straddle: the one race ordering provably cannot close — 9.4% residual under ordering alone in the research), `list()` snapshots before every reader-side dict iteration, and filtered searches retry a stale allowlist then fall back to a non-raising unfiltered-search + post-filter (bounded retry alone left 2/240k in the research; the fallback closes them). Load-time strictness (#178 keyset/handle checks) is untouched — corruption still fails loud at load; tolerance covers only in-flight windows.

**Documented contract** (each integration doc + class docstring): reads run concurrently and scale; writes serialize on a per-store lock; a read overlapping a write sees pre- or post-write state; under heavy churn a search may transiently return fewer than `k`. Honest-unsafe list documented where user-visible: no cross-call atomicity; batch writes not atomic w.r.t. readers; save serializes with writes; embedders/rerankers run outside the lock; multi-process access unsupported.

## Race matrix — before (research's measured rates on main) → after (this PR)

| store | cell | before | after |
|---|---|---|---|
| langchain | add-vs-search | KeyError 0.32% | **0** |
| langchain | churn-vs-search | KeyError 13.4% | **0** |
| langchain | filtered-search-vs-churn | dict-changed-size 10.0% (+KeyError 4.4%) | **0** |
| haystack | churn-vs-search | KeyError ~2.1% | **0** |
| haystack | filtered-search-vs-churn | dict-changed-size 4.3% | **0** |
| haystack | filter_documents-vs-churn | dict-changed-size 1.9% | **0** |
| llama_index | add-vs-search | KeyError 7.7% | **0** |
| llama_index | churn-vs-search | KeyError 31.8% | **0** |
| llama_index | **add-vs-add** | **DATA LOSS: 832 docs rejected (0.78% of adds), 137 lost `_next_u64` increments** | **0 — `_next_u64` exact** |
| llama_index | filtered-search-vs-churn | dict-changed-size 36.3% | **0** |
| agno | delete-vs-delete | dict-changed-size 86.5% | **0** |
| agno | filtered-search-vs-churn | dict-changed-size 13.5% | **0** |

Verified by checking out main's store sources against the new suite: **29 tests fail on unpatched main** (every scenario class bites on at least one store, matching the research matrix — including the llama add-vs-add data-loss cell), and all pass on this branch. Agno's already-tolerant unfiltered reads stay clean on both, as the research measured.

## Perf gate (research methodology: LangChain store, dim 256, M-series arm64; two interleaved runs each)

| metric | main | this PR | delta |
|---|---|---|---|
| add (ms / 256-doc batch) | 5.22 / 5.18 | 5.23 / 5.30 | +1.2% avg |
| search 2k-doc store (µs) | 47.5 / 47.4 | 47.4 / 47.6 | +0.1% |
| search 50k-doc store (µs) | 277.8 / 277.1 | 278.4 / 278.3 | +0.3% |
| 1T search (ops/s) | 3588 / 3596 | 3571 / 3562 | −0.7% |
| 4T search (ops/s) | 13431 / 13519 | 13377 / 13285 | −1.1% |
| **4T/1T scaling** | **3.74x / 3.76x** | **3.75x / 3.73x** | noise |

All deltas within the ±3% run-to-run noise band; the #186 concurrent-read scaling is intact.

## Tests

- `tests/test_store_thread_safety.py` — port of the research harness: 4 stores × 7 scenarios (add-vs-search, churn-vs-search, filtered-search-vs-churn, add-vs-add, delete-vs-delete, add-vs-delete, get-vs-churn), `slow`-marked at ~1.5 s per cell, asserting zero exceptions in every role + `len(index) == len(each map)` + exact `_next_u64` on add-vs-add (the duplicate-handle catcher).
- Deterministic units (all four stores): maps-before-index-add and index-removal-before-map-pop observed via a spy index; #89 unwind preservation (failed add over an upsert restores the previous entry exactly); tolerant skip of a handle deleted mid-search; non-raising stale-allowlist fallback returning correctly filtered results.
- Full suite: **552 passed** (504 on main baseline + 48 new); `test_gil_release.py` stays green.

## Follow-up suggestions (not in this PR)

- A nightly 4-thread scaling floor probe (≥3x on 4 cores), per the research's test plan — regression-prevention infra, kept separate from the fix.

Closes #161

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
