### PR TITLE
fix: LlamaIndex dotted-namespace stem collision + legacy fallback; document node_ids=[] semantics (#200, #130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -300,6 +300,23 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **LlamaIndex: dotted namespaces no longer silently collide in a shared
+  `persist_dir`.** The persistence stem handling used `with_suffix`,
+  which re-split the stem at its last dot, so namespaces `v1.2` and
+  `v1.3` both persisted to `v1.tvim` / `v1.nodes.json` — the second
+  persist silently overwrote the first (data loss), and
+  `from_persist_dir(namespace="v1.2")` returned the other namespace's
+  data. Extensions are now appended to the full namespace-derived stem
+  (`v1.2__vector_store.tvim` / `v1.2__vector_store.nodes.json`), so
+  dotted namespaces coexist. Non-dotted namespaces keep byte-identical
+  file paths — no migration. A store persisted by an earlier release
+  under a dotted namespace still loads: when the correct filename is
+  absent but the old mangled one exists, `from_persist_path` falls back
+  to it (safe — the mangling meant at most one store could survive per
+  mangled prefix), and the next `persist` writes the correct names.
+  `_validate_namespace` additionally rejects `:` (a Windows
+  drive-relative name like `C:foo` escapes `persist_dir` with no
+  separator), extending the #152/#197 guard. (#200)
 - **Threshold and relevance-score paths are no longer broken for
   non-unit-normalized embeddings** (the three wave-8 findings on #114
   — all symptoms of the mappings assuming cosine input while the

--- a/docs/integrations/llama_index.md
+++ b/docs/integrations/llama_index.md
@@ -144,6 +144,8 @@ Filter semantics match `SimpleVectorStore`'s reference implementation — notabl
 
 Filters are resolved to a handle allowlist **before** scoring. Selective filters return up to `similarity_top_k` matches from the filtered set; you never get fewer just because the filter happened to exclude the top-scoring candidates.
 
+An **empty** `node_ids` (or `doc_ids`) list restricts nothing — it behaves like omitting the argument. This follows the framework's own calling convention: `VectorStoreIndex.as_retriever` passes `node_ids=list(index_struct.nodes_dict.values())`, and for a `stores_text=True` store like this one that list is always empty — it means "unrestricted", and treating it as match-nothing would make every retriever query return zero results. `get_nodes` / `delete_nodes` are different: there `node_ids` *is* the selection, so an explicit empty list selects nothing.
+
 ## Get nodes
 
 ```python
@@ -152,7 +154,7 @@ nodes = vector_store.get_nodes(filters=filters)
 nodes = vector_store.get_nodes(node_ids=["chunk-1", "chunk-2"], filters=filters)  # intersect
 ```
 
-Returns a `List[BaseNode]` reconstructed from the side-car. Missing `node_id`s are silently skipped.
+Returns a `List[BaseNode]` reconstructed from the side-car. Missing `node_id`s are silently skipped. `node_ids` is the explicit selection: an empty list selects nothing and returns `[]` (same for `delete_nodes`, where an empty list is a no-op).
 
 ## Upsert semantics
 
@@ -215,7 +217,9 @@ storage_context = StorageContext.from_defaults(
 )
 ```
 
-`from_persist_dir(persist_dir, namespace="default", fs=None)` constructs the namespaced filename (`{persist_dir}/{namespace}__vector_store.json`) and delegates to `from_persist_path`. Multiple namespaced stores can share a persist directory. `namespace` names a store *within* `persist_dir`, so it must be non-empty and must not contain path separators or `..`; a value that would resolve outside `persist_dir` raises `ValueError`. Any other string (alphanumerics, dash, underscore) is accepted; a dotted namespace is truncated at its first dot by the current persistence layout, so avoid dotted namespaces that share a prefix in one persist directory.
+`from_persist_dir(persist_dir, namespace="default", fs=None)` constructs the namespaced filename (`{persist_dir}/{namespace}__vector_store.json`) and delegates to `from_persist_path`. Multiple namespaced stores can share a persist directory — including dotted namespaces (`v1.2`, `v1.3`), which map to distinct file pairs (`v1.2__vector_store.tvim` / `v1.2__vector_store.nodes.json`, and so on). `namespace` names a store *within* `persist_dir`, so it must be non-empty and must not contain path separators, `..`, or `:` (a Windows drive-relative name like `C:foo` would escape `persist_dir`); such a value raises `ValueError`. Any other string (alphanumerics, dash, underscore, dots) is accepted.
+
+A store persisted by an older turbovec under a dotted namespace sits on disk under a truncated filename (`v1.tvim` for namespace `v1.2`). Loading finds it via a legacy-filename fallback — used only when the correct filename is absent — and the next `persist` writes the correct filenames.
 
 ### Config-only round-trip
 

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -88,14 +88,15 @@ def _validate_namespace(namespace: str) -> str:
 
     ``from_persist_dir`` builds ``{persist_dir}/{namespace}__vector_store.json``.
     A ``namespace`` containing a path separator or ``..`` resolves outside
-    ``persist_dir`` (path traversal), and an empty/``.`` namespace names the
-    directory itself rather than a store file. We reject these loudly rather
-    than silently basenaming them — silent rewriting could load a *different*
-    store than the caller named. Any other namespace is accepted verbatim
-    (alphanumerics, dash, underscore, and other non-separator characters).
-    Note a dotted namespace is truncated at its first dot by the current
-    persistence layout, so two dotted namespaces sharing a prefix (e.g.
-    ``v1.2`` and ``v1.3``) collide in one ``persist_dir`` — see issue #200.
+    ``persist_dir`` (path traversal), an empty/``.`` namespace names the
+    directory itself rather than a store file, and a ``:`` forms a
+    Windows drive-relative name (``C:foo``) that escapes ``persist_dir``
+    without any separator. We reject these loudly rather than silently
+    basenaming them — silent rewriting could load a *different* store
+    than the caller named. Any other namespace is accepted verbatim
+    (alphanumerics, dash, underscore, dots, and other non-separator
+    characters); dotted namespaces such as ``v1.2`` map to distinct
+    file pairs and coexist in one ``persist_dir``.
 
     This is a deliberate divergence from ``SimpleVectorStore``, which does
     not sanitize its namespace, in the safer direction.
@@ -110,18 +111,51 @@ def _validate_namespace(namespace: str) -> str:
             f"'..'; got {namespace!r}. It names a store within persist_dir, "
             "not a path."
         )
+    if ":" in namespace:
+        raise ValueError(
+            "namespace must not contain ':' (a Windows drive-relative name "
+            f"like 'C:foo' escapes persist_dir); got {namespace!r}. It "
+            "names a store within persist_dir, not a path."
+        )
     return namespace
 
 
 def _split_persist_base(persist_path: str | Path) -> Path:
-    """Strip the framework-provided extension off `persist_path` so the
-    binary index and JSON side-car can sit next to each other under a
-    shared base. We then append our own extensions in persist / load."""
+    """Derive the on-disk base from ``persist_path``: the binary index is
+    written to ``{base}.tvim`` and the node side-car to
+    ``{base}.nodes.json`` (extensions *appended* — see ``_with_ext``).
+
+    Only a trailing ``.json`` — the conventional extension the framework
+    hands us via ``{namespace}__vector_store.json`` — is stripped; every
+    other character of the name is kept verbatim, including dots from a
+    dotted namespace. ``v1.2__vector_store.json`` and
+    ``v1.3__vector_store.json`` therefore map to distinct file pairs.
+    (The previous ``with_suffix``-based implementation re-split the stem
+    at its last dot when appending extensions, so dotted namespaces
+    sharing a prefix silently overwrote each other — issue #200.)"""
     p = Path(persist_path)
-    # Use the path without its suffix so both .tvim and .nodes.json share
-    # a base. If the input has no suffix (e.g. a bare folder-like name),
-    # use it as-is.
-    return p.with_suffix("") if p.suffix else p
+    if p.name.endswith(".json") and p.name != ".json":
+        return p.with_name(p.name[: -len(".json")])
+    return p
+
+
+def _with_ext(base: Path, ext: str) -> Path:
+    """Append ``ext`` to ``base``'s filename verbatim. Never
+    ``with_suffix`` — that would strip everything after the last dot of
+    a dotted stem (issue #200)."""
+    return base.with_name(base.name + ext)
+
+
+def _legacy_split_persist_base(persist_path: str | Path) -> tuple[Path, Path]:
+    """Reproduce the pre-#200 (mangled) index/side-car paths for
+    ``persist_path``: the old code stripped the last extension, then
+    ``with_suffix`` stripped from the last remaining dot again when
+    appending ``.tvim`` / ``.nodes.json`` — so namespace ``v1.2``
+    produced ``v1.tvim`` / ``v1.nodes.json``. Used only as a load-time
+    fallback for stores persisted by earlier releases."""
+    p = Path(persist_path)
+    base = p.with_suffix("") if p.suffix else p
+    return base.with_suffix(_INDEX_EXT), base.with_suffix(_STORE_EXT)
 
 
 class TurboQuantVectorStore(BasePydanticVectorStore):
@@ -388,6 +422,9 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
     ) -> None:
         """Delete every node matching ``node_ids`` and/or ``filters``. Both
         constraints intersect when supplied. Missing node_ids are ignored.
+        ``node_ids`` is the explicit selection here: an empty list selects
+        nothing (a no-op), unlike ``query``'s ``node_ids=[]``, which
+        follows the retriever calling convention and restricts nothing.
         Matches the signature and semantics of ``SimpleVectorStore.delete_nodes``.
         """
         if not node_ids and filters is None:
@@ -440,7 +477,10 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
     ) -> List[BaseNode]:
         """Return the nodes matching ``node_ids`` and/or ``filters``. Both
         constraints intersect when supplied; missing node_ids are
-        silently skipped.
+        silently skipped. ``node_ids`` is the explicit selection here: an
+        empty list selects nothing and returns ``[]``, unlike ``query``'s
+        ``node_ids=[]``, which follows the retriever calling convention
+        and restricts nothing.
 
         Unlike ``SimpleVectorStore`` (which raises NotImplementedError
         here because it doesn't store nodes), turbovec keeps node text
@@ -515,14 +555,31 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         doc_ids: list[str] | None,
     ) -> list[int]:
         """Resolve ``query.filters``, ``query.node_ids`` and ``query.doc_ids``
-        to the list of internal u64 handles that satisfy the filter. Empty
-        list means no node matches.
+        to the list of internal u64 handles that satisfy the constraints.
+        An empty *return* means no node satisfies them.
 
-        Semantics (matching the SimpleVectorStore reference where applicable):
-          - ``node_ids``: filter by node_id (set membership).
-          - ``doc_ids``: filter by ``ref_doc_id`` only (source document id).
+        Semantics:
+          - ``node_ids``: filter by node_id (set membership). An **empty
+            list restricts nothing** — it is treated the same as ``None``.
+            This matches the framework's own calling convention:
+            ``VectorStoreIndex.as_retriever`` passes
+            ``node_ids=list(index_struct.nodes_dict.values())``
+            (llama_index/core/indices/vector_store/base.py), and for a
+            ``stores_text=True`` store like this one ``nodes_dict`` stays
+            empty (only Image/Index nodes are tracked there) — so every
+            retriever query arrives with ``node_ids=[]`` meaning
+            *unrestricted*. Treating ``[]`` as match-nothing would make
+            every ``VectorStoreIndex`` retrieval return zero results
+            (maintainer ruling on issue #130).
+          - ``doc_ids``: filter by ``ref_doc_id`` only (source document
+            id). Same convention: an empty list restricts nothing — as in
+            the ``SimpleVectorStore`` reference.
           - ``filters``: apply metadata filters.
-        All three intersect when more than one is supplied.
+        All supplied non-empty constraints intersect.
+
+        Contrast ``get_nodes`` / ``delete_nodes``: those are direct
+        node-selection APIs where ``node_ids`` *is* the selection, so an
+        explicit empty list there selects nothing.
         """
         # list() snapshot: this runs on the (lock-free) query path, so a
         # concurrent writer must not invalidate the iteration mid-scan.
@@ -683,6 +740,9 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         if len(self._index) == 0:
             return VectorStoreQueryResult(nodes=[], similarities=[], ids=[])
 
+        # Truthiness is deliberate: node_ids=[] / doc_ids=[] mean "no
+        # restriction", per the retriever calling convention — see the
+        # _resolve_allowed_handles docstring (issue #130 ruling).
         has_filters = (
             query.filters is not None
             or bool(query.node_ids)
@@ -833,8 +893,11 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
     def persist(self, persist_path: str, fs: Any = None) -> None:
         """Persist the store. ``persist_path`` is treated as a path *stem*:
         the binary index goes to ``{stem}.tvim`` and the node side-car to
-        ``{stem}.nodes.json``. Any extension on ``persist_path`` (e.g.
-        ``.json`` from a StorageContext default) is replaced.
+        ``{stem}.nodes.json``. A trailing ``.json`` extension (the
+        StorageContext default) is stripped from ``persist_path`` first;
+        dots anywhere else in the name (e.g. a dotted namespace like
+        ``v1.2``) are preserved verbatim, so dotted namespaces sharing a
+        prefix persist to distinct file pairs (issue #200).
 
         This matches the layout assumed by ``StorageContext.persist`` —
         which calls us with ``persist_path = {persist_dir}/{namespace}__vector_store.json`` —
@@ -870,9 +933,9 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
             # so a failed persist can't destroy a previous store at this path.
             atomic_save(
                 self._index,
-                base.with_suffix(_INDEX_EXT),
+                _with_ext(base, _INDEX_EXT),
                 payload,
-                base.with_suffix(_STORE_EXT),
+                _with_ext(base, _STORE_EXT),
             )
 
     @classmethod
@@ -882,8 +945,17 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         fs: Any = None,
     ) -> "TurboQuantVectorStore":
         """Load a previously-persisted store. ``persist_path`` is the same
-        path that was passed to :meth:`persist` (extension is ignored;
-        ``{stem}.tvim`` and ``{stem}.nodes.json`` are read).
+        path that was passed to :meth:`persist` (a trailing ``.json`` is
+        ignored; ``{stem}.tvim`` and ``{stem}.nodes.json`` are read).
+
+        Legacy fallback: releases before the #200 fix mangled dotted
+        stems (namespace ``v1.2`` persisted as ``v1.tvim`` /
+        ``v1.nodes.json``). If the correct filename is absent but the
+        old mangled one exists, that pair is loaded instead — safe
+        because the mangling made colliding namespaces overwrite each
+        other, so at most one store can exist under a given mangled
+        prefix. A subsequent :meth:`persist` writes the correct
+        (unmangled) filenames.
 
         Safe to call on any path — the side-car is plain JSON, never
         pickle, so there's no deserialization-of-code risk.
@@ -893,8 +965,14 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
                 "fsspec filesystems are not supported yet; pass a local path."
             )
         base = _split_persist_base(persist_path)
-        index = IdMapIndex.load(str(base.with_suffix(_INDEX_EXT)))
-        with open(base.with_suffix(_STORE_EXT)) as f:
+        index_path = _with_ext(base, _INDEX_EXT)
+        store_path = _with_ext(base, _STORE_EXT)
+        if not index_path.exists():
+            legacy_index, legacy_store = _legacy_split_persist_base(persist_path)
+            if legacy_index != index_path and legacy_index.exists():
+                index_path, store_path = legacy_index, legacy_store
+        index = IdMapIndex.load(str(index_path))
+        with open(store_path) as f:
             state = json.load(f)
         version = state.get("schema_version", 0)
         if version not in _NODES_SCHEMA_COMPAT:
@@ -953,9 +1031,12 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         extensions derived from the same stem.
 
         ``namespace`` names a store *within* ``persist_dir``; it must not
-        contain path separators or ``..`` and must be non-empty. A traversal
-        namespace raises ``ValueError`` rather than reading outside
-        ``persist_dir``.
+        contain path separators, ``..``, or ``:`` and must be non-empty. A
+        traversal (or Windows drive-relative) namespace raises
+        ``ValueError`` rather than reading outside ``persist_dir``.
+        Dotted namespaces (``v1.2``) are fine and coexist; a store
+        persisted by a pre-#200 release under a dotted namespace is found
+        via the legacy-filename fallback in :meth:`from_persist_path`.
         """
         _validate_namespace(namespace)
         persist_fname = f"{namespace}{_NAMESPACE_SEP}{_DEFAULT_PERSIST_FNAME}"

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -255,12 +255,14 @@ def test_from_persist_dir_with_custom_namespace(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "bad_namespace", ["../x", "a/b", "a\\b", "..", "", "."]
+    "bad_namespace", ["../x", "a/b", "a\\b", "..", "", ".", "C:foo", "a:b"]
 )
 def test_from_persist_dir_rejects_traversal_namespace(tmp_path, bad_namespace):
     # Issue #152: a namespace containing a path separator or `..` (or an
     # empty/`.` namespace) would escape persist_dir when composed into the
     # side-car filename. We reject it loudly rather than silently basenaming.
+    # Issue #200 extended the guard to ':' — a Windows drive-relative name
+    # (`C:foo`) escapes persist_dir without any separator.
     with pytest.raises(ValueError, match="namespace"):
         TurboQuantVectorStore.from_persist_dir(
             str(tmp_path), namespace=bad_namespace
@@ -284,11 +286,9 @@ def test_from_persist_dir_traversal_does_not_read_outside(tmp_path):
 
 def test_from_persist_dir_legit_namespace_with_dot_roundtrips(tmp_path):
     # A dotted namespace (e.g. a version tag) is accepted, not rejected —
-    # only `..` and path separators are. This pins single-store behavior.
-    # Caveat: the current persistence layout truncates the stem at the first
-    # dot, so two dotted namespaces sharing a prefix (v1.2 / v1.3) collide in
-    # one persist_dir — a pre-existing bug tracked in issue #200, out of
-    # scope for the #152 traversal fix.
+    # only `..`, path separators, and ':' are. This pins single-store
+    # behavior; sibling dotted namespaces coexisting is pinned separately
+    # below (issue #200).
     store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
     store.add([_make_node("versioned", seed=0)])
     store.persist(str(tmp_path / "v1.2__vector_store.json"))
@@ -296,6 +296,86 @@ def test_from_persist_dir_legit_namespace_with_dot_roundtrips(tmp_path):
         str(tmp_path), namespace="v1.2"
     )
     assert len(loaded._nodes) == 1
+
+
+def test_dotted_namespaces_coexist_in_shared_persist_dir(tmp_path):
+    # Issue #200 collision repro: v1.2 and v1.3 share a persist_dir. The
+    # old with_suffix-based stem handling truncated both to `v1.tvim` /
+    # `v1.nodes.json`, so the second persist silently overwrote the first
+    # and from_persist_dir("v1.2") returned v1.3's data. Each namespace
+    # must map to its own file pair and round-trip its own data.
+    store_a = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    node_a = _make_node("data for v1.2", seed=1)
+    store_a.add([node_a])
+    store_a.persist(str(tmp_path / "v1.2__vector_store.json"))
+
+    store_b = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    node_b = _make_node("data for v1.3", seed=2)
+    store_b.add([node_b])
+    store_b.persist(str(tmp_path / "v1.3__vector_store.json"))
+
+    # Distinct, unmangled file pairs on disk.
+    assert (tmp_path / "v1.2__vector_store.tvim").exists()
+    assert (tmp_path / "v1.2__vector_store.nodes.json").exists()
+    assert (tmp_path / "v1.3__vector_store.tvim").exists()
+    assert (tmp_path / "v1.3__vector_store.nodes.json").exists()
+    assert not (tmp_path / "v1.tvim").exists()
+
+    loaded_a = TurboQuantVectorStore.from_persist_dir(
+        str(tmp_path), namespace="v1.2"
+    )
+    loaded_b = TurboQuantVectorStore.from_persist_dir(
+        str(tmp_path), namespace="v1.3"
+    )
+    assert [n.get_content() for n in loaded_a.get_nodes()] == ["data for v1.2"]
+    assert [n.get_content() for n in loaded_b.get_nodes()] == ["data for v1.3"]
+    assert loaded_a.get_nodes()[0].node_id == node_a.node_id
+    assert loaded_b.get_nodes()[0].node_id == node_b.node_id
+
+
+def test_from_persist_dir_loads_legacy_mangled_dotted_store(tmp_path):
+    # A store persisted by a pre-#200 release under a dotted namespace
+    # sits on disk under the MANGLED names (`v1.tvim` / `v1.nodes.json`
+    # for namespace v1.2 — with_suffix stripped from the stem's last
+    # dot). The load path must fall back to those names when the correct
+    # ones are absent. Safe by construction: the mangling made colliding
+    # namespaces overwrite each other, so at most one store exists per
+    # mangled prefix.
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    node = _make_node("legacy data", seed=3)
+    store.add([node])
+    store.persist(str(tmp_path / "v1.2__vector_store.json"))
+    # Rename to the exact byte-paths the old code produced (verified
+    # against main's _split_persist_base + with_suffix pipeline).
+    (tmp_path / "v1.2__vector_store.tvim").rename(tmp_path / "v1.tvim")
+    (tmp_path / "v1.2__vector_store.nodes.json").rename(tmp_path / "v1.nodes.json")
+
+    loaded = TurboQuantVectorStore.from_persist_dir(
+        str(tmp_path), namespace="v1.2"
+    )
+    assert [n.get_content() for n in loaded.get_nodes()] == ["legacy data"]
+    assert loaded.get_nodes()[0].node_id == node.node_id
+
+    # Re-persisting writes the correct (unmangled) filenames.
+    loaded.persist(str(tmp_path / "v1.2__vector_store.json"))
+    assert (tmp_path / "v1.2__vector_store.tvim").exists()
+    assert (tmp_path / "v1.2__vector_store.nodes.json").exists()
+
+
+def test_non_dotted_namespace_filenames_unchanged(tmp_path):
+    # No migration for non-dotted namespaces: the #200 stem fix must
+    # produce byte-identical file paths to the previous release
+    # (`{namespace}__vector_store.tvim` / `.nodes.json`), so existing
+    # stores keep loading with no fallback involved.
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([_make_node("plain", seed=4)])
+    store.persist(str(tmp_path / "default__vector_store.json"))
+    assert sorted(p.name for p in tmp_path.iterdir()) == [
+        "default__vector_store.nodes.json",
+        "default__vector_store.tvim",
+    ]
+    loaded = TurboQuantVectorStore.from_persist_dir(str(tmp_path))
+    assert [n.get_content() for n in loaded.get_nodes()] == ["plain"]
 
 
 def test_add_accepts_generator_input():
@@ -505,6 +585,46 @@ def test_query_with_node_ids_filter():
     result = store.query(q)
     assert len(result.nodes) == 2
     assert {n.node_id for n in result.nodes} == set(keep)
+
+
+def test_query_empty_node_ids_means_no_restriction():
+    # Maintainer ruling on issue #130: `query(node_ids=[])` restricts
+    # NOTHING — it returns the unrestricted top-k. This pins the
+    # framework calling convention: VectorStoreIndex.as_retriever passes
+    # node_ids=list(index_struct.nodes_dict.values()), and for a
+    # stores_text=True store nodes_dict stays empty — so every retriever
+    # query arrives with node_ids=[] meaning "unrestricted". Treating []
+    # as match-nothing would make every VectorStoreIndex retrieval over
+    # this store return zero results.
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [_make_node(f"doc {i}", seed=i) for i in range(4)]
+    store.add(nodes)
+
+    unrestricted = store.query(
+        VectorStoreQuery(query_embedding=_unit_vec(0, 64), similarity_top_k=4)
+    )
+    with_empty = store.query(
+        VectorStoreQuery(
+            query_embedding=_unit_vec(0, 64), similarity_top_k=4, node_ids=[]
+        )
+    )
+    assert len(with_empty.nodes) == 4
+    assert with_empty.ids == unrestricted.ids
+    assert with_empty.similarities == unrestricted.similarities
+
+    # doc_ids=[] follows the same convention (as in SimpleVectorStore).
+    with_empty_docs = store.query(
+        VectorStoreQuery(
+            query_embedding=_unit_vec(0, 64), similarity_top_k=4, doc_ids=[]
+        )
+    )
+    assert with_empty_docs.ids == unrestricted.ids
+
+    # Contrast: get_nodes / delete_nodes are direct node-selection APIs —
+    # an explicit empty list there is an empty selection.
+    assert store.get_nodes(node_ids=[]) == []
+    store.delete_nodes(node_ids=[])  # no-op
+    assert len(store.get_nodes()) == 4
 
 
 def test_query_with_doc_ids_filter_matches_ref_doc_id_only():


### PR DESCRIPTION
Closes #130
Closes #200

Two ruled LlamaIndex fixes in one component-scoped PR.

## #200 — dotted-namespace stem collision (silent data loss)

`_split_persist_base` and the persist/load paths used `with_suffix`, which strips from the last dot of the stem. Repro (verified on main d3aeaf8):

```
persist v1.2 and v1.3 in the same dir -> files: ['v1.nodes.json', 'v1.tvim']
from_persist_dir(namespace="v1.2")    -> the v1.3 store's data   # v1.3 overwrote v1.2
```

Fix:
- Filenames are built by **appending** `.tvim` / `.nodes.json` to the full namespace-derived stem — `v1.2__vector_store.json` → `v1.2__vector_store.tvim` / `v1.2__vector_store.nodes.json`. Caller dots are never stripped (only the trailing conventional `.json` is). The issue's collision repro now fails to collide; each namespace round-trips its own data.
- **Legacy fallback:** `from_persist_path` falls back to the old mangled names (`v1.tvim` for namespace `v1.2`) when the correct filename is absent — safe because the mangling meant at most one store could survive per mangled prefix. Verified end-to-end against a fixture persisted by **main's actual code** (`git show d3aeaf8:...llama_index.py`): main wrote `['v1.nodes.json', 'v1.tvim']`, branch `from_persist_dir(namespace="v1.2")` loaded the node intact. The next `persist` writes the correct names.
- **Non-dotted namespaces: byte-identical paths before/after** (`default__vector_store.tvim` / `.nodes.json`) — no migration, no fallback involved; pinned by exact-directory-listing test.
- `_validate_namespace` now also rejects `:` anywhere (Windows drive-relative `C:foo` escapes `persist_dir` with no separator); all existing #152/#197 rejections kept.
- The `nodes.json` v3 schema handling (#211) is untouched — the fix is filename-only.

## #130 — `query(node_ids=[])`: KEEP []-means-no-restriction; document reality

Per the maintainer ruling, behavior is kept and the false docstring claim ("Empty list means no node matches") is fixed. Framework evidence (cited in the code): `VectorStoreIndex.as_retriever` passes `node_ids=list(index_struct.nodes_dict.values())` (llama_index/core/indices/vector_store/base.py), and for a `stores_text=True` store `nodes_dict` stays empty — so **every** retriever query arrives with `node_ids=[]` meaning *unrestricted*. Treating `[]` as match-nothing would make every `VectorStoreIndex` retrieval over turbovec return zero results. Verified against llama-index-core 0.14.23.

The docs now tell one coherent story: `query`'s `node_ids`/`doc_ids` follow the retriever calling convention (`[]` = no restriction); `get_nodes` / `delete_nodes` are direct node-selection APIs where `node_ids` *is* the selection (`[]` selects nothing / no-op) — their current behavior, now documented. Updated: `_resolve_allowed_handles`, `get_nodes`, `delete_nodes` docstrings, a comment at `query`'s `has_filters`, and `docs/integrations/llama_index.md`.

## Tests

New in `turbovec-python/tests/test_llama_index.py`:

- `test_dotted_namespaces_coexist_in_shared_persist_dir` — the collision repro; fails on main ("data for v1.3" loaded under namespace v1.2), passes on the branch with unmangled file pairs asserted
- `test_from_persist_dir_loads_legacy_mangled_dotted_store` — legacy fallback (exact mangled byte-paths, verified against main's persist output) + re-persist writes correct names
- `test_non_dotted_namespace_filenames_unchanged` — exact directory listing pin (passes on main and branch: no migration)
- `test_query_empty_node_ids_means_no_restriction` — `node_ids=[]` / `doc_ids=[]` return the unrestricted top-k, `get_nodes([])`/`delete_nodes([])` are empty-selection (pin; passes on main too — behavior kept)
- `test_from_persist_dir_rejects_traversal_namespace` extended with `C:foo` and `a:b` (fail on main, pass on branch); full existing rejection matrix still green
- `test_from_persist_dir_legit_namespace_with_dot_roundtrips` — #197-era collision caveat comment dropped (now false)

Bite verified on unfixed sources: 4 failed (coexist, legacy-fallback setup, `C:foo`, `a:b`), pins passed.

Full suite: **593 passed, 0 failed** (587 baseline post-#211 + 6 new).

## Docs

- CHANGELOG: Python package → Fixed (#200; collision was silent data loss)
- `docs/integrations/llama_index.md`: namespace section rewritten steady-state (truncation caveat dropped — now false; fixed behavior + legacy fallback described), filtered-query section documents the `[]` convention

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
