### PR TITLE
In-memory serialization API (to_bytes/from_bytes) + correct pickle/copy semantics for all four stores (#148, #149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,9 +267,11 @@ appears under each surface it touches.
   are excluded and recreated on restore), `__deepcopy__`, and
   `__copy__`. The state is snapshotted under the store's writer lock,
   so a pickle overlapping a write captures a consistent index/side-car
-  pair. `pickle.loads(pickle.dumps(store))` round-trips documents,
-  metadata, search results, and the handle counter, including into
-  `multiprocessing` spawn workers. `copy.copy` deliberately equals
+  pair (per-doc payload dicts are copied deeply enough that an
+  in-place metadata update landing mid-pickle cannot tear the
+  snapshot). `pickle.loads(pickle.dumps(store))` round-trips
+  documents, metadata, search results, the similarity mode, and the
+  handle counter, including into `multiprocessing` spawn workers. `copy.copy` deliberately equals
   `copy.deepcopy`: there is no meaningful shallow copy of a store —
   sharing the mutable Rust index means mutations bleed between the
   copies (see *Fixed*). (#148, #149)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,25 @@ appears under each surface it touches.
   version" error (verified against the previous release's loader — no
   silent misparse).
 
+- **In-memory serialization: `to_bytes` / `from_bytes` on both index
+  types, and generic `Read`/`Write` I/O entry points.**
+  `TurboQuantIndex::to_bytes` / `IdMapIndex::to_bytes` serialize an
+  index to its `.tv` / `.tvim` wire format in memory — byte-identical
+  to the file `write(path)` produces — and `from_bytes` mirrors `load`
+  with exactly the same validation (version handling, structural and
+  value-level checks, v4 rotation-drift verification, the `.tvim`
+  duplicate-id check), so bytes and the file they came from load, or
+  fail, identically. `write_to_writer<W: Write>` /
+  `load_from_reader<R: Read>` are the generic-sink forms; the `io`
+  module gains the matching raw entry points `io::write_to`,
+  `io::load_from`, `io::write_id_map_to` and `io::load_id_map_from`.
+  Like the file paths, `to_bytes` on the index types reuses the cached
+  rotation matrix for the v4 fingerprint (no `O(dim³)` rebuild); only
+  the raw `io` writers rebuild it. `IdMapIndex` now derives `Debug`.
+  This delivers the in-memory I/O half of #70 (the `from_parts` half
+  landed in #204) and is the substrate for the Python stores' pickle
+  support. (#148, #149, #70)
+
 #### Changed
 
 - **`MAX_DIM` lowered from 65536 to 16384.** The engine builds a
@@ -233,6 +252,27 @@ appears under each surface it touches.
   importing `importlib.metadata` eagerly would multiply the import
   time by ~25x). Falls back to `"0.0.0.dev0"` when no dist metadata
   is installed. (#153)
+- **`to_bytes()` / `from_bytes(data)` on `TurboQuantIndex` and
+  `IdMapIndex`.** Serialize an index to `bytes` in its `.tv` / `.tvim`
+  wire format — byte-identical to the file `write(path)` produces —
+  and reconstruct it from those bytes with exactly the same validation
+  as `load` (corrupt or drifted payloads raise `ValueError`). Both run
+  with the GIL released; `from_bytes` accepts `bytes` or `bytearray`.
+  This is the in-memory persistence path (caches, databases, pickling)
+  that previously required a filesystem round-trip. (#148, #70)
+- **All four integration stores are picklable and copyable.** The
+  LangChain, Haystack, LlamaIndex, and Agno stores implement
+  `__getstate__` / `__setstate__` (the Rust index rides along as its
+  `.tvim` bytes; the per-store lock — and Haystack's async executor —
+  are excluded and recreated on restore), `__deepcopy__`, and
+  `__copy__`. The state is snapshotted under the store's writer lock,
+  so a pickle overlapping a write captures a consistent index/side-car
+  pair. `pickle.loads(pickle.dumps(store))` round-trips documents,
+  metadata, search results, and the handle counter, including into
+  `multiprocessing` spawn workers. `copy.copy` deliberately equals
+  `copy.deepcopy`: there is no meaningful shallow copy of a store —
+  sharing the mutable Rust index means mutations bleed between the
+  copies (see *Fixed*). (#148, #149)
 
 #### Changed
 
@@ -349,6 +389,29 @@ appears under each surface it touches.
   in fact required all along; the 1.70 declared in
   `turbovec-python/Cargo.toml` was never sufficient. Prebuilt-wheel
   users are unaffected. (#182)
+- **Pickling a LlamaIndex store no longer silently returns an EMPTY
+  store (total data loss).** `pickle.dumps` / `pickle.loads` of a
+  populated LlamaIndex `TurboQuantVectorStore` *appeared* to succeed
+  but dropped the Rust index on the floor: it lives in a pydantic
+  `PrivateAttr`, and the inherited `BaseComponent.__getstate__`
+  removes any private attribute that fails `pickle.dumps` with only a
+  log warning — so the store deserialized valid-looking and every
+  query returned `[]`. This hit exactly the scenarios users pickle
+  for (caching, `multiprocessing`, Ray, Celery): ship a populated
+  store, workers silently search an empty one. The store now pickles
+  faithfully via the new `to_bytes` / `from_bytes` core API; the
+  LangChain, Haystack, and Agno stores — which previously raised
+  `TypeError: cannot pickle 'builtins.IdMapIndex' object` — now
+  round-trip too. (#148)
+- **`copy.copy` of a store no longer aliases the Rust index, and
+  `copy.deepcopy` works.** A shallow copy of any of the four stores
+  shared the underlying mutable `IdMapIndex` and side-car maps, so
+  mutating the copy silently mutated the original (and vice versa) —
+  and `copy.deepcopy`, the only safe alternative, raised `TypeError`
+  because deepcopy rides the pickle path. Both now return a fully
+  independent store (`__copy__` is deliberately identical to
+  `__deepcopy__`; a shared-index "shallow" copy is precisely the bug).
+  (#149)
 - **LlamaIndex `add()` no longer loses data under concurrent calls.**
   `_next_u64 += 1` on a pydantic `PrivateAttr` is not atomic under
   the GIL, so two concurrent `add()` calls could issue the same

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,6 +46,7 @@ Before the first add, `idx.dim` is `None`, `len(idx)` is `0`, and `search()` ret
 | `swap_remove(idx)` | O(1). Moves the last vector into `idx`; returns the previous position of that moved vector (so external refs can be updated if needed). |
 | `prepare()` | Optional. Eagerly builds the rotation matrix, Lloyd-Max centroids and SIMD-blocked layout so the first `search` call doesn't pay the one-time cost. No-op on a lazy index that hasn't seen its first add. |
 | `write(path)` / `load(path)` | `.tv` format. |
+| `to_bytes()` / `from_bytes(data)` | In-memory `.tv` serialization — see [In-memory serialization](#in-memory-serialization). |
 | `len(idx)` / `idx.dim` / `idx.bit_width` | Introspection. `idx.dim` returns `int` once committed, or `None` on a lazy index that hasn't seen its first add. |
 
 ### `swap_remove` semantics
@@ -111,6 +112,7 @@ idx.add_with_ids(vectors, ids)           # locks dim to vectors.shape[1]
 | `search(queries, k, *, allowlist=None)` | Returns `(scores, ids)` — `ids` are `uint64` external ids. `allowlist` is an optional `uint64` array of ids; when given, results are restricted to those ids and `effective_k = min(k, number of unique ids in allowlist)` (the allowlist is deduplicated; repeated ids don't widen the result). Raises `ValueError` on an empty allowlist or a non-finite / `\|value\| ≥ 1e16` query coordinate, and `KeyError` on unknown ids. |
 | `contains(id)` / `id in idx` | Membership. |
 | `write(path)` / `load(path)` | `.tvim` format. |
+| `to_bytes()` / `from_bytes(data)` | In-memory `.tvim` serialization — see [In-memory serialization](#in-memory-serialization). |
 | `len(idx)` / `idx.dim` / `idx.bit_width` / `prepare()` | Same as `TurboQuantIndex`. |
 
 ### When to use which
@@ -193,6 +195,19 @@ Common use cases:
 ```
 
 On load, the reverse `id → slot` map is rebuilt in memory. Duplicate ids in the `slot_to_id` table are rejected as corrupt.
+
+### In-memory serialization
+
+Both index types (de)serialize their wire format in memory, without a filesystem round-trip:
+
+```python
+payload = idx.to_bytes()                  # bytes, byte-identical to write(path)'s file
+restored = IdMapIndex.from_bytes(payload) # same validation as load(path)
+```
+
+`to_bytes()` returns exactly the bytes `write(path)` would put in the file (`.tv` for `TurboQuantIndex`, `.tvim` for `IdMapIndex`), reusing the cached rotation matrix for the v4 fingerprint. `from_bytes(data)` accepts `bytes` or `bytearray` and applies exactly the same validation as `load` — version handling, structural and value-level checks, rotation-drift verification, and the `.tvim` duplicate-id check — raising `ValueError` on a corrupt or drifted payload (there is no file to blame, so it is not an `OSError`). Both release the GIL. This is the path to use for caches, database columns, and pickling; the integration stores' pickle support is built on it.
+
+On the Rust API the same pair exists as `to_bytes()` / `from_bytes(&[u8])`, alongside generic-sink forms `write_to_writer<W: Write>` / `load_from_reader<R: Read>` on both types and the raw module-level entry points `io::write_to`, `io::load_from`, `io::write_id_map_to`, `io::load_id_map_from` (which rebuild the rotation for the fingerprint rather than using an index's cache).
 
 ### Rotation fingerprint
 

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -144,6 +144,8 @@ The similarity mode is recorded in `docstore.json`. Because the store is constru
 
 `save` is atomic with respect to the destination: both files are written to sibling temp files and moved into place, so a failed save (e.g. non-JSON-serializable metadata) leaves a store previously saved at the same path intact.
 
+The store also supports `pickle` (e.g. for `multiprocessing` workers, provided the embedder/reranker are picklable) and `copy.copy` / `copy.deepcopy` — both copies return a fully independent store (there is no shallow copy that shares the underlying index).
+
 ## Async
 
 The lifecycle, write, and read methods have async counterparts: `async_create`, `async_drop`, `async_exists`, `async_name_exists`, `async_get_count`, `async_insert`, `async_upsert`, `async_search`. The remaining methods (the `delete_by_*` family, `update_metadata`, `save`, `id_exists`, `content_hash_exists`, `optimize`) are sync-only. When the embedder exposes `async_get_embedding` / `async_get_embeddings_batch_and_usage`, the async paths use it for genuine async embedding generation.

--- a/docs/integrations/haystack.md
+++ b/docs/integrations/haystack.md
@@ -153,6 +153,8 @@ Document metadata must be JSON-serializable — the same constraint `InMemoryDoc
 
 `save_to_disk` is atomic with respect to the destination: both files are written to sibling temp files and moved into place, so a failed save (e.g. non-JSON-serializable metadata) leaves a store previously saved at the same path intact.
 
+The store also supports `pickle` (e.g. for `multiprocessing` workers; the restored store owns a fresh async executor) and `copy.copy` / `copy.deepcopy` — both copies return a fully independent store (there is no shallow copy that shares the underlying index).
+
 ## Using in a Haystack Pipeline
 
 `TurboQuantDocumentStore` implements `to_dict` / `from_dict` so it can be serialized as part of a Haystack `Pipeline`. `to_dict` captures the component *config* (`dim`, `bit_width`, `embedding_similarity_function`, `return_embedding`); persisting the stored documents is the job of `save_to_disk` / `load_from_disk`.

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -156,6 +156,8 @@ Document metadata must be JSON-serializable — the same constraint `InMemoryVec
 
 `dump` is atomic with respect to the destination: both files are written to sibling temp files and moved into place, so a failed dump (e.g. non-JSON-serializable metadata) leaves a store previously saved at the same path intact.
 
+The store also supports `pickle` (e.g. for `multiprocessing` workers, provided the embedder is picklable) and `copy.copy` / `copy.deepcopy` — both copies return a fully independent store (there is no shallow copy that shares the underlying index).
+
 ## Thread safety
 
 The store is safe for concurrent multi-threaded use:

--- a/docs/integrations/llama_index.md
+++ b/docs/integrations/llama_index.md
@@ -226,6 +226,8 @@ fresh = TurboQuantVectorStore.from_dict(config)                   # empty store 
 
 `to_dict` / `from_dict` serialize only the store's configuration. Node data round-trips through `persist` / `from_persist_path`.
 
+The store also supports `pickle` with full data fidelity (e.g. for `multiprocessing` workers) and `copy.copy` / `copy.deepcopy` — both copies return a fully independent store (there is no shallow copy that shares the underlying index).
+
 ## Thread safety
 
 The store is safe for concurrent multi-threaded use:

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -9,6 +9,7 @@ backend) so this can be swapped in wherever ``LanceDb`` is used.
 
 from __future__ import annotations
 
+import copy as _copy
 import json
 import threading
 from hashlib import md5
@@ -1092,6 +1093,56 @@ class TurboQuantVectorDb(VectorDb):
         # here rather than misbehaving later — matching the other
         # integrations' load paths (issue #115).
         check_persisted_handles(self._index, self._u64_to_doc.keys(), what="document")
+
+    # ---- Copy & pickle ----------------------------------------------------
+    #
+    # The Rust index is not directly picklable; it round-trips through
+    # the core's in-memory ``.tvim`` byte format
+    # (``IdMapIndex.to_bytes`` / ``from_bytes``). The per-store lock is
+    # excluded from the state — locks cannot cross pickling — and
+    # recreated on restore. The embedder and reranker are pickled by
+    # value like any other attribute; their picklability is the
+    # caller's concern.
+
+    def __getstate__(self) -> Dict[str, Any]:
+        # Snapshot under the writer lock so the index bytes and the
+        # side-car maps come from one consistent store state (the same
+        # guarantee save() gives the on-disk pair). The maps are copied
+        # (sets per-entry, since they are mutated in place) so a write
+        # landing after this returns cannot desync the captured pair.
+        with self._write_lock:
+            state = self.__dict__.copy()
+            del state["_write_lock"]
+            # A store that hasn't seen create() — or was drop()ped — has
+            # no index; None round-trips that state.
+            state["_index"] = self._index.to_bytes() if self._index is not None else None
+            state["_str_to_u64"] = {k: set(v) for k, v in self._str_to_u64.items()}
+            state["_u64_to_doc"] = dict(self._u64_to_doc)
+            state["_content_hashes"] = set(self._content_hashes)
+            state["_name_to_ids"] = {k: set(v) for k, v in self._name_to_ids.items()}
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        state = dict(state)
+        index_bytes = state.pop("_index")
+        self.__dict__.update(state)
+        self._index = (
+            IdMapIndex.from_bytes(index_bytes) if index_bytes is not None else None
+        )
+        self._write_lock = threading.RLock()
+
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "TurboQuantVectorDb":
+        new = self.__class__.__new__(self.__class__)
+        new.__setstate__(_copy.deepcopy(self.__getstate__(), memo))
+        return new
+
+    def __copy__(self) -> "TurboQuantVectorDb":
+        # Deliberately identical to __deepcopy__: there is no meaningful
+        # shallow copy of a store. Sharing the mutable Rust index between
+        # two store objects means every mutation of one silently mutates
+        # the other (issue #149), so ``copy.copy`` returns an independent
+        # copy instead of an alias.
+        return self.__deepcopy__({})
 
 
 __all__ = ["TurboQuantVectorDb"]

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -1104,12 +1104,27 @@ class TurboQuantVectorDb(VectorDb):
     # value like any other attribute; their picklability is the
     # caller's concern.
 
+    @staticmethod
+    def _snapshot_doc(data: Dict[str, Any]) -> Dict[str, Any]:
+        """Copy a per-doc payload deeply enough that no in-place store
+        mutation can reach the snapshot: ``update_metadata`` mutates the
+        payload dict (and its ``meta_data`` / ``filters`` sub-dicts) in
+        place, so sharing them would let a write landing after
+        ``__getstate__`` returns tear the pickle mid-serialization."""
+        out = dict(data)
+        for key in ("meta_data", "filters"):
+            value = out.get(key)
+            if isinstance(value, dict):
+                out[key] = dict(value)
+        return out
+
     def __getstate__(self) -> Dict[str, Any]:
         # Snapshot under the writer lock so the index bytes and the
         # side-car maps come from one consistent store state (the same
-        # guarantee save() gives the on-disk pair). The maps are copied
-        # (sets per-entry, since they are mutated in place) so a write
-        # landing after this returns cannot desync the captured pair.
+        # guarantee save() gives the on-disk pair). Everything the store
+        # mutates in place is copied (per-id handle sets, the per-doc
+        # payload dicts and their metadata sub-dicts) so a write landing
+        # after this returns cannot desync — or tear — the captured pair.
         with self._write_lock:
             state = self.__dict__.copy()
             del state["_write_lock"]
@@ -1117,7 +1132,9 @@ class TurboQuantVectorDb(VectorDb):
             # no index; None round-trips that state.
             state["_index"] = self._index.to_bytes() if self._index is not None else None
             state["_str_to_u64"] = {k: set(v) for k, v in self._str_to_u64.items()}
-            state["_u64_to_doc"] = dict(self._u64_to_doc)
+            state["_u64_to_doc"] = {
+                h: self._snapshot_doc(d) for h, d in self._u64_to_doc.items()
+            }
             state["_content_hashes"] = set(self._content_hashes)
             state["_name_to_ids"] = {k: set(v) for k, v in self._name_to_ids.items()}
         return state

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -16,6 +16,7 @@ callers that rely on ``Document.embedding`` after retrieval will see
 from __future__ import annotations
 
 import asyncio
+import copy as _copy
 import json
 import math
 import threading
@@ -906,6 +907,57 @@ class TurboQuantDocumentStore:
             )
         check_persisted_handles(store._index, store._u64_to_doc.keys(), what="document")
         return store
+
+    # ---- Copy & pickle ------------------------------------------------
+    #
+    # The Rust index is not directly picklable; it round-trips through
+    # the core's in-memory ``.tvim`` byte format
+    # (``IdMapIndex.to_bytes`` / ``from_bytes``). The per-store lock and
+    # the async executor are excluded from the state — neither can cross
+    # pickling — and recreated on restore; a restored/copied store always
+    # owns a fresh executor, even when the original wrapped a
+    # caller-provided one.
+
+    def __getstate__(self) -> Dict[str, Any]:
+        # Snapshot under the writer lock so the index bytes and the
+        # side-car maps come from one consistent store state (the same
+        # guarantee save_to_disk() gives the on-disk pair). The maps are
+        # shallow-copied so a write landing after this returns cannot
+        # desync the captured pair.
+        with self._write_lock:
+            state = self.__dict__.copy()
+            del state["_write_lock"]
+            del state["executor"]
+            del state["_owns_executor"]
+            state["_index"] = self._index.to_bytes()
+            state["_str_to_u64"] = dict(self._str_to_u64)
+            state["_u64_to_doc"] = dict(self._u64_to_doc)
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        state = dict(state)
+        index_bytes = state.pop("_index")
+        self.__dict__.update(state)
+        self._index = IdMapIndex.from_bytes(index_bytes)
+        self._write_lock = threading.RLock()
+        self._owns_executor = True
+        self.executor = ThreadPoolExecutor(
+            thread_name_prefix=f"async-turbovec-docstore-executor-{id(self)}",
+            max_workers=1,
+        )
+
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "TurboQuantDocumentStore":
+        new = self.__class__.__new__(self.__class__)
+        new.__setstate__(_copy.deepcopy(self.__getstate__(), memo))
+        return new
+
+    def __copy__(self) -> "TurboQuantDocumentStore":
+        # Deliberately identical to __deepcopy__: there is no meaningful
+        # shallow copy of a store. Sharing the mutable Rust index between
+        # two store objects means every mutation of one silently mutates
+        # the other (issue #149), so ``copy.copy`` returns an independent
+        # copy instead of an alias.
+        return self.__deepcopy__({})
 
     # ---- Internals ----------------------------------------------------
 

--- a/turbovec-python/python/turbovec/haystack.py
+++ b/turbovec-python/python/turbovec/haystack.py
@@ -918,12 +918,26 @@ class TurboQuantDocumentStore:
     # owns a fresh executor, even when the original wrapped a
     # caller-provided one.
 
+    @staticmethod
+    def _snapshot_doc(data: Dict[str, Any]) -> Dict[str, Any]:
+        """Copy a per-doc payload deeply enough that no in-place store
+        mutation can reach the snapshot: ``update_by_filter`` mutates the
+        payload's ``meta`` dict in place, so sharing it would let a write
+        landing after ``__getstate__`` returns tear the pickle
+        mid-serialization."""
+        out = dict(data)
+        meta = out.get("meta")
+        if isinstance(meta, dict):
+            out["meta"] = dict(meta)
+        return out
+
     def __getstate__(self) -> Dict[str, Any]:
         # Snapshot under the writer lock so the index bytes and the
         # side-car maps come from one consistent store state (the same
-        # guarantee save_to_disk() gives the on-disk pair). The maps are
-        # shallow-copied so a write landing after this returns cannot
-        # desync the captured pair.
+        # guarantee save_to_disk() gives the on-disk pair). Everything
+        # the store mutates in place is copied (the maps, the per-doc
+        # payload dicts and their meta sub-dicts) so a write landing
+        # after this returns cannot desync — or tear — the captured pair.
         with self._write_lock:
             state = self.__dict__.copy()
             del state["_write_lock"]
@@ -931,7 +945,9 @@ class TurboQuantDocumentStore:
             del state["_owns_executor"]
             state["_index"] = self._index.to_bytes()
             state["_str_to_u64"] = dict(self._str_to_u64)
-            state["_u64_to_doc"] = dict(self._u64_to_doc)
+            state["_u64_to_doc"] = {
+                h: self._snapshot_doc(d) for h, d in self._u64_to_doc.items()
+            }
         return state
 
     def __setstate__(self, state: Dict[str, Any]) -> None:

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -8,6 +8,7 @@ so this store can be swapped in wherever the in-memory store is used.
 
 from __future__ import annotations
 
+import copy as _copy
 import json
 import threading
 import uuid
@@ -850,6 +851,49 @@ class TurboQuantVectorStore(VectorStore):
             str_to_u64=str_to_u64,
             next_u64=int(state["next_u64"]),
         )
+
+    # ---- Copy & pickle ------------------------------------------------
+    #
+    # The Rust index is not directly picklable; it round-trips through
+    # the core's in-memory ``.tvim`` byte format
+    # (``IdMapIndex.to_bytes`` / ``from_bytes``). The per-store lock is
+    # excluded from the state — locks cannot cross pickling — and
+    # recreated on restore.
+
+    def __getstate__(self) -> dict[str, Any]:
+        # Snapshot under the writer lock so the index bytes and the
+        # side-car maps come from one consistent store state (the same
+        # guarantee dump() gives the on-disk pair). The maps are
+        # shallow-copied so a write landing after this returns cannot
+        # desync the captured pair.
+        with self._write_lock:
+            state = self.__dict__.copy()
+            del state["_write_lock"]
+            state["_index"] = self._index.to_bytes()
+            state["_docs"] = dict(self._docs)
+            state["_str_to_u64"] = dict(self._str_to_u64)
+            state["_u64_to_str"] = dict(self._u64_to_str)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        state = dict(state)
+        index_bytes = state.pop("_index")
+        self.__dict__.update(state)
+        self._index = IdMapIndex.from_bytes(index_bytes)
+        self._write_lock = threading.RLock()
+
+    def __deepcopy__(self, memo: dict) -> "TurboQuantVectorStore":
+        new = self.__class__.__new__(self.__class__)
+        new.__setstate__(_copy.deepcopy(self.__getstate__(), memo))
+        return new
+
+    def __copy__(self) -> "TurboQuantVectorStore":
+        # Deliberately identical to __deepcopy__: there is no meaningful
+        # shallow copy of a store. Sharing the mutable Rust index between
+        # two store objects means every mutation of one silently mutates
+        # the other (issue #149), so ``copy.copy`` returns an independent
+        # copy instead of an alias.
+        return self.__deepcopy__({})
 
 
 __all__ = ["TurboQuantVectorStore"]

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -989,6 +989,11 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
                 # unpickled instance is fully initialized.
                 "fields": {k: getattr(self, k) for k in type(self).model_fields},
                 "bit_width": self._index.bit_width,
+                # Private attrs are NOT covered by `model_fields` — each
+                # must be carried explicitly or __setstate__'s __init__
+                # call silently resets it to its default (a dot_product
+                # store would unpickle as cosine, with diverging scores).
+                "similarity": self._similarity,
                 "index_bytes": self._index.to_bytes(),
                 "nodes": dict(self._nodes),
                 "node_id_to_u64": dict(self._node_id_to_u64),
@@ -999,6 +1004,7 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         self.__init__(  # type: ignore[misc]
             index=IdMapIndex.from_bytes(state["index_bytes"]),
             bit_width=state["bit_width"],
+            similarity=state["similarity"],
             **state["fields"],
         )
         self._nodes = dict(state["nodes"])

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -5,6 +5,7 @@ Install with: ``pip install turbovec[llama-index]``.
 
 from __future__ import annotations
 
+import copy as _copy
 import json
 import os
 import threading
@@ -961,6 +962,63 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         persist_fname = f"{namespace}{_NAMESPACE_SEP}{_DEFAULT_PERSIST_FNAME}"
         persist_path = os.path.join(persist_dir, persist_fname)
         return cls.from_persist_path(persist_path, fs=fs)
+
+    # ---- Copy & pickle ----------------------------------------------------
+    #
+    # Without these overrides, pickling silently returned an EMPTY store:
+    # the Rust index lives in a pydantic ``PrivateAttr``, and the
+    # inherited ``BaseComponent.__getstate__`` drops any private
+    # attribute that fails ``pickle.dumps`` — so ``_index`` (and the
+    # lock) vanished with only a log warning, and the store deserialized
+    # valid-looking but with zero nodes (issue #148). The state instead
+    # round-trips the index through the core's in-memory ``.tvim`` byte
+    # format (``IdMapIndex.to_bytes`` / ``from_bytes``); the per-store
+    # lock is excluded — locks cannot cross pickling — and recreated on
+    # restore.
+
+    def __getstate__(self) -> dict[str, Any]:
+        # Snapshot under the writer lock so the index bytes and the
+        # side-car maps come from one consistent store state (the same
+        # guarantee persist() gives the on-disk pair). The maps are
+        # shallow-copied so a write landing after this returns cannot
+        # desync the captured pair.
+        with self._write_lock:
+            return {
+                # Pydantic model fields (stores_text & co.), restored
+                # through __init__ so the pydantic machinery on the bare
+                # unpickled instance is fully initialized.
+                "fields": {k: getattr(self, k) for k in type(self).model_fields},
+                "bit_width": self._index.bit_width,
+                "index_bytes": self._index.to_bytes(),
+                "nodes": dict(self._nodes),
+                "node_id_to_u64": dict(self._node_id_to_u64),
+                "next_u64": self._next_u64,
+            }
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__init__(  # type: ignore[misc]
+            index=IdMapIndex.from_bytes(state["index_bytes"]),
+            bit_width=state["bit_width"],
+            **state["fields"],
+        )
+        self._nodes = dict(state["nodes"])
+        self._node_id_to_u64 = dict(state["node_id_to_u64"])
+        self._u64_to_node_id = {h: nid for nid, h in self._node_id_to_u64.items()}
+        self._next_u64 = state["next_u64"]
+
+    def __deepcopy__(self, memo: dict) -> "TurboQuantVectorStore":
+        new = self.__class__.__new__(self.__class__)
+        new.__setstate__(_copy.deepcopy(self.__getstate__(), memo))
+        return new
+
+    def __copy__(self) -> "TurboQuantVectorStore":
+        # Deliberately identical to __deepcopy__ (overriding pydantic's
+        # field-sharing shallow copy): there is no meaningful shallow
+        # copy of a store. Sharing the mutable Rust index between two
+        # store objects means every mutation of one silently mutates the
+        # other (issue #149), so ``copy.copy`` returns an independent
+        # copy instead of an alias.
+        return self.__deepcopy__({})
 
 
 __all__ = ["TurboQuantVectorStore"]

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -1,6 +1,6 @@
 use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::prelude::*;
-use pyo3::types::PyType;
+use pyo3::types::{PyBytes, PyType};
 
 fn not_contiguous_err(kind: &str) -> PyErr {
     pyo3::exceptions::PyValueError::new_err(format!(
@@ -156,6 +156,31 @@ fn validate_queries(values: &[f32], dim: usize) -> PyResult<()> {
         )));
     }
     Ok(())
+}
+
+/// Extract a bytes-like argument (`bytes` / `bytearray`) into an owned
+/// buffer; see [`extract_f32_2d`] for the error-naming rationale. Owned
+/// because the buffer must cross a GIL release (`py.detach`), where a
+/// borrowed Python buffer would be mutable out from under us.
+fn extract_bytes(name: &str, obj: &Bound<'_, PyAny>) -> PyResult<Vec<u8>> {
+    if let Ok(b) = obj.cast::<PyBytes>() {
+        return Ok(b.as_bytes().to_vec());
+    }
+    if let Ok(b) = obj.cast::<pyo3::types::PyByteArray>() {
+        return Ok(b.to_vec());
+    }
+    Err(pyo3::exceptions::PyTypeError::new_err(format!(
+        "{name} must be a bytes-like object (bytes or bytearray), got {}",
+        type_name(obj),
+    )))
+}
+
+/// Map an `io::Error` from `from_bytes` to Python. Unlike [`load_err`]
+/// there is no path to blame, and the input is an in-memory value —
+/// so corrupt bytes raise `ValueError` (like other malformed-value
+/// arguments) rather than `OSError`.
+fn from_bytes_err(e: std::io::Error) -> PyErr {
+    pyo3::exceptions::PyValueError::new_err(e.to_string())
 }
 
 /// Map an `io::Error` from `load` to Python: `ErrorKind::NotFound`
@@ -341,6 +366,35 @@ impl TurboQuantIndex {
             .py()
             .detach(|| turbovec_core::TurboQuantIndex::load(path))
             .map_err(|e| load_err(path, e))?;
+        Ok(Self {
+            inner: std::sync::RwLock::new(inner),
+        })
+    }
+
+    /// Serialize the index to ``bytes`` in the ``.tv`` format —
+    /// byte-identical to the file ``write(path)`` produces. Pairs with
+    /// ``from_bytes`` for in-memory persistence (caches, databases,
+    /// pickling) without a filesystem round-trip.
+    fn to_bytes<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+        // Serialize under the read lock with the GIL released (the
+        // payload scales with the index size); wrap into a PyBytes
+        // only once back under the GIL.
+        let buf = py.detach(|| lock_read(&self.inner).to_bytes());
+        PyBytes::new(py, &buf)
+    }
+
+    /// Deserialize an index from ``bytes`` produced by ``to_bytes`` (or
+    /// read out of a ``.tv`` file). Applies exactly the same validation
+    /// as ``load`` — corrupt or drifted payloads raise ``ValueError``.
+    #[classmethod]
+    fn from_bytes(cls: &Bound<PyType>, data: &Bound<'_, PyAny>) -> PyResult<Self> {
+        // Snapshot the buffer before releasing the GIL (a bytearray can
+        // be mutated by another Python thread once it is released).
+        let owned = extract_bytes("data", data)?;
+        let inner = cls
+            .py()
+            .detach(|| turbovec_core::TurboQuantIndex::from_bytes(&owned))
+            .map_err(from_bytes_err)?;
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
         })
@@ -642,6 +696,36 @@ impl IdMapIndex {
             .py()
             .detach(|| turbovec_core::IdMapIndex::load(path))
             .map_err(|e| load_err(path, e))?;
+        Ok(Self {
+            inner: std::sync::RwLock::new(inner),
+        })
+    }
+
+    /// Serialize the index (and its id-map side-tables) to ``bytes`` in
+    /// the ``.tvim`` format — byte-identical to the file ``write(path)``
+    /// produces. Pairs with ``from_bytes`` for in-memory persistence
+    /// (caches, databases, pickling) without a filesystem round-trip.
+    fn to_bytes<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+        // Serialize under the read lock with the GIL released (the
+        // payload scales with the index size); wrap into a PyBytes
+        // only once back under the GIL.
+        let buf = py.detach(|| lock_read(&self.inner).to_bytes());
+        PyBytes::new(py, &buf)
+    }
+
+    /// Deserialize an index from ``bytes`` produced by ``to_bytes`` (or
+    /// read out of a ``.tvim`` file). Applies exactly the same
+    /// validation as ``load`` — corrupt or drifted payloads raise
+    /// ``ValueError``.
+    #[classmethod]
+    fn from_bytes(cls: &Bound<PyType>, data: &Bound<'_, PyAny>) -> PyResult<Self> {
+        // Snapshot the buffer before releasing the GIL (a bytearray can
+        // be mutated by another Python thread once it is released).
+        let owned = extract_bytes("data", data)?;
+        let inner = cls
+            .py()
+            .detach(|| turbovec_core::IdMapIndex::from_bytes(&owned))
+            .map_err(from_bytes_err)?;
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
         })

--- a/turbovec-python/tests/test_pickle_copy.py
+++ b/turbovec-python/tests/test_pickle_copy.py
@@ -1,0 +1,490 @@
+"""Pickle / copy semantics: the core in-memory serialization API
+(`to_bytes` / `from_bytes`) and correct `pickle` / `copy.copy` /
+`copy.deepcopy` behaviour on all four integration stores.
+
+Covers issues #148 (LlamaIndex pickle silently returned an EMPTY store —
+total data loss) and #149 (copy.copy shared the Rust index so mutations
+bled across copies; deepcopy raised, so no safe copy existed).
+
+The embedders here are deterministic *across processes* (hashlib-seeded,
+not `hash()`-seeded, since spawn children get a different hash seed) so
+the multiprocessing smoke tests can compare search results between
+parent and child.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import multiprocessing
+import pickle
+import threading
+
+import numpy as np
+import pytest
+
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DIM = 32
+
+
+def _text_seed(text: str) -> int:
+    return int.from_bytes(hashlib.md5(text.encode()).digest()[:4], "little")
+
+
+def _unit(seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    v = rng.standard_normal(DIM).astype(np.float32)
+    return v / (np.linalg.norm(v) + 1e-9)
+
+
+def _embed_text(text: str) -> list[float]:
+    return _unit(_text_seed(text)).tolist()
+
+
+def _vectors(n: int, seed: int = 7) -> np.ndarray:
+    return np.stack([_unit(seed + i) for i in range(n)])
+
+
+# ---------------------------------------------------------------------------
+# Core binding: to_bytes / from_bytes
+# ---------------------------------------------------------------------------
+
+
+def test_index_to_bytes_round_trips_and_matches_file(tmp_path):
+    idx = TurboQuantIndex(DIM, 4)
+    idx.add(_vectors(16))
+    payload = idx.to_bytes()
+    assert isinstance(payload, bytes)
+
+    # Byte-identical to the .tv file write() produces.
+    idx.write(str(tmp_path / "index.tv"))
+    assert payload == (tmp_path / "index.tv").read_bytes()
+
+    back = TurboQuantIndex.from_bytes(payload)
+    assert len(back) == 16
+    q = _vectors(2, seed=99)
+    s0, i0 = idx.search(q, 5)
+    s1, i1 = back.search(q, 5)
+    np.testing.assert_array_equal(s0, s1)
+    np.testing.assert_array_equal(i0, i1)
+
+
+def test_id_map_to_bytes_round_trips_and_matches_file(tmp_path):
+    idx = IdMapIndex(DIM, 4)
+    ids = np.arange(1000, 1016, dtype=np.uint64)
+    idx.add_with_ids(_vectors(16), ids)
+    payload = idx.to_bytes()
+    assert isinstance(payload, bytes)
+
+    idx.write(str(tmp_path / "index.tvim"))
+    assert payload == (tmp_path / "index.tvim").read_bytes()
+
+    back = IdMapIndex.from_bytes(payload)
+    assert len(back) == 16
+    assert all(int(i) in back for i in ids)
+    q = _vectors(2, seed=99)
+    s0, i0 = idx.search(q, 5)
+    s1, i1 = back.search(q, 5)
+    np.testing.assert_array_equal(s0, s1)
+    np.testing.assert_array_equal(i0, i1)
+
+
+def test_from_bytes_accepts_bytearray():
+    idx = IdMapIndex(DIM, 4)
+    idx.add_with_ids(_vectors(3), np.arange(3, dtype=np.uint64))
+    back = IdMapIndex.from_bytes(bytearray(idx.to_bytes()))
+    assert len(back) == 3
+
+
+def test_from_bytes_rejects_corrupt_and_wrong_type():
+    idx = IdMapIndex(DIM, 4)
+    idx.add_with_ids(_vectors(3), np.arange(3, dtype=np.uint64))
+    payload = idx.to_bytes()
+
+    with pytest.raises(ValueError, match="magic"):
+        IdMapIndex.from_bytes(b"garbage-not-a-tvim-payload")
+    with pytest.raises(ValueError, match="truncated"):
+        IdMapIndex.from_bytes(payload[:-5])
+    with pytest.raises(TypeError, match="bytes-like"):
+        IdMapIndex.from_bytes("not bytes")
+    with pytest.raises(ValueError, match="magic"):
+        TurboQuantIndex.from_bytes(b"\x00\x01\x02\x03\x04\x05\x06\x07")
+    # A .tv payload is not a .tvim payload.
+    with pytest.raises(ValueError, match="TVIM"):
+        IdMapIndex.from_bytes(TurboQuantIndex(DIM, 4).to_bytes())
+
+
+def test_lazy_index_bytes_round_trip():
+    lazy = IdMapIndex(bit_width=3)
+    back = IdMapIndex.from_bytes(lazy.to_bytes())
+    assert back.dim is None
+    assert back.bit_width == 3
+    assert len(back) == 0
+
+
+# ---------------------------------------------------------------------------
+# Store fixtures
+# ---------------------------------------------------------------------------
+
+
+class LangchainEmb:
+    """Deterministic, picklable, cross-process-stable embedder."""
+
+    def embed_documents(self, texts):
+        return [_embed_text(t) for t in texts]
+
+    def embed_query(self, text):
+        return _embed_text(text)
+
+
+class AgnoEmb:
+    dimensions = DIM
+
+    def get_embedding(self, text):
+        return _embed_text(text)
+
+
+LC_TEXTS = ["alpha", "beta", "gamma"]
+LC_IDS = ["id-a", "id-b", "id-c"]
+
+
+def _make_langchain():
+    pytest.importorskip("langchain_core")
+    from turbovec.langchain import TurboQuantVectorStore
+
+    store = TurboQuantVectorStore(embedding=LangchainEmb())
+    store.add_texts(
+        LC_TEXTS,
+        metadatas=[{"n": i, "tag": "t"} for i in range(3)],
+        ids=LC_IDS,
+    )
+    return store
+
+
+def _lc_search_ids(store, text="alpha", k=3):
+    return sorted(doc.id for doc in store.similarity_search(text, k=k))
+
+
+def _make_haystack():
+    pytest.importorskip("haystack")
+    from haystack import Document
+
+    from turbovec.haystack import TurboQuantDocumentStore
+
+    store = TurboQuantDocumentStore(dim=DIM)
+    store.write_documents(
+        [
+            Document(id=f"doc-{i}", content=f"content {i}", embedding=_unit(i).tolist(), meta={"n": i})
+            for i in range(3)
+        ]
+    )
+    return store
+
+
+def _hs_search_ids(store, k=3):
+    return sorted(d.id for d in store.embedding_retrieval(_unit(0).tolist(), top_k=k))
+
+
+def _make_llama():
+    pytest.importorskip("llama_index")
+    from llama_index.core.schema import TextNode
+
+    from turbovec.llama_index import TurboQuantVectorStore
+
+    store = TurboQuantVectorStore(bit_width=4)
+    store.add(
+        [
+            TextNode(
+                id_=f"node-{i}",
+                text=f"text {i}",
+                embedding=_unit(i).tolist(),
+                metadata={"n": i},
+            )
+            for i in range(3)
+        ]
+    )
+    return store
+
+
+def _llama_query(store, k=3):
+    from llama_index.core.vector_stores.types import VectorStoreQuery
+
+    return store.query(
+        VectorStoreQuery(query_embedding=_unit(0).tolist(), similarity_top_k=k)
+    )
+
+
+def _make_agno():
+    pytest.importorskip("agno")
+    from agno.knowledge.document import Document
+
+    from turbovec.agno import TurboQuantVectorDb
+
+    db = TurboQuantVectorDb(embedder=AgnoEmb())
+    db.create()
+    db.insert(
+        "hash-1",
+        [
+            Document(id=f"agno-{i}", content=f"agno content {i}", embedding=_unit(i).tolist())
+            for i in range(3)
+        ],
+    )
+    return db
+
+
+def _agno_search_contents(db, k=3):
+    return sorted(d.content for d in db.search("agno content 0", limit=k))
+
+
+# ---------------------------------------------------------------------------
+# Pickle round-trips REAL data (headline: on main the llama store came
+# back silently EMPTY — issue #148)
+# ---------------------------------------------------------------------------
+
+
+def test_llama_pickle_round_trips_data():
+    store = _make_llama()
+    before = _llama_query(store)
+    assert sorted(before.ids) == ["node-0", "node-1", "node-2"]
+
+    restored = pickle.loads(pickle.dumps(store))
+    after = _llama_query(restored)
+    # The #148 failure mode: after.ids == [] with no error.
+    assert sorted(after.ids) == sorted(before.ids)
+    assert after.similarities == before.similarities
+    # Full node payload survives (metadata, text).
+    nodes = restored.get_nodes(node_ids=["node-1"])
+    assert nodes[0].metadata == {"n": 1}
+    assert "text 1" in nodes[0].get_content()
+    # Persistence-affecting state survives: a post-restore add issues a
+    # fresh handle (no collision with the restored ones) and is
+    # immediately searchable.
+    from llama_index.core.schema import TextNode
+
+    restored.add([TextNode(id_="node-9", text="text 9", embedding=_unit(9).tolist())])
+    assert sorted(_llama_query(restored, k=4).ids) == [
+        "node-0", "node-1", "node-2", "node-9",
+    ]
+
+
+def test_langchain_pickle_round_trips_data():
+    store = _make_langchain()
+    restored = pickle.loads(pickle.dumps(store))
+    assert _lc_search_ids(restored) == _lc_search_ids(store)
+    docs = restored.get_by_ids(["id-b"])
+    assert docs[0].page_content == "beta"
+    assert docs[0].metadata == {"n": 1, "tag": "t"}
+    # Score parity, not just membership.
+    s0 = store.similarity_search_with_score("alpha", k=3)
+    s1 = restored.similarity_search_with_score("alpha", k=3)
+    assert [(d.id, s) for d, s in s0] == [(d.id, s) for d, s in s1]
+    restored.add_texts(["delta"], ids=["id-d"])
+    assert _lc_search_ids(restored, k=4) == sorted(LC_IDS + ["id-d"])
+
+
+def test_haystack_pickle_round_trips_data():
+    store = _make_haystack()
+    restored = pickle.loads(pickle.dumps(store))
+    assert restored.count_documents() == 3
+    assert _hs_search_ids(restored) == _hs_search_ids(store)
+    doc = restored.filter_documents(
+        {"field": "meta.n", "operator": "==", "value": 1}
+    )
+    assert len(doc) == 1 and doc[0].id == "doc-1"
+    # A restored store owns a working executor and lock: writing works.
+    from haystack import Document
+
+    restored.write_documents([Document(id="doc-9", content="c9", embedding=_unit(9).tolist())])
+    assert restored.count_documents() == 4
+
+
+def test_agno_pickle_round_trips_data():
+    db = _make_agno()
+    restored = pickle.loads(pickle.dumps(db))
+    assert restored.get_count() == 3
+    assert _agno_search_contents(restored) == _agno_search_contents(db)
+    assert restored.content_hash_exists("hash-1")
+    from agno.knowledge.document import Document
+
+    restored.insert("hash-2", [Document(id="agno-9", content="agno content 9", embedding=_unit(9).tolist())])
+    assert restored.get_count() == 4
+
+
+def test_agno_uncreated_store_pickles():
+    pytest.importorskip("agno")
+    from turbovec.agno import TurboQuantVectorDb
+
+    db = TurboQuantVectorDb(embedder=AgnoEmb())
+    restored = pickle.loads(pickle.dumps(db))
+    assert restored.exists() is False
+    restored.create()
+    assert restored.get_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# deepcopy independence (the #149 repro), both directions
+# ---------------------------------------------------------------------------
+
+
+def test_langchain_deepcopy_is_independent():
+    store = _make_langchain()
+    clone = copy.deepcopy(store)
+    # Mutate the copy: original untouched.
+    clone.add_texts(["zeta"], ids=["id-z"])
+    assert len(store._index) == 3
+    assert "id-z" not in store._docs
+    # Mutate the original: copy untouched.
+    store.delete(["id-a"])
+    assert len(clone._index) == 4
+    assert "id-a" in clone._docs
+    assert _lc_search_ids(clone, k=4) == sorted(LC_IDS + ["id-z"])
+
+
+def test_haystack_deepcopy_is_independent():
+    store = _make_haystack()
+    clone = copy.deepcopy(store)
+    from haystack import Document
+
+    clone.write_documents([Document(id="doc-z", content="cz", embedding=_unit(42).tolist())])
+    assert store.count_documents() == 3
+    store.delete_documents(["doc-0"])
+    assert clone.count_documents() == 4
+
+
+def test_llama_deepcopy_is_independent():
+    store = _make_llama()
+    clone = copy.deepcopy(store)
+    from llama_index.core.schema import TextNode
+
+    clone.add([TextNode(id_="node-z", text="tz", embedding=_unit(42).tolist())])
+    assert sorted(_llama_query(store, k=10).ids) == ["node-0", "node-1", "node-2"]
+    store.delete_nodes(node_ids=["node-0"])
+    assert sorted(_llama_query(clone, k=10).ids) == [
+        "node-0", "node-1", "node-2", "node-z",
+    ]
+
+
+def test_agno_deepcopy_is_independent():
+    db = _make_agno()
+    clone = copy.deepcopy(db)
+    from agno.knowledge.document import Document
+
+    clone.insert("hash-z", [Document(id="agno-z", content="agno z", embedding=_unit(42).tolist())])
+    assert db.get_count() == 3
+    db.delete_by_id(next(iter(db._str_to_u64)))
+    assert clone.get_count() == 4
+
+
+# ---------------------------------------------------------------------------
+# copy.copy no longer bleeds (it now equals deepcopy — there is no
+# meaningful shallow copy of a store)
+# ---------------------------------------------------------------------------
+
+
+def test_langchain_copy_does_not_bleed():
+    store = _make_langchain()
+    clone = copy.copy(store)
+    assert clone._index is not store._index
+    assert clone._docs is not store._docs
+    clone.add_texts(["zeta"], ids=["id-z"])
+    assert len(store._index) == 3
+    assert list(store._docs) == LC_IDS
+
+
+def test_haystack_copy_does_not_bleed():
+    store = _make_haystack()
+    clone = copy.copy(store)
+    from haystack import Document
+
+    clone.write_documents([Document(id="doc-z", content="cz", embedding=_unit(42).tolist())])
+    assert store.count_documents() == 3
+
+
+def test_llama_copy_does_not_bleed():
+    store = _make_llama()
+    clone = copy.copy(store)
+    from llama_index.core.schema import TextNode
+
+    clone.add([TextNode(id_="node-z", text="tz", embedding=_unit(42).tolist())])
+    assert sorted(_llama_query(store, k=10).ids) == ["node-0", "node-1", "node-2"]
+
+
+def test_agno_copy_does_not_bleed():
+    db = _make_agno()
+    clone = copy.copy(db)
+    from agno.knowledge.document import Document
+
+    clone.insert("hash-z", [Document(id="agno-z", content="agno z", embedding=_unit(42).tolist())])
+    assert db.get_count() == 3
+
+
+# ---------------------------------------------------------------------------
+# The restored lock still serializes mutations (quick stress)
+# ---------------------------------------------------------------------------
+
+
+def test_unpickled_langchain_store_lock_serializes_writes():
+    restored = pickle.loads(pickle.dumps(_make_langchain()))
+    n_threads, per_thread = 4, 25
+    errors = []
+
+    def add_batch(t: int) -> None:
+        try:
+            for i in range(per_thread):
+                restored.add_texts([f"t{t}-{i}"], ids=[f"tid-{t}-{i}"])
+        except Exception as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+
+    threads = [threading.Thread(target=add_batch, args=(t,)) for t in range(n_threads)]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+    assert errors == []
+    # 3 restored + every concurrent add landed exactly once.
+    assert len(restored._index) == 3 + n_threads * per_thread
+    assert len(restored._docs) == 3 + n_threads * per_thread
+
+
+# ---------------------------------------------------------------------------
+# Multiprocessing spawn smoke: pickle a populated store into a spawned
+# child and search there (spawn, not fork — #147 is parked)
+# ---------------------------------------------------------------------------
+
+
+def _llama_child(payload: bytes, out) -> None:  # pragma: no cover - child process
+    import pickle as _pickle
+
+    store = _pickle.loads(payload)
+    res = _llama_query(store)
+    out.put(sorted(res.ids))
+
+
+def _langchain_child(payload: bytes, out) -> None:  # pragma: no cover - child process
+    import pickle as _pickle
+
+    store = _pickle.loads(payload)
+    out.put(_lc_search_ids(store))
+
+
+@pytest.mark.parametrize(
+    "maker, child, expected",
+    [
+        (_make_llama, _llama_child, ["node-0", "node-1", "node-2"]),
+        (_make_langchain, _langchain_child, sorted(LC_IDS)),
+    ],
+    ids=["llama", "langchain"],
+)
+def test_spawned_child_searches_pickled_store(maker, child, expected):
+    store = maker()
+    ctx = multiprocessing.get_context("spawn")
+    out = ctx.Queue()
+    proc = ctx.Process(target=child, args=(pickle.dumps(store), out))
+    proc.start()
+    try:
+        result = out.get(timeout=120)
+    finally:
+        proc.join(timeout=120)
+    assert proc.exitcode == 0
+    assert result == expected

--- a/turbovec-python/tests/test_pickle_copy.py
+++ b/turbovec-python/tests/test_pickle_copy.py
@@ -420,6 +420,206 @@ def test_agno_copy_does_not_bleed():
 
 
 # ---------------------------------------------------------------------------
+# Similarity-mode round-trip: pickle and deepcopy must preserve the
+# store's mode (cosine vs dot_product) with score parity. The mode lives
+# outside the index bytes (a pydantic PrivateAttr on the llama store),
+# so a __getstate__ that misses it silently resets a dot_product store
+# to cosine on restore — same ranking, diverging scores, and future adds
+# normalized when they shouldn't be. Embeddings here are deliberately
+# NON-unit so cosine and dot_product scores differ.
+# ---------------------------------------------------------------------------
+
+
+def _scaled(seed: int) -> np.ndarray:
+    """Deterministic non-unit vector (norm varies with the seed)."""
+    return _unit(seed) * (2.0 + seed % 5)
+
+
+def _embed_text_scaled(text: str) -> list[float]:
+    return _scaled(_text_seed(text) % 1000).tolist()
+
+
+class ScaledLangchainEmb:
+    def embed_documents(self, texts):
+        return [_embed_text_scaled(t) for t in texts]
+
+    def embed_query(self, text):
+        return _embed_text_scaled(text)
+
+
+class ScaledAgnoEmb:
+    dimensions = DIM
+
+    def get_embedding(self, text):
+        return _embed_text_scaled(text)
+
+
+def _round_trips(store):
+    """The two restore paths under test, labelled."""
+    return [
+        ("pickle", pickle.loads(pickle.dumps(store))),
+        ("deepcopy", copy.deepcopy(store)),
+    ]
+
+
+@pytest.mark.parametrize("mode", ["cosine", "dot_product"])
+def test_langchain_mode_survives_pickle_and_deepcopy(mode):
+    pytest.importorskip("langchain_core")
+    from turbovec.langchain import TurboQuantVectorStore
+
+    store = TurboQuantVectorStore(embedding=ScaledLangchainEmb(), similarity=mode)
+    store.add_texts(LC_TEXTS, ids=LC_IDS)
+    before = store.similarity_search_with_score("alpha", k=3)
+    for label, restored in _round_trips(store):
+        assert restored.similarity == mode, label
+        after = restored.similarity_search_with_score("alpha", k=3)
+        assert [(d.id, s) for d, s in after] == [(d.id, s) for d, s in before], label
+
+
+@pytest.mark.parametrize("mode", ["cosine", "dot_product"])
+def test_haystack_mode_survives_pickle_and_deepcopy(mode):
+    pytest.importorskip("haystack")
+    from haystack import Document
+
+    from turbovec.haystack import TurboQuantDocumentStore
+
+    store = TurboQuantDocumentStore(dim=DIM, embedding_similarity_function=mode)
+    store.write_documents(
+        [
+            Document(id=f"doc-{i}", content=f"content {i}", embedding=_scaled(i).tolist())
+            for i in range(3)
+        ]
+    )
+    q = _scaled(0).tolist()
+    before = [(d.id, d.score) for d in store.embedding_retrieval(q, top_k=3)]
+    for label, restored in _round_trips(store):
+        assert restored.embedding_similarity_function == mode, label
+        after = [(d.id, d.score) for d in restored.embedding_retrieval(q, top_k=3)]
+        assert after == before, label
+
+
+@pytest.mark.parametrize("mode", ["cosine", "dot_product"])
+def test_llama_mode_survives_pickle_and_deepcopy(mode):
+    pytest.importorskip("llama_index")
+    from llama_index.core.schema import TextNode
+    from llama_index.core.vector_stores.types import VectorStoreQuery
+
+    from turbovec.llama_index import TurboQuantVectorStore
+
+    store = TurboQuantVectorStore(similarity=mode)
+    store.add(
+        [
+            TextNode(id_=f"node-{i}", text=f"text {i}", embedding=_scaled(i).tolist())
+            for i in range(3)
+        ]
+    )
+    query = VectorStoreQuery(query_embedding=_scaled(0).tolist(), similarity_top_k=3)
+    before = store.query(query)
+    for label, restored in _round_trips(store):
+        # The mode is a pydantic PrivateAttr — the regression here was
+        # a dot_product store silently unpickling as cosine.
+        assert restored.similarity == mode, label
+        after = restored.query(query)
+        assert after.ids == before.ids, label
+        assert after.similarities == before.similarities, label
+
+
+@pytest.mark.parametrize("mode_name", ["cosine", "max_inner_product"])
+def test_agno_mode_survives_pickle_and_deepcopy(mode_name):
+    pytest.importorskip("agno")
+    from agno.knowledge.document import Document
+    from agno.vectordb.distance import Distance
+
+    from turbovec.agno import TurboQuantVectorDb
+
+    mode = getattr(Distance, mode_name)
+    db = TurboQuantVectorDb(embedder=ScaledAgnoEmb(), distance=mode)
+    db.create()
+    db.insert(
+        "hash-1",
+        [
+            Document(id=f"agno-{i}", content=f"agno content {i}", embedding=_scaled(i).tolist())
+            for i in range(3)
+        ],
+    )
+    before = [d.id for d in db.search("agno content 0", limit=3)]
+    for label, restored in _round_trips(db):
+        assert restored.distance == mode, label
+        after = [d.id for d in restored.search("agno content 0", limit=3)]
+        assert after == before, label
+        # The mode drives insert-side normalization: a post-restore
+        # insert must go through the same path as on the original.
+        restored.insert(
+            "hash-9",
+            [Document(id="agno-9", content="agno content 9", embedding=_scaled(9).tolist())],
+        )
+        assert restored.get_count() == 4, label
+
+
+# ---------------------------------------------------------------------------
+# Snapshot isolation: __getstate__'s captured state must be immune to
+# in-place metadata mutations that land after it returns (pickle
+# serializes the state outside the store lock, so a shared inner dict
+# would tear the payload mid-serialization).
+# ---------------------------------------------------------------------------
+
+
+def test_agno_getstate_snapshot_isolated_from_update_metadata():
+    pytest.importorskip("agno")
+    from agno.knowledge.document import Document
+
+    from turbovec.agno import TurboQuantVectorDb
+
+    db = TurboQuantVectorDb(embedder=AgnoEmb())
+    db.create()
+    db.insert(
+        "hash-1",
+        [
+            Document(
+                id=f"agno-{i}",
+                content=f"agno content {i}",
+                embedding=_unit(i).tolist(),
+                content_id="cid-1",
+                meta_data={"version": 1},
+            )
+            for i in range(3)
+        ],
+    )
+    state = db.__getstate__()
+    # In-place mutation landing after the snapshot was taken (the
+    # deterministic form of the update-during-pickle interleave).
+    db.update_metadata("cid-1", {"version": 2})
+    metas = [d["meta_data"] for d in state["_u64_to_doc"].values()]
+    assert metas == [{"version": 1}] * 3, "snapshot tore: post-snapshot update leaked in"
+    # And the live store did apply the update — the snapshot is old, not
+    # the mutation lost.
+    assert all(
+        d["meta_data"] == {"version": 2} for d in db._u64_to_doc.values()
+    )
+
+
+def test_haystack_getstate_snapshot_isolated_from_update_by_filter():
+    pytest.importorskip("haystack")
+    from haystack import Document
+
+    from turbovec.haystack import TurboQuantDocumentStore
+
+    store = TurboQuantDocumentStore(dim=DIM)
+    store.write_documents(
+        [
+            Document(id=f"doc-{i}", content=f"content {i}", embedding=_unit(i).tolist(), meta={"version": 1})
+            for i in range(3)
+        ]
+    )
+    state = store.__getstate__()
+    store.update_by_filter(
+        {"field": "meta.version", "operator": "==", "value": 1}, {"version": 2}
+    )
+    metas = [d["meta"] for d in state["_u64_to_doc"].values()]
+    assert metas == [{"version": 1}] * 3, "snapshot tore: post-snapshot update leaked in"
+
+
+# ---------------------------------------------------------------------------
 # The restored lock still serializes mutations (quick stress)
 # ---------------------------------------------------------------------------
 

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -42,6 +42,7 @@ use crate::io;
 use crate::{AddError, ConstructError, TurboQuantIndex};
 
 /// ID-addressed wrapper around [`TurboQuantIndex`].
+#[derive(Debug)]
 pub struct IdMapIndex {
     inner: TurboQuantIndex,
     /// slot → external id. `slot_to_id[i]` is the id of the vector
@@ -298,8 +299,74 @@ impl IdMapIndex {
 
     /// Load a `.tvim` file previously written by [`Self::write`].
     pub fn load(path: impl AsRef<Path>) -> std::io::Result<Self> {
-        let ((bit_width, dim, n_vectors, packed_codes, scales, tqplus_shift, tqplus_scale, slot_to_id), rot) =
-            io::load_id_map_with_rotation(path)?;
+        let (parts, rot) = io::load_id_map_with_rotation(path)?;
+        Self::from_loaded(parts, rot)
+    }
+
+    /// Serialize the index in the `.tvim` byte format to any
+    /// [`std::io::Write`] sink. Emits exactly the bytes [`Self::write`]
+    /// would put in the file, reusing the cached rotation matrix for the
+    /// v4 fingerprint (no `O(dim³)` rebuild when the index has one —
+    /// adding vectors always populates the cache).
+    ///
+    /// Unlike [`Self::write`] there is no atomic-replace behaviour: the
+    /// caller owns the sink.
+    pub fn write_to_writer<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
+        io::write_id_map_to_with_fingerprint(
+            w,
+            self.inner.bit_width(),
+            self.inner.dim_opt().unwrap_or(0),
+            self.inner.len(),
+            self.inner.packed_codes(),
+            self.inner.scales(),
+            self.inner.tqplus_shift(),
+            self.inner.tqplus_scale(),
+            &self.slot_to_id,
+            self.inner.rotation_fingerprint(),
+        )
+    }
+
+    /// Serialize the index to `.tvim`-format bytes in memory —
+    /// byte-identical to the file [`Self::write`] produces. Pairs with
+    /// [`Self::from_bytes`] for callers that persist the index through
+    /// their own storage (a database column, a cache, a pickle payload)
+    /// instead of the filesystem.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        self.write_to_writer(&mut buf)
+            .expect("writing to a Vec<u8> cannot fail");
+        buf
+    }
+
+    /// Deserialize an index from any [`std::io::Read`] source of
+    /// `.tvim`-format bytes. Applies exactly the same validation as
+    /// [`Self::load`] — version handling, structural and value-level
+    /// checks, (v4) rotation-drift verification, and the duplicate-id
+    /// table check — so a byte stream and the file it came from load,
+    /// or fail, identically.
+    pub fn load_from_reader<R: std::io::Read>(r: &mut R) -> std::io::Result<Self> {
+        let (parts, rot) = io::load_id_map_from_with_rotation(r)?;
+        Self::from_loaded(parts, rot)
+    }
+
+    /// Deserialize an index from in-memory `.tvim`-format bytes, as
+    /// produced by [`Self::to_bytes`] (or read out of a `.tvim` file).
+    /// Same validation as [`Self::load`]; see
+    /// [`Self::load_from_reader`].
+    pub fn from_bytes(bytes: &[u8]) -> std::io::Result<Self> {
+        Self::load_from_reader(&mut &bytes[..])
+    }
+
+    /// Shared tail of [`Self::load`] / [`Self::load_from_reader`]:
+    /// assemble the wrapper from an io-layer payload plus the
+    /// drift-verified rotation.
+    #[allow(clippy::type_complexity)]
+    fn from_loaded(
+        parts: (usize, usize, usize, Vec<u8>, Vec<f32>, Vec<f32>, Vec<f32>, Vec<u64>),
+        rot: Option<Vec<f32>>,
+    ) -> std::io::Result<Self> {
+        let (bit_width, dim, n_vectors, packed_codes, scales, tqplus_shift, tqplus_scale, slot_to_id) =
+            parts;
         let dim_opt = if dim == 0 { None } else { Some(dim) };
         let inner = TurboQuantIndex::from_parts(
             dim_opt, bit_width, n_vectors, packed_codes, scales, tqplus_shift, tqplus_scale,
@@ -311,7 +378,7 @@ impl IdMapIndex {
             .enumerate()
             .map(|(slot, &id)| (id, slot))
             .collect();
-        // Reject corrupt files where the id table contains duplicates —
+        // Reject corrupt payloads where the id table contains duplicates —
         // this would desync the two tables.
         if id_to_slot.len() != slot_to_id.len() {
             return Err(std::io::Error::new(

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -1,5 +1,14 @@
 //! Read/write TurboVec index files.
 //!
+//! Every format has two symmetric entry-point pairs: a path-based pair
+//! ([`write`]/[`load`], [`write_id_map`]/[`load_id_map`]) that adds
+//! atomic-replace semantics on the write side, and a generic pair
+//! ([`write_to`]/[`load_from`], [`write_id_map_to`]/[`load_id_map_from`])
+//! over any [`std::io::Write`]/[`std::io::Read`] for callers that hold
+//! the payload in memory (e.g. a database page or a network buffer).
+//! Both pairs produce and accept exactly the same bytes and apply
+//! exactly the same validation.
+//!
 //! Two formats live here:
 //! * `.tv` — [`TurboQuantIndex`](crate::TurboQuantIndex) — 4-byte magic
 //!   "TVPI" + version + bit_width/dim/n_vectors header + packed codes +
@@ -96,6 +105,57 @@ pub fn write(
     )
 }
 
+/// `.tv` write to any [`Write`] sink — the in-memory counterpart of
+/// [`write`]. Emits exactly the bytes [`write`] would put in the file
+/// (magic + version + v4 core payload), so a `Vec<u8>` filled by this
+/// function is byte-identical to the corresponding `.tv` file.
+///
+/// Unlike [`write`] there is no atomicity story: the caller owns the
+/// sink. Like [`write`], when the index holds vectors this entry point
+/// rebuilds the rotation matrix to fingerprint it (`O(dim³)`);
+/// [`TurboQuantIndex::to_bytes`](crate::TurboQuantIndex::to_bytes)
+/// reuses its cached rotation instead.
+#[allow(clippy::too_many_arguments)]
+pub fn write_to<W: Write>(
+    w: &mut W,
+    bit_width: usize,
+    dim: usize,
+    n_vectors: usize,
+    packed_codes: &[u8],
+    scales: &[f32],
+    tqplus_shift: &[f32],
+    tqplus_scale: &[f32],
+) -> io::Result<()> {
+    let rotation_fp = fingerprint_for(dim, n_vectors);
+    write_to_with_fingerprint(
+        w, bit_width, dim, n_vectors, packed_codes, scales,
+        tqplus_shift, tqplus_scale, rotation_fp,
+    )
+}
+
+/// [`write_to`] with a caller-supplied rotation fingerprint — see
+/// [`write_with_fingerprint`].
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn write_to_with_fingerprint<W: Write>(
+    w: &mut W,
+    bit_width: usize,
+    dim: usize,
+    n_vectors: usize,
+    packed_codes: &[u8],
+    scales: &[f32],
+    tqplus_shift: &[f32],
+    tqplus_scale: &[f32],
+    rotation_fp: RotationFingerprint,
+) -> io::Result<()> {
+    assert_tqplus_calibration(dim, tqplus_shift, tqplus_scale);
+    w.write_all(TV_MAGIC)?;
+    w.write_all(&[TV_VERSION])?;
+    write_core(
+        w, bit_width, dim, n_vectors, packed_codes, scales,
+        tqplus_shift, tqplus_scale, rotation_fp,
+    )
+}
+
 /// Rotation fingerprint stored in a v4 header: computed from the
 /// rebuilt rotation matrix for `dim`, or all-zero when the file holds
 /// no vectors (the rotation is meaningless without codes encoded
@@ -125,12 +185,11 @@ pub(crate) fn write_with_fingerprint(
     rotation_fp: RotationFingerprint,
 ) -> io::Result<()> {
     // Validate before any file is created so a violation cannot destroy
-    // a previous good index at `path`.
+    // a previous good index at `path`. (`write_to_with_fingerprint`
+    // re-asserts — harmlessly — for its direct callers.)
     assert_tqplus_calibration(dim, tqplus_shift, tqplus_scale);
     write_atomic(path.as_ref(), |f| {
-        f.write_all(TV_MAGIC)?;
-        f.write_all(&[TV_VERSION])?;
-        write_core(
+        write_to_with_fingerprint(
             f, bit_width, dim, n_vectors, packed_codes, scales,
             tqplus_shift, tqplus_scale, rotation_fp,
         )
@@ -151,6 +210,15 @@ pub fn load(path: impl AsRef<Path>) -> io::Result<CoreLoad> {
     Ok(load_with_rotation(path)?.0)
 }
 
+/// `.tv` load from any [`Read`] source — the in-memory counterpart of
+/// [`load`]. Applies exactly the same version handling and validation
+/// (structural checks, value-level float validation, v4 rotation-drift
+/// verification), so a byte slice and the file it came from load — or
+/// fail — identically.
+pub fn load_from<R: Read>(r: &mut R) -> io::Result<CoreLoad> {
+    Ok(load_from_with_rotation(r)?.0)
+}
+
 /// [`load`], additionally returning the drift-verified rotation matrix
 /// for v4 files with vectors (`None` otherwise) so the index types can
 /// seed their rotation cache instead of rebuilding it on first search.
@@ -158,7 +226,14 @@ pub(crate) fn load_with_rotation(
     path: impl AsRef<Path>,
 ) -> io::Result<(CoreLoad, Option<Vec<f32>>)> {
     let mut f = BufReader::new(File::open(path)?);
+    load_from_with_rotation(&mut f)
+}
 
+/// [`load_from`], additionally returning the drift-verified rotation
+/// matrix — see [`load_with_rotation`].
+pub(crate) fn load_from_with_rotation<R: Read>(
+    f: &mut R,
+) -> io::Result<(CoreLoad, Option<Vec<f32>>)> {
     let mut magic = [0u8; 4];
     f.read_exact(&mut magic)?;
     if &magic != TV_MAGIC {
@@ -184,7 +259,7 @@ pub(crate) fn load_with_rotation(
     }
     let mut version = [0u8; 1];
     f.read_exact(&mut version)?;
-    read_core_versioned(&mut f, version[0], TV_VERSION, ".tv")
+    read_core_versioned(f, version[0], TV_VERSION, ".tv")
 }
 
 
@@ -212,6 +287,67 @@ pub fn write_id_map(
     )
 }
 
+/// `.tvim` write to any [`Write`] sink — the in-memory counterpart of
+/// [`write_id_map`]. Emits exactly the bytes [`write_id_map`] would put
+/// in the file. Like [`write_id_map`], rebuilds the rotation matrix to
+/// fingerprint it when the index holds vectors (`O(dim³)`);
+/// [`IdMapIndex::to_bytes`](crate::IdMapIndex::to_bytes) reuses its
+/// cached rotation instead.
+#[allow(clippy::too_many_arguments)]
+pub fn write_id_map_to<W: Write>(
+    w: &mut W,
+    bit_width: usize,
+    dim: usize,
+    n_vectors: usize,
+    packed_codes: &[u8],
+    scales: &[f32],
+    tqplus_shift: &[f32],
+    tqplus_scale: &[f32],
+    slot_to_id: &[u64],
+) -> io::Result<()> {
+    let rotation_fp = fingerprint_for(dim, n_vectors);
+    write_id_map_to_with_fingerprint(
+        w, bit_width, dim, n_vectors, packed_codes, scales,
+        tqplus_shift, tqplus_scale, slot_to_id, rotation_fp,
+    )
+}
+
+/// [`write_id_map_to`] with a caller-supplied rotation fingerprint —
+/// see [`write_with_fingerprint`].
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn write_id_map_to_with_fingerprint<W: Write>(
+    w: &mut W,
+    bit_width: usize,
+    dim: usize,
+    n_vectors: usize,
+    packed_codes: &[u8],
+    scales: &[f32],
+    tqplus_shift: &[f32],
+    tqplus_scale: &[f32],
+    slot_to_id: &[u64],
+    rotation_fp: RotationFingerprint,
+) -> io::Result<()> {
+    assert_eq!(
+        slot_to_id.len(),
+        n_vectors,
+        "slot_to_id length {} does not match n_vectors {}",
+        slot_to_id.len(),
+        n_vectors,
+    );
+    assert_tqplus_calibration(dim, tqplus_shift, tqplus_scale);
+
+    w.write_all(TVIM_MAGIC)?;
+    w.write_all(&[TVIM_VERSION])?;
+    write_core(
+        w, bit_width, dim, n_vectors, packed_codes, scales,
+        tqplus_shift, tqplus_scale, rotation_fp,
+    )?;
+    for &id in slot_to_id {
+        w.write_all(&id.to_le_bytes())?;
+    }
+    Ok(())
+}
+
 /// [`write_id_map`] with a caller-supplied rotation fingerprint — see
 /// [`write_with_fingerprint`].
 #[allow(clippy::too_many_arguments)]
@@ -229,6 +365,8 @@ pub(crate) fn write_id_map_with_fingerprint(
 ) -> io::Result<()> {
     // Validate before any file is created so a violation cannot destroy
     // a previous good index at `path`.
+    // (`write_id_map_to_with_fingerprint` re-asserts — harmlessly —
+    // for its direct callers.)
     assert_eq!(
         slot_to_id.len(),
         n_vectors,
@@ -239,17 +377,10 @@ pub(crate) fn write_id_map_with_fingerprint(
     assert_tqplus_calibration(dim, tqplus_shift, tqplus_scale);
 
     write_atomic(path.as_ref(), |f| {
-        f.write_all(TVIM_MAGIC)?;
-        f.write_all(&[TVIM_VERSION])?;
-        write_core(
+        write_id_map_to_with_fingerprint(
             f, bit_width, dim, n_vectors, packed_codes, scales,
-            tqplus_shift, tqplus_scale, rotation_fp,
-        )?;
-
-        for &id in slot_to_id {
-            f.write_all(&id.to_le_bytes())?;
-        }
-        Ok(())
+            tqplus_shift, tqplus_scale, slot_to_id, rotation_fp,
+        )
     })
 }
 
@@ -260,6 +391,17 @@ pub fn load_id_map(
     path: impl AsRef<Path>,
 ) -> io::Result<(usize, usize, usize, Vec<u8>, Vec<f32>, Vec<f32>, Vec<f32>, Vec<u64>)> {
     Ok(load_id_map_with_rotation(path)?.0)
+}
+
+/// `.tvim` load from any [`Read`] source — the in-memory counterpart of
+/// [`load_id_map`], with exactly the same version handling and
+/// validation, so a byte slice and the file it came from load — or
+/// fail — identically.
+#[allow(clippy::type_complexity)]
+pub fn load_id_map_from<R: Read>(
+    r: &mut R,
+) -> io::Result<(usize, usize, usize, Vec<u8>, Vec<f32>, Vec<f32>, Vec<f32>, Vec<u64>)> {
+    Ok(load_id_map_from_with_rotation(r)?.0)
 }
 
 /// [`load_id_map`], additionally returning the drift-verified rotation
@@ -273,7 +415,18 @@ pub(crate) fn load_id_map_with_rotation(
     Option<Vec<f32>>,
 )> {
     let mut f = BufReader::new(File::open(path)?);
+    load_id_map_from_with_rotation(&mut f)
+}
 
+/// [`load_id_map_from`], additionally returning the drift-verified
+/// rotation matrix — see [`load_with_rotation`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn load_id_map_from_with_rotation<R: Read>(
+    f: &mut R,
+) -> io::Result<(
+    (usize, usize, usize, Vec<u8>, Vec<f32>, Vec<f32>, Vec<f32>, Vec<u64>),
+    Option<Vec<f32>>,
+)> {
     let mut magic = [0u8; 4];
     f.read_exact(&mut magic)?;
     if &magic != TVIM_MAGIC {
@@ -296,7 +449,7 @@ pub(crate) fn load_id_map_with_rotation(
         ));
     }
     let ((bit_width, dim, n_vectors, packed_codes, scales, tqplus_shift, tqplus_scale), rotation) =
-        read_core_versioned(&mut f, version[0], TVIM_VERSION, ".tvim")?;
+        read_core_versioned(f, version[0], TVIM_VERSION, ".tvim")?;
 
     // Read the slot_to_id table via the capped reader rather than
     // `Vec::with_capacity(n_vectors)` — `n_vectors` is attacker-controlled and
@@ -304,7 +457,7 @@ pub(crate) fn load_id_map_with_rotation(
     let id_bytes = n_vectors
         .checked_mul(8)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "id table size overflows usize"))?;
-    let raw = read_exact_vec(&mut f, id_bytes)?;
+    let raw = read_exact_vec(f, id_bytes)?;
     let slot_to_id: Vec<u64> = raw
         .chunks_exact(8)
         .map(|b| u64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]))

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -641,6 +641,58 @@ impl TurboQuantIndex {
         )
     }
 
+    /// Serialize the index in the `.tv` byte format to any
+    /// [`std::io::Write`] sink. Emits exactly the bytes [`Self::write`]
+    /// would put in the file, reusing the cached rotation matrix for the
+    /// v4 fingerprint (no `O(dim³)` rebuild when the index has one —
+    /// adding vectors always populates the cache).
+    ///
+    /// Unlike [`Self::write`] there is no atomic-replace behaviour: the
+    /// caller owns the sink.
+    pub fn write_to_writer<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
+        io::write_to_with_fingerprint(
+            w,
+            self.bit_width,
+            self.dim.unwrap_or(0),
+            self.n_vectors,
+            &self.packed_codes,
+            &self.scales,
+            &self.tqplus_shift,
+            &self.tqplus_scale,
+            self.rotation_fingerprint(),
+        )
+    }
+
+    /// Serialize the index to `.tv`-format bytes in memory —
+    /// byte-identical to the file [`Self::write`] produces. Pairs with
+    /// [`Self::from_bytes`] for callers that persist the index through
+    /// their own storage (a database column, a cache, a pickle payload)
+    /// instead of the filesystem.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        self.write_to_writer(&mut buf)
+            .expect("writing to a Vec<u8> cannot fail");
+        buf
+    }
+
+    /// Deserialize an index from any [`std::io::Read`] source of
+    /// `.tv`-format bytes. Applies exactly the same validation as
+    /// [`Self::load`] — version handling, structural and value-level
+    /// checks, and (v4) rotation-drift verification — so a byte stream
+    /// and the file it came from load, or fail, identically.
+    pub fn load_from_reader<R: std::io::Read>(r: &mut R) -> std::io::Result<Self> {
+        let (parts, rot) = io::load_from_with_rotation(r)?;
+        Self::from_loaded(parts, rot)
+    }
+
+    /// Deserialize an index from in-memory `.tv`-format bytes, as
+    /// produced by [`Self::to_bytes`] (or read out of a `.tv` file).
+    /// Same validation as [`Self::load`]; see
+    /// [`Self::load_from_reader`].
+    pub fn from_bytes(bytes: &[u8]) -> std::io::Result<Self> {
+        Self::load_from_reader(&mut &bytes[..])
+    }
+
     /// Fingerprint of this index's rotation matrix, for the v4 header:
     /// all-zero when the index holds no vectors, otherwise computed
     /// from the (cached, or built-on-demand) rotation. Adding vectors
@@ -659,10 +711,21 @@ impl TurboQuantIndex {
     }
 
     pub fn load(path: impl AsRef<Path>) -> std::io::Result<Self> {
-        let ((bit_width, dim, n_vectors, packed_codes, scales, tqplus_shift, tqplus_scale), rot) =
-            io::load_with_rotation(path)?;
+        let (parts, rot) = io::load_with_rotation(path)?;
+        Self::from_loaded(parts, rot)
+    }
+
+    /// Shared tail of [`Self::load`] / [`Self::load_from_reader`]:
+    /// assemble an index from an io-layer core payload plus the
+    /// drift-verified rotation (when the source was a v4 payload with
+    /// vectors).
+    fn from_loaded(
+        parts: (usize, usize, usize, Vec<u8>, Vec<f32>, Vec<f32>, Vec<f32>),
+        rot: Option<Vec<f32>>,
+    ) -> std::io::Result<Self> {
+        let (bit_width, dim, n_vectors, packed_codes, scales, tqplus_shift, tqplus_scale) = parts;
         let dim_opt = if dim == 0 { None } else { Some(dim) };
-        // io::load already validates the payload at the read layer, so
+        // The io layer already validates the payload at the read layer, so
         // from_parts should always succeed here; surface any residual
         // inconsistency as InvalidData rather than panicking.
         let index = Self::from_parts(

--- a/turbovec/tests/bytes_io.rs
+++ b/turbovec/tests/bytes_io.rs
@@ -1,0 +1,313 @@
+//! In-memory serialization API: `to_bytes` / `from_bytes` /
+//! `write_to_writer` / `load_from_reader` on both index types, and the
+//! generic `io::write_to` / `io::load_from` /
+//! `io::write_id_map_to` / `io::load_id_map_from` entry points.
+//!
+//! Covers:
+//! 1. Byte identity: `to_bytes` (and the generic io writers) produce
+//!    exactly the bytes `write` puts in the file, for populated, empty,
+//!    and lazy-uncommitted indexes.
+//! 2. Round-trip: `from_bytes(to_bytes(x))` reproduces `x` — search
+//!    parity, ids, dim/bit_width/len, and a re-serialization that is
+//!    byte-identical again.
+//! 3. Error parity with `load`: corrupt or drifted bytes fail
+//!    `from_bytes` with the same error kind and message as the same
+//!    bytes written to a file and passed to `load` (io_v4-style cases:
+//!    wrong magic, v1 version byte, unsupported version, truncation,
+//!    rotation drift, duplicate `.tvim` ids).
+
+use std::path::PathBuf;
+
+use turbovec::{io, IdMapIndex, TurboQuantIndex};
+
+fn temp_dir(name: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    p.push(format!("turbovec-{}-{}", nonce, name));
+    std::fs::create_dir(&p).unwrap();
+    p
+}
+
+/// Deterministic vector source (same LCG family as tests/io_v4.rs).
+fn lcg_vectors(n: usize, dim: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed;
+    (0..n * dim)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            ((state >> 32) as u32 as f64 / 2_147_483_648.0 - 1.0) as f32
+        })
+        .collect()
+}
+
+const DIM: usize = 32;
+const N: usize = 64;
+const VEC_SEED: u64 = 0xDECAF;
+const QUERY_SEED: u64 = 0xC0FFEE;
+
+// v4 header offsets shared with tests/io_v4.rs.
+const OFF_VERSION: usize = 4;
+const OFF_HASH: usize = 18;
+const OFF_PROBES: usize = 26;
+const N_PROBES: usize = 64;
+
+fn build_index() -> TurboQuantIndex {
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.add_2d(&lcg_vectors(N, DIM, VEC_SEED), DIM).unwrap();
+    idx
+}
+
+fn build_id_map() -> IdMapIndex {
+    let mut idx = IdMapIndex::new(DIM, 4).unwrap();
+    let ids: Vec<u64> = (0..N as u64).map(|i| 1000 + i).collect();
+    idx.add_with_ids(&lcg_vectors(N, DIM, VEC_SEED), &ids).unwrap();
+    idx
+}
+
+// ---------------------------------------------------------------------------
+// 1. Byte identity with the file writers
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tv_to_bytes_is_byte_identical_to_write_file() {
+    let dir = temp_dir("tv-byte-identity");
+    let path = dir.join("index.tv");
+    let idx = build_index();
+    idx.write(&path).unwrap();
+    let file_bytes = std::fs::read(&path).unwrap();
+
+    assert_eq!(idx.to_bytes(), file_bytes, "to_bytes must equal the .tv file bytes");
+
+    // The generic io writer (which rebuilds the rotation for the
+    // fingerprint rather than using the index's cache) must produce the
+    // same bytes too — the fingerprint is a deterministic function of dim.
+    let mut via_io = Vec::new();
+    io::write_to(
+        &mut via_io,
+        idx.bit_width(),
+        idx.dim(),
+        idx.len(),
+        idx.packed_codes(),
+        idx.scales(),
+        idx.tqplus_shift(),
+        idx.tqplus_scale(),
+    )
+    .unwrap();
+    assert_eq!(via_io, file_bytes, "io::write_to must equal the .tv file bytes");
+
+    // write_to_writer is the same serialization behind a Write sink.
+    let mut via_writer = Vec::new();
+    idx.write_to_writer(&mut via_writer).unwrap();
+    assert_eq!(via_writer, file_bytes);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn tvim_to_bytes_is_byte_identical_to_write_file() {
+    let dir = temp_dir("tvim-byte-identity");
+    let path = dir.join("index.tvim");
+    let idx = build_id_map();
+    idx.write(&path).unwrap();
+    let file_bytes = std::fs::read(&path).unwrap();
+
+    assert_eq!(idx.to_bytes(), file_bytes, "to_bytes must equal the .tvim file bytes");
+
+    let mut via_writer = Vec::new();
+    idx.write_to_writer(&mut via_writer).unwrap();
+    assert_eq!(via_writer, file_bytes);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn empty_and_lazy_indexes_round_trip_byte_identically() {
+    let dir = temp_dir("empty-lazy-bytes");
+
+    // Eager but empty: dim committed, no vectors, zero fingerprint.
+    let eager = TurboQuantIndex::new(DIM, 4).unwrap();
+    let path = dir.join("eager.tv");
+    eager.write(&path).unwrap();
+    assert_eq!(eager.to_bytes(), std::fs::read(&path).unwrap());
+    let back = TurboQuantIndex::from_bytes(&eager.to_bytes()).unwrap();
+    assert_eq!(back.dim_opt(), Some(DIM));
+    assert_eq!(back.len(), 0);
+
+    // Lazy uncommitted: dim=0 sentinel.
+    let lazy = IdMapIndex::new_lazy(3).unwrap();
+    let path = dir.join("lazy.tvim");
+    lazy.write(&path).unwrap();
+    assert_eq!(lazy.to_bytes(), std::fs::read(&path).unwrap());
+    let back = IdMapIndex::from_bytes(&lazy.to_bytes()).unwrap();
+    assert_eq!(back.dim_opt(), None);
+    assert_eq!(back.bit_width(), 3);
+    assert_eq!(back.len(), 0);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ---------------------------------------------------------------------------
+// 2. Round-trip equality
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tv_from_bytes_round_trip_search_parity() {
+    let idx = build_index();
+    let queries = lcg_vectors(4, DIM, QUERY_SEED);
+    let before = idx.search(&queries, 5);
+
+    let back = TurboQuantIndex::from_bytes(&idx.to_bytes()).unwrap();
+    assert_eq!(back.len(), idx.len());
+    assert_eq!(back.dim(), idx.dim());
+    assert_eq!(back.bit_width(), idx.bit_width());
+    let after = back.search(&queries, 5);
+    assert_eq!(before.scores, after.scores, "scores must survive the bytes round-trip");
+    assert_eq!(before.indices, after.indices, "indices must survive the bytes round-trip");
+
+    // Idempotence: re-serializing the deserialized index is
+    // byte-identical (full state equality at the wire level).
+    assert_eq!(back.to_bytes(), idx.to_bytes());
+}
+
+#[test]
+fn tvim_from_bytes_round_trip_search_and_id_parity() {
+    let idx = build_id_map();
+    let queries = lcg_vectors(4, DIM, QUERY_SEED);
+    let (scores_before, ids_before) = idx.search(&queries, 5);
+
+    let back = IdMapIndex::from_bytes(&idx.to_bytes()).unwrap();
+    assert_eq!(back.len(), idx.len());
+    let (scores_after, ids_after) = back.search(&queries, 5);
+    assert_eq!(scores_before, scores_after);
+    assert_eq!(ids_before, ids_after);
+    for id in 1000..1000 + N as u64 {
+        assert!(back.contains(id), "id {id} must survive the bytes round-trip");
+    }
+    assert_eq!(back.to_bytes(), idx.to_bytes());
+
+    // The generic reader sees the same payload.
+    let bytes = idx.to_bytes();
+    let via_reader = IdMapIndex::load_from_reader(&mut &bytes[..]).unwrap();
+    assert_eq!(via_reader.len(), idx.len());
+}
+
+#[test]
+fn io_generic_id_map_round_trip_matches_file_load() {
+    // The raw io-module pair round-trips the same parts the file pair
+    // does (the #70 ask: no tmpfile needed to (de)serialize a .tvim
+    // payload held in memory).
+    let idx = build_id_map();
+    let mut buf = Vec::new();
+    io::write_id_map_to(
+        &mut buf,
+        idx.bit_width(),
+        idx.dim(),
+        idx.len(),
+        // Round-trip through the accessors like an external embedder would.
+        TurboQuantIndex::from_bytes(&build_index().to_bytes()).unwrap().packed_codes(),
+        &vec![1.0; N],
+        &[],
+        &[],
+        &(0..N as u64).collect::<Vec<_>>(),
+    )
+    .unwrap();
+    let (bit_width, dim, n_vectors, _codes, scales, _shift, _scale, slot_to_id) =
+        io::load_id_map_from(&mut &buf[..]).unwrap();
+    assert_eq!((bit_width, dim, n_vectors), (4, DIM, N));
+    assert_eq!(scales, vec![1.0; N]);
+    assert_eq!(slot_to_id, (0..N as u64).collect::<Vec<_>>());
+
+    // And io::load_from parses a .tv byte payload.
+    let tv_bytes = build_index().to_bytes();
+    let (bit_width, dim, n_vectors, ..) = io::load_from(&mut &tv_bytes[..]).unwrap();
+    assert_eq!((bit_width, dim, n_vectors), (4, DIM, N));
+}
+
+// ---------------------------------------------------------------------------
+// 3. Error parity with `load` on corrupt / drifted bytes
+// ---------------------------------------------------------------------------
+
+/// Assert `from_bytes` and `load` fail identically on the same payload.
+fn assert_same_error_tv(dir: &PathBuf, name: &str, bytes: &[u8]) -> std::io::Error {
+    let path = dir.join(name);
+    std::fs::write(&path, bytes).unwrap();
+    let from_bytes_err =
+        TurboQuantIndex::from_bytes(bytes).expect_err("corrupt bytes must not deserialize");
+    let load_err = TurboQuantIndex::load(&path).expect_err("corrupt file must not load");
+    assert_eq!(from_bytes_err.kind(), load_err.kind(), "{name}: error kind must match load");
+    assert_eq!(
+        from_bytes_err.to_string(),
+        load_err.to_string(),
+        "{name}: error message must match load",
+    );
+    from_bytes_err
+}
+
+#[test]
+fn tv_from_bytes_rejects_corrupt_bytes_with_same_errors_as_load() {
+    let dir = temp_dir("tv-corrupt-parity");
+    let good = build_index().to_bytes();
+
+    // Wrong magic.
+    let mut wrong_magic = good.clone();
+    wrong_magic[0] = b'X';
+    let e = assert_same_error_tv(&dir, "wrong-magic.tv", &wrong_magic);
+    assert!(e.to_string().contains("wrong magic"), "got: {e}");
+
+    // v1 sentinel (bare bit_width first byte).
+    let mut v1 = good.clone();
+    v1[0] = 4; // in 2..=4 → the targeted v1 error
+    let e = assert_same_error_tv(&dir, "v1.tv", &v1);
+    assert!(e.to_string().contains("turbovec ≤ 0.4.3"), "got: {e}");
+
+    // Unsupported version byte.
+    let mut future = good.clone();
+    future[OFF_VERSION] = 9;
+    let e = assert_same_error_tv(&dir, "future.tv", &future);
+    assert!(e.to_string().contains("unsupported .tv format version"), "got: {e}");
+
+    // Truncation.
+    let truncated = &good[..good.len() - 7];
+    let e = assert_same_error_tv(&dir, "truncated.tv", truncated);
+    assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof);
+
+    // Rotation drift: shift every probe far out of tolerance and break
+    // the hash (the io_v4 drift construction).
+    let mut drifted = good.clone();
+    drifted[OFF_HASH] ^= 0xFF;
+    for i in 0..N_PROBES {
+        let o = OFF_PROBES + 4 * i;
+        let p = f32::from_le_bytes(drifted[o..o + 4].try_into().unwrap());
+        drifted[o..o + 4].copy_from_slice(&(p + 1.0).to_le_bytes());
+    }
+    let e = assert_same_error_tv(&dir, "drifted.tv", &drifted);
+    assert!(e.to_string().contains("rotation drift"), "got: {e}");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn tvim_from_bytes_rejects_duplicate_ids_like_load() {
+    let dir = temp_dir("tvim-dup-parity");
+    let mut idx = IdMapIndex::new(8, 4).unwrap();
+    idx.add_with_ids(&lcg_vectors(3, 8, VEC_SEED), &[7, 8, 9]).unwrap();
+    let mut bytes = idx.to_bytes();
+
+    // The id table is the trailing 3 × u64; overwrite id 9 with 7.
+    let n = bytes.len();
+    bytes[n - 8..].copy_from_slice(&7u64.to_le_bytes());
+
+    let path = dir.join("dup.tvim");
+    std::fs::write(&path, &bytes).unwrap();
+    let from_bytes_err = IdMapIndex::from_bytes(&bytes).expect_err("duplicate ids must not load");
+    let load_err = IdMapIndex::load(&path).expect_err("duplicate ids must not load");
+    assert_eq!(from_bytes_err.kind(), std::io::ErrorKind::InvalidData);
+    assert_eq!(from_bytes_err.to_string(), load_err.to_string());
+    assert!(from_bytes_err.to_string().contains("duplicate ids"), "got: {from_bytes_err}");
+
+    // A .tv payload fed to the .tvim reader is the wrong-magic error.
+    let tv_bytes = build_index().to_bytes();
+    let e = IdMapIndex::from_bytes(&tv_bytes).expect_err(".tv bytes are not a TVIM payload");
+    assert!(e.to_string().contains("not a TVIM file"), "got: {e}");
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
Implements the maintainer-ruled D5: a core in-memory serialization API and correct copy/pickle semantics for all four integration stores.

Closes #148. Closes #149.
Delivers the in-memory I/O half of #70 (the `from_parts` half landed in #204; leaving #70 open for the reporter to confirm).

## The bugs (reproduced on this branch's base, b524c4c)

**#148 — LlamaIndex pickle silently returns an EMPTY store.** The Rust index lives in a pydantic `PrivateAttr`; `BaseComponent.__getstate__` drops any private attribute that fails `pickle.dumps` with only a log warning:

```
orig query ids:    ['0', '2', '1']
pickled  _nodes:   []
pickled query ids: []          # total, silent data loss
```

The other three stores raised a clean `TypeError: cannot pickle 'builtins.IdMapIndex' object`.

**#149 — copy.copy bleeds; deepcopy raises.** On all four stores, `copy.copy` shared the Rust index (mutating the copy mutated the original: langchain `len(s._index)` 3→4, haystack `count_documents()` 3→4, llama query grew an id, agno `get_count()` 1→2), and `copy.deepcopy` raised `TypeError` — so no safe copy existed.

## Design

### 1. Core (Rust): `to_bytes` / `from_bytes` + generic `Read`/`Write` I/O

- `TurboQuantIndex::to_bytes()` / `IdMapIndex::to_bytes()` emit exactly the v4 `.tv`/`.tvim` file bytes; `from_bytes(&[u8])` mirrors `load` with **exactly** the same validation (version handling, structural + value-level checks, v4 rotation-drift verification, `.tvim` duplicate-id check).
- The io module's internals were already generic over `Read`/`Write`; the path-based fns are now thin wrappers over new generic entry points (`io::write_to`, `io::load_from`, `io::write_id_map_to`, `io::load_id_map_from`, plus `write_to_writer<W>` / `load_from_reader<R>` on both types — the exact surface #70 proposed). **No serialization logic is duplicated**: `write`/`write_id_map` call `write_atomic` around the same generic writer; `load`/`load_id_map` open a `BufReader` and call the same generic reader.
- **Rotation-fingerprint cost** (the #205 review observation): `to_bytes` on the index types goes through `rotation_fingerprint()` → `self.rotation.get_or_init`, reusing the cached matrix like `write` does; only the raw `io::write_to`/`io::write_id_map_to` rebuild it (documented). Verified empirically at dim 4096: `add` (builds rotation) 1.80 s, `to_bytes` 0.07 s (O(dim²) hash only); `from_bytes` pays one rebuild for drift verification, same as `load` (1.93 s).
- Properties pinned by tests: `to_bytes()` == the bytes `write(path)` puts on disk (byte-identical, incl. empty and lazy-uncommitted indexes); `from_bytes(to_bytes(x))` reproduces `x` (search/id parity + re-serialization byte-identical); corrupt/drifted bytes fail with the **same error kind and message** as the same bytes passed through a file and `load` (wrong magic, v1 sentinel, unsupported version, truncation, rotation drift, duplicate `.tvim` ids).
- `IdMapIndex` now derives `Debug` (parity with `TurboQuantIndex`).

### 2. Bindings

`to_bytes() -> bytes` / `from_bytes(data)` classmethods on both pyclasses. Serialization runs under the read lock inside `py.detach` (payloads can be big); `from_bytes` snapshots the buffer before detaching (a `bytearray` can be mutated by another thread once the GIL is released) and parses detached. Corrupt bytes raise `ValueError` — there is no path to blame, so not `OSError`. `cargo check -p turbovec-python`: 0 warnings.

### 3. Stores (all four): `__getstate__` / `__setstate__` / `__deepcopy__` / `__copy__`

- State = the index as its `.tvim` bytes + shallow-copied side-car maps + the plain attributes, **snapshotted under the writer lock** so a pickle overlapping a write captures a consistent index/side-car pair (same guarantee the save paths give the on-disk pair).
- Excluded from state and recreated in `__setstate__`: the per-store `RLock` (locks are not picklable), and for Haystack also the `ThreadPoolExecutor` — a restored/copied store always owns a fresh single-thread executor, even when the original wrapped a caller-provided one (documented).
- LlamaIndex restores through `__init__` so the pydantic machinery (`__pydantic_private__` etc.) is fully initialized on the bare unpickled instance; model fields ride along and are re-validated.
- Agno round-trips the not-yet-`create()`d / dropped state as `index_bytes=None`.

### 4. The `__copy__` design call

`__copy__` is **deliberately identical to `__deepcopy__`** — there is no meaningful shallow copy of a store. Evidence from running the canonical references:

| reference | `copy.copy` | `copy.deepcopy` | `pickle` |
|---|---|---|---|
| langchain `InMemoryVectorStore` | shares store dict (bleeds) | independent | round-trips |
| llama `SimpleVectorStore` | shares data dict (bleeds) | independent | round-trips |
| haystack `InMemoryDocumentStore` | shares (bleeds) | **raises** (`_queue.SimpleQueue`) | **raises** |

The references bleed under `copy.copy` only as the accidental default-object behaviour; no framework code calls `copy.copy` on a store and relies on aliasing (grepped the installed packages). For turbovec, alias-sharing a *Rust* index is precisely the #149 bug the maintainer ruled against ("Expected: `copy.copy`/`copy.deepcopy` yield an independent store"), so the safe, least-surprising choice is an independent copy — cheaper to reason about than a documented-but-surprising alias, and it also fixes deepcopy on the Haystack store where even the reference raises. Note our pickle support now *exceeds* the Haystack reference, which cannot pickle at all in 3.0.

## Evidence

**Headline before/after** (same script, unfixed → fixed):

```
# before                                    # after
pickled query ids: []                       pickled query ids: ['0', '2', '1']
langchain deepcopy raised: TypeError        independent copy, both directions
haystack: copy bleeds, count 3→4            original untouched
```

**Biting**: with the store fixes stashed (extension already carrying `to_bytes`), all 16 store tests fail exactly as the issues describe — llama pickle asserts `[] == ['node-0', 'node-1', 'node-2']`, the others fail on `TypeError`/bleed; the 5 core-binding tests pass. With the fixes restored: 21/21 pass.

**Tests added**
- Rust (`turbovec/tests/bytes_io.rs`, 8): `tv_to_bytes_is_byte_identical_to_write_file`, `tvim_to_bytes_is_byte_identical_to_write_file`, `empty_and_lazy_indexes_round_trip_byte_identically`, `tv_from_bytes_round_trip_search_parity`, `tvim_from_bytes_round_trip_search_and_id_parity`, `io_generic_id_map_round_trip_matches_file_load`, `tv_from_bytes_rejects_corrupt_bytes_with_same_errors_as_load`, `tvim_from_bytes_rejects_duplicate_ids_like_load`.
- Python (`turbovec-python/tests/test_pickle_copy.py`, 21): binding round-trips (byte-identity vs file, bytearray, corrupt/wrong-type → `ValueError`/`TypeError`, lazy index), per-store pickle-with-real-data (docs, metadata, score parity, and the handle counter — a post-restore add gets a fresh non-colliding handle), deepcopy independence both directions (the #149 repro), copy.copy no-bleed, a post-unpickle 4-thread × 25-add lock stress, and a `multiprocessing` **spawn**-context smoke (llama + langchain: pickle a populated store into a spawned child and search there; embedders are hashlib-seeded so they're stable across the child's different hash seed). Spawn, not fork — #147 is parked.

**Suites**
- `cargo test -p turbovec`: **216 passed, 0 failed** (208 baseline + 8 new)
- `cargo check -p turbovec-python`: **0 warnings** (`--tests` on the core also 0)
- Full pytest (scratch venv, extension rebuilt): **573 passed, 0 failed** (552 baseline + 21 new)

**Docs**: `docs/api.md` gains `to_bytes`/`from_bytes` rows in both method tables plus an "In-memory serialization" section (covers the Rust generic I/O surface); each integration doc gets a one-line pickle/copy note in its save/load section; CHANGELOG under Unreleased — Rust crate *Added*, Python package *Added* + *Fixed* (llama silent-empty-pickle as the headline).

---

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
