### PR TITLE
fix: correct declared MSRV from 1.70 to 1.83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,6 +343,12 @@ appears under each surface it touches.
     default cosine function collapsed distinct scores to `1.0`,
     violating the "same ranking, mapped into [0, 1]" contract; scaled
     scores are now distinct and order-preserving. (#114)
+- **Declared MSRV corrected from 1.70 to 1.83.** Building the PyPI
+  package from source (sdist, or a platform with no prebuilt wheel) now
+  correctly requires rustc 1.83 — the toolchain the dependency tree has
+  in fact required all along; the 1.70 declared in
+  `turbovec-python/Cargo.toml` was never sufficient. Prebuilt-wheel
+  users are unaffected. (#182)
 - **LlamaIndex `add()` no longer loses data under concurrent calls.**
   `_next_u64 += 1` on a pydantic `PrivateAttr` is not atomic under
   the GIL, so two concurrent `add()` calls could issue the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,15 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **Declared MSRV corrected from 1.70 to 1.83.** The
+  `rust-version = "1.70"` declared in both `Cargo.toml`s was never
+  accurate: when it was introduced (2026-04-13, chosen for the crate's
+  own `OnceLock` use), the dependency tree already required newer
+  toolchains — `pest` 2.8.6 (transitive via
+  `faer` → `npyz` → `py_literal`) requires rustc 1.83, `faer` 0.20.2
+  requires 1.81, and the v4 `Cargo.lock` needs cargo ≥ 1.78 to parse.
+  Both packages now declare `rust-version = "1.83"`, verified by a clean
+  `cargo +1.83 check` of each. (#182)
 - **Pre-AVX2 x86-64 CPUs no longer SIGILL before the scalar fallback can
   run.** The repo-level `.cargo/config.toml` set a global
   `target-cpu=x86-64-v3` (AVX2/FMA/BMI2) baseline, so every *plain* (non-

--- a/turbovec-python/Cargo.toml
+++ b/turbovec-python/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbovec-python"
 version = "0.8.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.83"
 
 [lib]
 name = "_turbovec"

--- a/turbovec/Cargo.toml
+++ b/turbovec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbovec"
 version = "0.9.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.83"
 description = "Fast vector quantization with 2-4 bit compression and SIMD search"
 license = "MIT"
 repository = "https://github.com/RyanCodrai/turbovec"


### PR DESCRIPTION
## What

Both `turbovec/Cargo.toml` and `turbovec-python/Cargo.toml` declared `rust-version = "1.70"`. The true floor with the current lockfile is **1.83**. Both now declare `1.83`. Addresses the MSRV half of #182.

## Why 1.83 (and not 1.81 + a pest downgrade)

The ruling allowed either declaring 1.83 plainly, or declaring 1.81 (faer's floor) and pinning pest back to its last 1.81-compatible release. Both options were tested; 1.83 was chosen.

**Evidence table — what requires what:**

| Package | Locked version | Requires rustc | Path into the tree |
|---|---|---|---|
| `pest` / `pest_derive` / `pest_generator` / `pest_meta` | 2.8.6 | **1.83** | `faer` → `npyz` → `py_literal` → pest family |
| `faer` | 0.20.2 | **1.81** | direct dependency of `turbovec` |
| `Cargo.lock` format | v4 | cargo ≥ **1.78** | lockfile itself (since d3ec596) |
| everything else | — | ≤ 1.81 | `cargo +1.81 check` reports only the pest family as incompatible |

**The 1.81 + downgrade option is feasible but fragile.** pest 2.8.3 is the last release with `rust-version = 1.81` (2.8.4+ require 1.83), `py_literal 0.4.0` allows `pest ^2.0`, and with the pest family pinned to 2.8.3 via `cargo update --precise`, `cargo +1.81 check` passes for both packages — this was verified, not assumed. It was rejected because:

- pest sits **four levels deep** in the tree; any routine `cargo update` or dep bump silently restores the newest pest and makes a declared 1.81 false again — recreating exactly the bug this PR fixes, with no MSRV gate to catch it (this repo intentionally has none).
- The gain is two minor rustc versions; 1.83 is ~20 months old.
- The pin would also forgo pest 2.8.4–2.8.6 fixes.

## How the declaration became false

It was false from the day it was written. `rust-version = "1.70"` was introduced in 091afb6 (2026-04-13, "Declare MSRV of 1.70 for OnceLock") — chosen from the crate's own API usage — but the lockfile already contained pest 2.8.6 and faer 0.20.2 from the workspace restructure 07cc1b1 (2026-04-01), and had been lockfile-v4 since d3ec596 (2026-03-30). The floor never silently rose after declaration; the declaration was never accurate.

## Local toolchain proof (exact declared floor, no new CI per repo convention)

```
$ cargo +1.70 check -p turbovec
error: failed to parse lock file at: .../Cargo.lock
Caused by:
  lock file version `4` was found, but this version of Cargo does not understand this lock file

$ cargo +1.81 check -p turbovec
error: rustc 1.81.0 is not supported by the following packages:
  pest@2.8.6 requires rustc 1.83
  pest_derive@2.8.6 requires rustc 1.83
  pest_generator@2.8.6 requires rustc 1.83
  pest_meta@2.8.6 requires rustc 1.83

$ cargo +1.83 check -p turbovec
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 17.81s

$ cargo +1.83 check -p turbovec-python
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.78s
```

Full suite on stable: `cargo test -p turbovec` — **208 passed, 0 failed**.

## Scope

- `turbovec/Cargo.toml`, `turbovec-python/Cargo.toml`: `rust-version` → `1.83`
- `CHANGELOG.md`: Unreleased → Rust crate → Fixed entry
- `Cargo.lock` untouched; no docs/README carry MSRV statements (grepped)

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)