### PR TITLE
fix: LangChain store loudly rejects non-str ids at the add boundary (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,21 @@ appears under each surface it touches.
 
 #### Changed
 
+- **LangChain: non-`str` ids are now rejected with `TypeError` at the
+  add boundary** (`add_texts` / `aadd_texts` / `add_documents` /
+  `from_texts` and async variants), naming the offending id, its type,
+  and its position, before any embedding-store mutation. Previously an
+  off-contract id (the declared type is `list[str]`) was accepted
+  in-memory and then corrupted by JSON persistence: an `int` id `2`
+  round-tripped as the string `"2"`, and an int id coexisting with its
+  equal-looking str id (`2` + `"2"`) produced a duplicate JSON key on
+  `dump` that `load` collapsed — one document silently destroyed and
+  the side-car left unloadably out of sync with the index. This is a
+  deliberate safer-than-reference deviation: `InMemoryVectorStore`
+  accepts non-str ids and exhibits the same dump/load corruption.
+  `None` entries in an explicit ids list are still replaced with
+  generated UUIDs; `bool` (a subclass of `int`) is rejected like any
+  other non-str type. (#124)
 - **Default scoring of the four integration stores changes for
   non-unit-normalized embeddings.** Under the new `cosine` default the
   stores normalize documents at add time and queries at search time, so

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -75,6 +75,8 @@ store.add_documents([
 
 If an id is already present, `add_texts` **upserts** — the existing entry is removed and the new one added with the same id. This matches the typical user expectation that re-indexing a document with the same id should replace it, not duplicate it.
 
+Ids must be `str`. A `None` entry in an explicit ids list is replaced with a generated UUID; any other non-`str` id (including `bool`/`int`) raises `TypeError` — naming the offending id, its type, and its position — before anything is stored. This is stricter than `InMemoryVectorStore`, which accepts non-str ids and then corrupts them through JSON persistence (an `int` `2` coexisting with the `str` `"2"` collapses to one document across `dump`/`load`).
+
 Async equivalents (`aadd_texts`, `aadd_documents`) use the embedding model's `aembed_documents` so they benefit from concurrent embedding generation when the model supports it.
 
 ## Search

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -189,6 +189,40 @@ class TurboQuantVectorStore(VectorStore):
 
     # ---- Write path ---------------------------------------------------
 
+    @staticmethod
+    def _normalize_ids(ids: list[str]) -> list[str]:
+        """Return a fresh ``list[str]`` copy of ``ids`` with per-entry
+        ``None`` replaced by a generated UUID (matches the reference
+        InMemoryVectorStore and keeps None out of the JSON side-car,
+        where it would round-trip as the string ``"null"``).
+
+        Any other non-``str`` id raises ``TypeError``. This is a
+        deliberate deviation from the reference InMemoryVectorStore,
+        which accepts e.g. an ``int`` id and then corrupts it: JSON
+        persistence coerces every key to ``str``, so ``2`` and ``"2"``
+        are two documents in memory but collapse to one on ``dump``/
+        ``load`` — silent data loss plus an out-of-sync side-car.
+        Rejecting at the add boundary (the declared contract is
+        ``list[str]``) makes that state unrepresentable. ``bool`` is a
+        subclass of ``int`` and is rejected like any other non-str type:
+        only ``str`` instances (and ``None``) are accepted.
+        """
+        normalized: list[str] = []
+        for pos, id_ in enumerate(ids):
+            if id_ is None:
+                normalized.append(str(uuid.uuid4()))
+            elif isinstance(id_, str):
+                normalized.append(id_)
+            else:
+                raise TypeError(
+                    f"ids[{pos}] is {id_!r} of type {type(id_).__name__}; "
+                    "ids must be str (or None for a generated UUID). "
+                    "Non-str ids are rejected because JSON persistence "
+                    "coerces keys to str, silently colliding with any "
+                    "equal-looking str id (e.g. 2 vs '2') on dump/load."
+                )
+        return normalized
+
     def add_texts(
         self,
         texts: Iterable[str],
@@ -208,12 +242,10 @@ class TurboQuantVectorStore(VectorStore):
         if ids is None:
             ids = [str(uuid.uuid4()) for _ in texts_list]
         else:
-            # Build a fresh list (so the return value is always list[str],
-            # whatever container the caller passed) and replace per-entry
-            # None with a generated UUID — matches the reference
-            # InMemoryVectorStore and keeps None out of the JSON side-car,
-            # where it would round-trip as the string "null".
-            ids = [i if i is not None else str(uuid.uuid4()) for i in ids]
+            # Fresh list[str] (whatever container the caller passed),
+            # per-entry None -> UUID, any other non-str id -> TypeError.
+            # Raised here, before embedding or any store mutation.
+            ids = self._normalize_ids(list(ids))
         if len(metadatas) != len(texts_list) or len(ids) != len(texts_list):
             raise ValueError("texts, metadatas, and ids must all have the same length")
 
@@ -239,8 +271,8 @@ class TurboQuantVectorStore(VectorStore):
         if ids is None:
             ids = [str(uuid.uuid4()) for _ in texts_list]
         else:
-            # See add_texts: fresh list[str], per-entry None -> UUID.
-            ids = [i if i is not None else str(uuid.uuid4()) for i in ids]
+            # See add_texts: fresh list[str], None -> UUID, non-str -> TypeError.
+            ids = self._normalize_ids(list(ids))
         if len(metadatas) != len(texts_list) or len(ids) != len(texts_list):
             raise ValueError("texts, metadatas, and ids must all have the same length")
 

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -993,6 +993,114 @@ def test_aadd_texts_none_id_replaced_with_uuid():
     assert None not in store._docs
 
 
+@pytest.mark.parametrize(
+    "bad_id, type_name",
+    [
+        (2, "int"),
+        (2.5, "float"),
+        (True, "bool"),
+        (b"raw", "bytes"),
+        (("t",), "tuple"),
+    ],
+)
+def test_add_texts_rejects_nonstr_id(bad_id, type_name):
+    # Any non-str, non-None id must be rejected loudly at the add boundary
+    # with an error naming the offending id, its type, and its position —
+    # never accepted and later corrupted by JSON key coercion (issue #124).
+    # bool is a subclass of int and must be rejected too.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore(embedding=emb)
+    with pytest.raises(TypeError, match=rf"ids\[0\].*{type_name}"):
+        store.add_texts(["a"], ids=[bad_id])
+    assert store._docs == {}
+    assert store._str_to_u64 == {}
+
+
+def test_add_texts_nonstr_id_mid_batch_leaves_store_unchanged():
+    # A non-str id anywhere in a mixed batch must abort the whole add
+    # before any mutation — valid ids earlier in the batch must not have
+    # been stored, and pre-existing state must be untouched (issue #124).
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["alpha", "beta"], emb, ids=["a", "b"], metadatas=[{"k": 1}, {"k": 2}]
+    )
+    index_len_before = len(store._index)
+    docs_before = dict(store._docs)
+    str_to_u64_before = dict(store._str_to_u64)
+    u64_to_str_before = dict(store._u64_to_str)
+    next_u64_before = store._next_u64
+    search_before = [
+        (d.id, round(s, 5)) for d, s in store.similarity_search_with_score("alpha", k=2)
+    ]
+
+    with pytest.raises(TypeError, match=r"ids\[1\].*\bint\b"):
+        store.add_texts(["gamma", "delta"], ids=["ok", 3])
+
+    assert len(store._index) == index_len_before
+    assert store._docs == docs_before
+    assert store._str_to_u64 == str_to_u64_before
+    assert store._u64_to_str == u64_to_str_before
+    assert store._next_u64 == next_u64_before
+    assert [
+        (d.id, round(s, 5)) for d, s in store.similarity_search_with_score("alpha", k=2)
+    ] == search_before
+    assert [d.id for d in store.get_by_ids(["a", "b", "ok"])] == ["a", "b"]
+
+
+def test_int_str_id_collision_is_unreachable(tmp_path):
+    # The original issue-#124 corruption: int id 2 coexisting with str id
+    # "2" is two documents in memory but json.dump coerces the int key to
+    # "2", producing a duplicate JSON key that json.load collapses —
+    # silent data loss plus an unloadable side-car. With non-str ids
+    # rejected at add, that state can never be constructed.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore(embedding=emb)
+    store.add_texts(["strdoc"], ids=["2"])
+    with pytest.raises(TypeError, match=r"ids\[0\].*\bint\b"):
+        store.add_texts(["intdoc"], ids=[2])
+
+    # The store still holds exactly the one str-id document and
+    # round-trips it intact.
+    assert set(store._docs) == {"2"}
+    store.dump(tmp_path)
+    reloaded = TurboQuantVectorStore.load(tmp_path, emb)
+    assert set(reloaded._docs) == {"2"}
+    assert [d.page_content for d in reloaded.get_by_ids(["2"])] == ["strdoc"]
+
+
+def test_aadd_texts_rejects_nonstr_id():
+    import asyncio
+
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore(embedding=emb)
+    with pytest.raises(TypeError, match=r"ids\[0\].*\bint\b"):
+        asyncio.run(store.aadd_texts(["a"], ids=[2]))
+    assert store._docs == {}
+
+
+def test_add_documents_and_from_texts_reject_nonstr_id():
+    # add_documents and from_texts route through add_texts, so the same
+    # boundary rejection must fire there too.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore(embedding=emb)
+    with pytest.raises(TypeError, match=r"ids\[0\].*\bint\b"):
+        store.add_documents([Document(page_content="a")], ids=[7])
+    assert store._docs == {}
+    with pytest.raises(TypeError, match=r"ids\[1\].*\bfloat\b"):
+        TurboQuantVectorStore.from_texts(["a", "b"], emb, ids=["x", 1.5])
+
+
+def test_add_texts_str_ids_and_none_still_accepted():
+    # Happy-path pin: plain str ids and per-entry None (-> UUID) are the
+    # only accepted forms and keep working unchanged.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore(embedding=emb)
+    out = store.add_texts(["a", "b"], ids=["x", None])
+    assert out[0] == "x"
+    assert isinstance(out[1], str) and out[1] != "x"
+    assert set(store._docs) == set(out)
+
+
 def test_add_texts_tuple_ids_returns_list():
     # add_texts documents a list[str] return; a tuple of ids must come back
     # as a fresh list, not the caller's tuple (issue #126).


### PR DESCRIPTION
Closes the remainder of #124 (the None-id half shipped in #171).

## What

Per the maintainer ruling on #124: the LangChain store now **loudly rejects non-`str` ids at the add boundary**. In the shared id-normalization path used by `add_texts` / `aadd_texts` (and therefore `add_documents`, `aadd_documents`, `from_texts`, `afrom_texts`), any id that is not `None` and not `str` raises `TypeError` naming the offending id, its type, and its position — before any store mutation. `isinstance(id_, str)` is the only acceptance, so `bool` (an `int` subclass) is rejected too. `None` entries still become generated UUIDs (#171 behavior, pinned by tests).

## Why reject (repro evidence)

The reference `InMemoryVectorStore` accepts-and-corrupts. Verified on unfixed sources:

```
add id=2 (int, 'intdoc') and id="2" (str, 'strdoc')
# in-memory: distinct keys, docs=2, index count=2
dump(): "str_to_u64": {"2": 1, "2": 2}   # json.dump coerces int key 2 -> "2" => duplicate JSON key
load(): last-wins collapse -> 1 entry, one document silently destroyed,
        then ValueError: side-car handle count out of sync with the index -> store unloadable
```

Plus the single-id drift: `add_texts(["hello"], ids=[5])` round-trips as str `"5"`, so a later `get_by_ids([5])`/`delete([5])` misses. Rejecting at the boundary (the declared contract is `list[str]`) makes both states unrepresentable — a deliberate safer-than-reference deviation per the #152 precedent.

## Tests

New in `turbovec-python/tests/test_langchain.py` (all verified failing on unfixed sources — 9 failed / 1 pin passed — and passing with the fix):

- `test_add_texts_rejects_nonstr_id[int|float|bool|bytes|tuple]` — TypeError naming position + type, store unchanged
- `test_add_texts_nonstr_id_mid_batch_leaves_store_unchanged` — mixed batch aborts before any mutation (deep-state assertion: index len, `_docs`, `_str_to_u64`, `_u64_to_str`, `_next_u64`, search results)
- `test_int_str_id_collision_is_unreachable` — the original `2` vs `"2"` corruption scenario can no longer be constructed; surviving doc round-trips intact
- `test_aadd_texts_rejects_nonstr_id`, `test_add_documents_and_from_texts_reject_nonstr_id` — every entry point covered
- `test_add_texts_str_ids_and_none_still_accepted` — happy-path + None→UUID pin

Full suite: **597 passed, 0 failed** (587 baseline post-#211 + 10 new). #208 locking and #211 similarity modes untouched.

## Docs

- CHANGELOG: Python package → Changed (off-contract ids now rejected; was silent corruption through dump/load; safer-than-reference note)
- `docs/integrations/langchain.md`: ids contract documented under "Adding with explicit ids"

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
