### PR TITLE
fix: lower x86 baseline to x86-64-v2 so pre-AVX2 CPUs reach the scalar fallback (#137)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,20 +1,22 @@
-# Target the x86-64-v3 microarchitecture level on all x86_64 builds.
+# Target the x86-64-v2 microarchitecture level on all x86_64 builds.
 #
-# x86-64-v3 corresponds to the generic Haswell/Excavator feature set
-# (AVX, AVX2, BMI1, BMI2, FMA, F16C, LZCNT, MOVBE, OSXSAVE) which has
-# been ubiquitous since 2013 and is the minimum floor for running
-# turbovec's AVX2 SIMD kernel anyway. Setting it here lets LLVM emit
-# AVX2/FMA instructions in the surrounding non-intrinsic Rust code
-# (rotation loops, LUT build, heap update) which measurably improves
-# the non-hot-kernel paths.
+# x86-64-v2 (Nehalem-era: SSE3/SSSE3/SSE4.1/SSE4.2/POPCNT) is the
+# baseline for all *plain* Rust code in the binary — the dispatch
+# prologue, LUT build, rotation loops, heap update, and the pre-AVX2
+# scalar fallback in search.rs. That code must execute on every x86_64
+# CPU the crate supports, including pre-Haswell CPUs without AVX2,
+# because it runs *before* the `is_x86_feature_detected!` dispatch can
+# choose a kernel.
 #
-# We do NOT set x86-64-v4 (AVX-512) here because the AVX-512 kernel is
-# already runtime-dispatched via `is_x86_feature_detected!`, and
-# raising the baseline to v4 would make the whole crate SIGILL on
-# CPUs without AVX-512 even though the AVX2 fallback kernel would
-# otherwise handle them fine.
+# We do NOT set x86-64-v3 (AVX2/BMI2) or v4 (AVX-512) here: the AVX2
+# and AVX-512 kernels are `#[target_feature]`-gated functions that are
+# compiled with their full feature sets regardless of this baseline and
+# selected at runtime via `is_x86_feature_detected!`. Raising the
+# baseline above v2 makes the surrounding non-kernel code SIGILL on
+# CPUs without those features before dispatch ever runs — defeating
+# the scalar fallback (issue #137).
 #
 # ARM / aarch64 builds are unaffected — they use their own default
 # codegen target.
 [target.'cfg(target_arch = "x86_64")']
-rustflags = ["-C", "target-cpu=x86-64-v3"]
+rustflags = ["-C", "target-cpu=x86-64-v2"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,11 +72,13 @@ appears under each surface it touches.
   and the pre-AVX2 scalar fallback itself — was compiled with AVX/VEX
   instructions and faulted on pre-Haswell CPUs before
   `is_x86_feature_detected!` could ever select the fallback. The baseline
-  is now `x86-64-v2`; the AVX2 and AVX-512 kernels are unaffected because
-  they are `#[target_feature]`-gated and compiled with their full feature
-  sets regardless of the baseline. Applies to builds made from the repo
-  checkout (the published crates.io `.crate` does not contain
-  `.cargo/config.toml` and was never affected). (#137)
+  is now `x86-64-v2`; the AVX2 and AVX-512 kernels stay runtime-dispatched
+  and are `#[target_feature]`-gated, so they are compiled with their full
+  feature sets regardless of the baseline (re-tuned by the baseline's
+  tuning model). Applies only to builds made from a repo checkout — CI,
+  benchmarks, and the wheel pipeline; the published crates.io `.crate`
+  does not contain `.cargo/config.toml`, so `cargo add turbovec` users
+  were never affected. (#137)
 - **Index saves are atomic.** `io::write` / `io::write_id_map` (and
   `TurboQuantIndex::write` / `IdMapIndex::write` on top of them) now write
   to a sibling temp file, fsync, and rename over the destination, so a
@@ -254,6 +256,17 @@ appears under each surface it touches.
   delete racing a filtered search. Load-time validation is
   unchanged: a corrupt persisted store still fails loudly at load.
   (#161)
+- **The x86_64 Linux and Windows wheels run on pre-AVX2 CPUs.** The
+  wheels are built inside the repo checkout, so they inherited the repo
+  `.cargo/config.toml`'s global `target-cpu=x86-64-v3` baseline: every
+  plain (non-`#[target_feature]`) function — including the runtime
+  dispatch and the scalar fallback itself — contained AVX/VEX
+  instructions, and importing-and-searching on a pre-Haswell x86-64 CPU
+  faulted (SIGILL) before the fallback could be selected. The wheels now
+  build at the `x86-64-v2` baseline; AVX2/AVX-512 hardware still gets the
+  `#[target_feature]`-gated SIMD kernels via runtime dispatch, compiled
+  with their full feature sets regardless of the baseline (re-tuned by
+  the baseline's tuning model). (#137)
 - **Agno's `TurboQuantVectorDb` accepts `bit_width=3`.** The constructor
   guard rejected 3 even though the core `IdMapIndex` — and the langchain,
   haystack, and llama_index stores built on it — fully support it; the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,18 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **Pre-AVX2 x86-64 CPUs no longer SIGILL before the scalar fallback can
+  run.** The repo-level `.cargo/config.toml` set a global
+  `target-cpu=x86-64-v3` (AVX2/FMA/BMI2) baseline, so every *plain* (non-
+  `#[target_feature]`) function — including the runtime-dispatch prologue
+  and the pre-AVX2 scalar fallback itself — was compiled with AVX/VEX
+  instructions and faulted on pre-Haswell CPUs before
+  `is_x86_feature_detected!` could ever select the fallback. The baseline
+  is now `x86-64-v2`; the AVX2 and AVX-512 kernels are unaffected because
+  they are `#[target_feature]`-gated and compiled with their full feature
+  sets regardless of the baseline. Applies to builds made from the repo
+  checkout (the published crates.io `.crate` does not contain
+  `.cargo/config.toml` and was never affected). (#137)
 - **Index saves are atomic.** `io::write` / `io::write_id_map` (and
   `TurboQuantIndex::write` / `IdMapIndex::write` on top of them) now write
   to a sibling temp file, fsync, and rename over the destination, so a

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Each vector is a direction on a high-dimensional hypersphere. TurboQuant compres
 
 Encoding cost: one extra `d`-dimensional dot product per vector to compute `⟨u, x̂⟩`. On 1M vectors at d=1536 this is sub-second of additional encode time — a one-shot price paid at ingest, not at query.
 
-**Search.** Instead of decompressing every database vector, we rotate the query once into the same domain and score directly against the codebook values. The scoring kernel uses SIMD intrinsics (NEON on ARM, AVX-512BW on modern x86 with an AVX2 fallback) with nibble-split lookup tables for maximum throughput.
+**Search.** Instead of decompressing every database vector, we rotate the query once into the same domain and score directly against the codebook values. The scoring kernel uses SIMD intrinsics (NEON on ARM; AVX-512BW on modern x86, falling back to AVX2, then to a scalar path on pre-AVX2 CPUs) with nibble-split lookup tables for maximum throughput.
 
 The Lloyd-Max codebook achieves distortion within a factor of 2.7x of the information-theoretic lower bound (Shannon's distortion-rate limit); the length-renormalization step removes the residual bias the Lloyd-Max codebook introduces on the inner-product estimator itself.
 
@@ -201,7 +201,7 @@ pip install target/wheels/*.whl
 cargo build --release
 ```
 
-All x86_64 builds target `x86-64-v3` (AVX2 baseline, Haswell 2013+) via `.cargo/config.toml`. Any CPU that can run the AVX2 fallback kernel can run the whole crate — the AVX-512 kernel is gated at runtime via `is_x86_feature_detected!` and only kicks in on hardware that supports it.
+All x86_64 builds target `x86-64-v2` (SSE4.2 baseline, Nehalem 2008+) via `.cargo/config.toml`, so any x86-64-v2 CPU can run the whole crate. The AVX-512 and AVX2 kernels are `#[target_feature]`-gated and selected at runtime via `is_x86_feature_detected!`, so they kick in on hardware that supports them regardless of the compile baseline; CPUs with neither run the scalar fallback.
 
 ## Running benchmarks
 


### PR DESCRIPTION
Implements the maintainer-ruled fix direction (a) from #137: lower the global x86 compile baseline from `x86-64-v3` to `x86-64-v2` so the runtime dispatch and the #106 scalar fallback actually function on pre-AVX2 CPUs.

## Mechanism

`.cargo/config.toml` applied `-C target-cpu=x86-64-v3` to **all** plain (non-`#[target_feature]`) code. That includes `turbovec::search::search`'s dispatch closure — LUT setup, heap init, and the inlined `score_query_into_heap` scalar fallback — which runs **before** the `is_x86_feature_detected!` checks. At v3 that closure alone contained **523 above-v2 instructions (302 `%ymm` references)**, so a pre-Haswell / AVX2-hiding-VM CPU raises `#UD` → SIGILL before dispatch can ever choose the fallback: exactly the CPUs #106 exists to serve.

The fix keeps the hot paths dispatched because the four SIMD kernels (`search_multi_query_avx2`, `search_multi_query_avx512bw`, `avx2_batch_flush_to_fa`, `avx2_post_flush_heap_update` — `turbovec/src/search.rs:168,402,700,737`) are `#[target_feature]`-gated functions: they are compiled with their full feature sets **regardless of the baseline** (re-tuned by the baseline's tuning model — see Performance below) and selected at runtime. Non-kernel glue drops from v3 to v2 codegen. ARM/aarch64 builds are byte-identical in intent and config: the section is scoped `[target.'cfg(target_arch = "x86_64")']` and only the `target-cpu` value changed.

## Wheel pipeline findings

- `release-pypi.yml` builds all wheels via `maturin-action` with `working-directory: turbovec-python` inside the repo checkout and sets **no RUSTFLAGS of its own** — cargo walks up and applies the root `.cargo/config.toml`. So the shipped x86_64 Linux and Windows wheels inherited v3, and this one-line config change fixes them; no workflow edit needed.
- The published crates.io `.crate` does **not** contain `.cargo/config.toml` (per the #166 file list), so `cargo add turbovec` users were never affected; the CHANGELOG entries say so.

## Evidence 1 — disassembly audit (macOS ARM host, cross-compiled `x86_64-apple-darwin`, release)

Scripted audit of the emitted `.s` (`cargo rustc --release --target x86_64-apple-darwin -p turbovec --lib -- --emit asm`): attribute every instruction to its enclosing symbol; flag any `%ymm`/`%zmm` reference, VEX/EVEX `v*` mnemonic, or BMI1/BMI2/`lzcnt` scalar op (i.e. anything above x86-64-v2); allowlist only the four `#[target_feature]` kernels plus `pulp::x86::V3::vectorize::__impl` (pulp is faer's SIMD layer; its `__impl` is generated with `#[target_feature(enable = ...)]` per feature and the `V3` token is only constructible after runtime detection — the same dispatch pattern as our kernels, verified in pulp 0.18.22 source).

| build | above-v2 instructions outside gated code | violating symbols |
|---|---|---|
| `target-cpu=x86-64-v3` (old) | **6,576** | **200** (incl. `search::search` closure: 523) |
| `target-cpu=x86-64-v2` (new) | **0** | **0** |

The v2 binary still contains the full AVX kernels (audit counts inside allowlisted symbols: 1,098 AVX/AVX-512 instructions in `search_multi_query_avx512bw`, 537 in `search_multi_query_avx2`, 251 in `avx2_post_flush_heap_update`), i.e. lowering the baseline did not strip the dispatched kernels.

**Scope of the zero-claim:** this audit covers the `turbovec` crate's own codegen units (the crate's emitted `.s`). Adversarial review extended the same audit to the fully-linked binary and verified, family by family, that every above-v2 instruction contributed by dependency crates (~71k, dominated by pulp/faer) also lives in runtime-feature-gated code — and confirmed pulp's gating in both 0.18.22 and 0.21.5.

<details>
<summary>Audit script (local verification tooling, not committed)</summary>

```python
#!/usr/bin/env python3
"""Audit an x86_64 .s file: flag AVX/AVX2/AVX-512/BMI/FMA (above-x86-64-v2)
instructions appearing OUTSIDE the #[target_feature]-gated kernel symbols."""
import re, sys, collections

ASM = sys.argv[1]
ALLOW = re.compile(
    r"search_multi_query_avx2|search_multi_query_avx512bw|"
    r"avx2_batch_flush_to_fa|avx2_post_flush_heap_update|"
    r"pulp3x86\dV\d+9vectorize6__impl"  # pulp runtime-gated vectorize impls
)
LEGACY_V = {"verr", "verw", "vmcall", "vmlaunch", "vmresume", "vmxoff",
            "vmxon", "vmclear", "vmptrld", "vmptrst", "vmread", "vmwrite",
            "vmfunc"}
BMI = re.compile(r"^\s+(mulxq?|pdepq?|pextq?|shlxq?|shrxq?|sarxq?|rorxq?|"
                 r"andnq?|andnl|bextrq?|blsiq?|blsmskq?|blsrq?|lzcntq?|lzcntl)\b")
VMNEM = re.compile(r"^\s+(v[a-z0-9]+)\b")
WIDE = re.compile(r"%[yz]mm\d+")

sym = None
bad = collections.defaultdict(list)
allowed_hits = collections.Counter()
label_re = re.compile(r"^(_?[A-Za-z_.$][\w.$]*):")

with open(ASM) as f:
    for n, line in enumerate(f, 1):
        m = label_re.match(line)
        if m and not m.group(1).startswith(("L", "l_", ".")):
            sym = m.group(1); continue
        hit = False
        if WIDE.search(line) and not line.lstrip().startswith((".", "#", "//")):
            hit = True
        else:
            vm = VMNEM.match(line)
            if vm and vm.group(1) not in LEGACY_V:
                hit = True
            elif BMI.match(line):
                hit = True
        if hit:
            if sym and ALLOW.search(sym):
                allowed_hits[sym] += 1
            else:
                bad[sym or "<no-symbol>"].append((n, line.rstrip()))

for s, c in allowed_hits.most_common():
    print(f"  {c:6d}  {s}")
if bad:
    print("VIOLATIONS outside gated kernels:")
    for s, lines in bad.items():
        print(f"  {s}: {len(lines)}")
    sys.exit(1)
print("PASS: no above-v2 instructions outside #[target_feature] kernels.")
```
</details>

## Evidence 2 — full suite under Rosetta 2 (executes the fallback end-to-end)

`cargo test --release --target x86_64-apple-darwin -p turbovec` on the ARM host runs every test binary under Rosetta 2, which reports **no** AVX/AVX2/FMA/BMI (probe: `sse4.2: true`, everything above: `false`) — a v2-class environment. Dispatch therefore takes the scalar-fallback branch (`search.rs:1577`) for every search in the suite.

**Result: 209/209 passed, 0 failed** (lib 30, concurrent_search 8, filtering 15, from_parts 33, id_map 19, input_validation 15, io_hardening 11, io_v4 13, io_versioning 9, kernel_correctness 7, lazy_init 24, rotation 5, state_sequences 9, swap_remove 6, tqplus_calibration 2, doc-tests 3).

**Honest limitation:** Rosetta cannot demonstrate the *SIGILL itself* — I verified directly that it executes VEX/AVX2 instructions it does not advertise (a `#[target_feature]` `_mm256_add_epi32` probe runs fine while `is_x86_feature_detected!("avx2")` returns false), and accordingly the old v3 build also happens to pass under Rosetta. So the Rosetta run proves "the scalar fallback genuinely executes end-to-end and returns correct results at the new baseline"; the SIGILL-on-real-silicon claim rests on the disassembly audit above — genuine pre-AVX2 CPUs raise `#UD` on VEX encodings by architecture definition, and the audit shows the v3 build put 6,576 of them in unconditionally-reachable code and the v2 build puts zero.

## AVX-capable machines still get the kernels

Both AVX kernels are present in the v2 binary (symbol + instruction counts above) and the dispatch logic is untouched — `avx512bw && avx512f` → AVX-512 kernel, else `avx2` → AVX2 kernel, else scalar. CI's `ubuntu-latest`/`windows-latest` runners are x86_64 **with** AVX2, so a green Rust CI on this PR is the execution proof that the AVX2 kernel path still selects and computes correctly at the v2 baseline (the same suite includes kernel-vs-scalar correctness comparisons).

## Performance

No benchmark numbers claimed. The gated kernels keep their full instruction-set capability, but they are **not bit-identical** across baselines: `target-cpu` also selects LLVM's tuning model, and measured deltas include `search_multi_query_avx512bw` growing 1,808 → 1,836 instructions at v2 (some unaligned 256-bit ops split into 128-bit pairs by the v2 tuning heuristics) and the AVX2 kernel being outlined at v2 where v3 had fully inlined it into the dispatch closure (that inlining being the bug itself). Correctness of both kernels at the new baseline is proven by CI (AVX2 runners) and the suite's kernel-vs-scalar comparisons; performance impact is expected to be minor but is unmeasured — **recommend one benchmark run on the x86 bench instance before the next release** to confirm. The other expected x86 delta is non-kernel glue (rotation loops, LUT build, heap bookkeeping outside the kernels) dropping from v3 to v2 codegen; if x86 CI timings visibly regress that should be investigated before merge. ARM builds are entirely outside the config section's scope and unaffected.

Closes #137

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

