### PR TITLE
Add insertion + removal speed benchmarks to benchmarks/suite/ (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -471,6 +471,19 @@ appears under each surface it touches.
 
 ### Benchmarks
 
+- Insertion and removal speed benchmarks join the suite. (#65) For every
+  published search-speed cell (d=1536/3072 × 2-bit/4-bit × ARM/x86 ×
+  ST/MT), `benchmarks/suite/` gains `speed_insert_*` — bulk `add()` into
+  an empty index (rotation/codebook init + TQ+ calibration fit included),
+  a warm append with calibration frozen (the steady-state encode path),
+  single-vector `add()` latency, and a FAISS `IndexPQFastScan` bulk-add
+  baseline — and `speed_remove_*` — `IdMapIndex.remove(id)` per-op
+  latency and throughput against a raw `TurboQuantIndex.swap_remove`
+  baseline, isolating the id-map layer's bookkeeping. Fresh index per
+  timed run (add is cumulative, remove shrinks the index), fixed seeds,
+  median of 5, results in `benchmarks/results/` like the rest of the
+  suite. ARM (Apple M3 Max) results are recorded; x86 cells await a run
+  on the reference bench instance.
 - `benchmarks/download_data.py` downloads to a `.tmp` sibling and renames
   into place on success, so an interrupted download no longer leaves a
   partial file at the final path that the existence guard then treats as

--- a/benchmarks/results/speed_insert_d1536_2bit_arm_mt.json
+++ b/benchmarks/results/speed_insert_d1536_2bit_arm_mt.json
@@ -1,0 +1,10 @@
+{
+  "dim": 1536,
+  "bit_width": 2,
+  "arch": "arm",
+  "threading": "mt",
+  "tq_bulk_insert_vecs_per_sec": 51445,
+  "tq_warm_insert_vecs_per_sec": 85439,
+  "tq_single_add_us": 65.52,
+  "faiss_bulk_insert_vecs_per_sec": 125338
+}

--- a/benchmarks/results/speed_insert_d1536_2bit_arm_st.json
+++ b/benchmarks/results/speed_insert_d1536_2bit_arm_st.json
@@ -1,0 +1,10 @@
+{
+  "dim": 1536,
+  "bit_width": 2,
+  "arch": "arm",
+  "threading": "st",
+  "tq_bulk_insert_vecs_per_sec": 21001,
+  "tq_warm_insert_vecs_per_sec": 80819,
+  "tq_single_add_us": 65.43,
+  "faiss_bulk_insert_vecs_per_sec": 45799
+}

--- a/benchmarks/results/speed_insert_d1536_4bit_arm_mt.json
+++ b/benchmarks/results/speed_insert_d1536_4bit_arm_mt.json
@@ -1,0 +1,10 @@
+{
+  "dim": 1536,
+  "bit_width": 4,
+  "arch": "arm",
+  "threading": "mt",
+  "tq_bulk_insert_vecs_per_sec": 33759,
+  "tq_warm_insert_vecs_per_sec": 81363,
+  "tq_single_add_us": 99.76,
+  "faiss_bulk_insert_vecs_per_sec": 83536
+}

--- a/benchmarks/results/speed_insert_d1536_4bit_arm_st.json
+++ b/benchmarks/results/speed_insert_d1536_4bit_arm_st.json
@@ -1,0 +1,10 @@
+{
+  "dim": 1536,
+  "bit_width": 4,
+  "arch": "arm",
+  "threading": "st",
+  "tq_bulk_insert_vecs_per_sec": 23679,
+  "tq_warm_insert_vecs_per_sec": 78900,
+  "tq_single_add_us": 79.87,
+  "faiss_bulk_insert_vecs_per_sec": 35065
+}

--- a/benchmarks/results/speed_insert_d3072_2bit_arm_mt.json
+++ b/benchmarks/results/speed_insert_d3072_2bit_arm_mt.json
@@ -1,0 +1,10 @@
+{
+  "dim": 3072,
+  "bit_width": 2,
+  "arch": "arm",
+  "threading": "mt",
+  "tq_bulk_insert_vecs_per_sec": 14289,
+  "tq_warm_insert_vecs_per_sec": 31355,
+  "tq_single_add_us": 810.6,
+  "faiss_bulk_insert_vecs_per_sec": 62122
+}

--- a/benchmarks/results/speed_insert_d3072_2bit_arm_st.json
+++ b/benchmarks/results/speed_insert_d3072_2bit_arm_st.json
@@ -1,0 +1,10 @@
+{
+  "dim": 3072,
+  "bit_width": 2,
+  "arch": "arm",
+  "threading": "st",
+  "tq_bulk_insert_vecs_per_sec": 8054,
+  "tq_warm_insert_vecs_per_sec": 34913,
+  "tq_single_add_us": 879.16,
+  "faiss_bulk_insert_vecs_per_sec": 25500
+}

--- a/benchmarks/results/speed_insert_d3072_4bit_arm_mt.json
+++ b/benchmarks/results/speed_insert_d3072_4bit_arm_mt.json
@@ -1,0 +1,10 @@
+{
+  "dim": 3072,
+  "bit_width": 4,
+  "arch": "arm",
+  "threading": "mt",
+  "tq_bulk_insert_vecs_per_sec": 11808,
+  "tq_warm_insert_vecs_per_sec": 28962,
+  "tq_single_add_us": 839.78,
+  "faiss_bulk_insert_vecs_per_sec": 35914
+}

--- a/benchmarks/results/speed_insert_d3072_4bit_arm_st.json
+++ b/benchmarks/results/speed_insert_d3072_4bit_arm_st.json
@@ -1,0 +1,10 @@
+{
+  "dim": 3072,
+  "bit_width": 4,
+  "arch": "arm",
+  "threading": "st",
+  "tq_bulk_insert_vecs_per_sec": 5359,
+  "tq_warm_insert_vecs_per_sec": 19866,
+  "tq_single_add_us": 1395.33,
+  "faiss_bulk_insert_vecs_per_sec": 10761
+}

--- a/benchmarks/results/speed_remove_d1536_2bit_arm_mt.json
+++ b/benchmarks/results/speed_remove_d1536_2bit_arm_mt.json
@@ -1,0 +1,9 @@
+{
+  "dim": 1536,
+  "bit_width": 2,
+  "arch": "arm",
+  "threading": "mt",
+  "tq_idmap_remove_us_per_op": 0.727,
+  "tq_idmap_removes_per_sec": 1375376,
+  "tq_swap_remove_us_per_op": 0.597
+}

--- a/benchmarks/results/speed_remove_d1536_2bit_arm_st.json
+++ b/benchmarks/results/speed_remove_d1536_2bit_arm_st.json
@@ -1,0 +1,9 @@
+{
+  "dim": 1536,
+  "bit_width": 2,
+  "arch": "arm",
+  "threading": "st",
+  "tq_idmap_remove_us_per_op": 0.384,
+  "tq_idmap_removes_per_sec": 2601000,
+  "tq_swap_remove_us_per_op": 0.281
+}

--- a/benchmarks/results/speed_remove_d1536_4bit_arm_mt.json
+++ b/benchmarks/results/speed_remove_d1536_4bit_arm_mt.json
@@ -1,0 +1,9 @@
+{
+  "dim": 1536,
+  "bit_width": 4,
+  "arch": "arm",
+  "threading": "mt",
+  "tq_idmap_remove_us_per_op": 0.825,
+  "tq_idmap_removes_per_sec": 1212519,
+  "tq_swap_remove_us_per_op": 0.675
+}

--- a/benchmarks/results/speed_remove_d1536_4bit_arm_st.json
+++ b/benchmarks/results/speed_remove_d1536_4bit_arm_st.json
@@ -1,0 +1,9 @@
+{
+  "dim": 1536,
+  "bit_width": 4,
+  "arch": "arm",
+  "threading": "st",
+  "tq_idmap_remove_us_per_op": 0.377,
+  "tq_idmap_removes_per_sec": 2651137,
+  "tq_swap_remove_us_per_op": 0.267
+}

--- a/benchmarks/results/speed_remove_d3072_2bit_arm_mt.json
+++ b/benchmarks/results/speed_remove_d3072_2bit_arm_mt.json
@@ -1,0 +1,9 @@
+{
+  "dim": 3072,
+  "bit_width": 2,
+  "arch": "arm",
+  "threading": "mt",
+  "tq_idmap_remove_us_per_op": 0.255,
+  "tq_idmap_removes_per_sec": 3918534,
+  "tq_swap_remove_us_per_op": 0.21
+}

--- a/benchmarks/results/speed_remove_d3072_2bit_arm_st.json
+++ b/benchmarks/results/speed_remove_d3072_2bit_arm_st.json
@@ -1,0 +1,9 @@
+{
+  "dim": 3072,
+  "bit_width": 2,
+  "arch": "arm",
+  "threading": "st",
+  "tq_idmap_remove_us_per_op": 0.234,
+  "tq_idmap_removes_per_sec": 4278868,
+  "tq_swap_remove_us_per_op": 0.177
+}

--- a/benchmarks/results/speed_remove_d3072_4bit_arm_mt.json
+++ b/benchmarks/results/speed_remove_d3072_4bit_arm_mt.json
@@ -1,0 +1,9 @@
+{
+  "dim": 3072,
+  "bit_width": 4,
+  "arch": "arm",
+  "threading": "mt",
+  "tq_idmap_remove_us_per_op": 0.339,
+  "tq_idmap_removes_per_sec": 2953236,
+  "tq_swap_remove_us_per_op": 0.272
+}

--- a/benchmarks/results/speed_remove_d3072_4bit_arm_st.json
+++ b/benchmarks/results/speed_remove_d3072_4bit_arm_st.json
@@ -1,0 +1,9 @@
+{
+  "dim": 3072,
+  "bit_width": 4,
+  "arch": "arm",
+  "threading": "st",
+  "tq_idmap_remove_us_per_op": 0.32,
+  "tq_idmap_removes_per_sec": 3126050,
+  "tq_swap_remove_us_per_op": 0.255
+}

--- a/benchmarks/suite/speed_insert_d1536_2bit_arm_mt.py
+++ b/benchmarks/suite/speed_insert_d1536_2bit_arm_mt.py
@@ -1,0 +1,75 @@
+import os, time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d1536_2bit_arm_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_insert_d1536_2bit_arm_st.py
+++ b/benchmarks/suite/speed_insert_d1536_2bit_arm_st.py
@@ -1,0 +1,78 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+faiss.omp_set_num_threads(1)
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d1536_2bit_arm_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_insert_d1536_2bit_x86_mt.py
+++ b/benchmarks/suite/speed_insert_d1536_2bit_x86_mt.py
@@ -1,0 +1,75 @@
+import os, time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d1536_2bit_x86_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_insert_d1536_2bit_x86_st.py
+++ b/benchmarks/suite/speed_insert_d1536_2bit_x86_st.py
@@ -1,0 +1,78 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+faiss.omp_set_num_threads(1)
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d1536_2bit_x86_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_insert_d1536_4bit_arm_mt.py
+++ b/benchmarks/suite/speed_insert_d1536_4bit_arm_mt.py
@@ -1,0 +1,75 @@
+import os, time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 4
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d1536_4bit_arm_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_insert_d1536_4bit_arm_st.py
+++ b/benchmarks/suite/speed_insert_d1536_4bit_arm_st.py
@@ -1,0 +1,78 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 4
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+faiss.omp_set_num_threads(1)
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d1536_4bit_arm_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_insert_d1536_4bit_x86_mt.py
+++ b/benchmarks/suite/speed_insert_d1536_4bit_x86_mt.py
@@ -1,0 +1,75 @@
+import os, time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 4
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d1536_4bit_x86_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_insert_d1536_4bit_x86_st.py
+++ b/benchmarks/suite/speed_insert_d1536_4bit_x86_st.py
@@ -1,0 +1,78 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 4
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+faiss.omp_set_num_threads(1)
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d1536_4bit_x86_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_insert_d3072_2bit_arm_mt.py
+++ b/benchmarks/suite/speed_insert_d3072_2bit_arm_mt.py
@@ -1,0 +1,75 @@
+import os, time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 2
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d3072_2bit_arm_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_insert_d3072_2bit_arm_st.py
+++ b/benchmarks/suite/speed_insert_d3072_2bit_arm_st.py
@@ -1,0 +1,78 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 2
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+faiss.omp_set_num_threads(1)
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d3072_2bit_arm_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_insert_d3072_2bit_x86_mt.py
+++ b/benchmarks/suite/speed_insert_d3072_2bit_x86_mt.py
@@ -1,0 +1,75 @@
+import os, time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 2
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d3072_2bit_x86_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_insert_d3072_2bit_x86_st.py
+++ b/benchmarks/suite/speed_insert_d3072_2bit_x86_st.py
@@ -1,0 +1,78 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 2
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+faiss.omp_set_num_threads(1)
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d3072_2bit_x86_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_insert_d3072_4bit_arm_mt.py
+++ b/benchmarks/suite/speed_insert_d3072_4bit_arm_mt.py
@@ -1,0 +1,75 @@
+import os, time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 4
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d3072_4bit_arm_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_insert_d3072_4bit_arm_st.py
+++ b/benchmarks/suite/speed_insert_d3072_4bit_arm_st.py
@@ -1,0 +1,78 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 4
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+faiss.omp_set_num_threads(1)
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d3072_4bit_arm_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_insert_d3072_4bit_x86_mt.py
+++ b/benchmarks/suite/speed_insert_d3072_4bit_x86_mt.py
@@ -1,0 +1,75 @@
+import os, time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 4
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d3072_4bit_x86_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_insert_d3072_4bit_x86_st.py
+++ b/benchmarks/suite/speed_insert_d3072_4bit_x86_st.py
@@ -1,0 +1,78 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 4
+N_APPEND, N_SINGLE = 10_000, 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    append = all_vecs[idx[100_000:100_000 + N_APPEND + N_SINGLE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    append /= np.linalg.norm(append, axis=-1, keepdims=True)
+    return database, append
+
+database, append = load_openai(DIM)
+batch = append[:N_APPEND]
+singles = np.ascontiguousarray(append[N_APPEND:])
+faiss.omp_set_num_threads(1)
+
+# TurboQuant. add() is cumulative, so each run rebuilds a fresh index —
+# looping the op on one index would not give comparable repeats.
+# Bulk = one add() into an empty index: includes the one-time
+# rotation/codebook init and the TQ+ calibration fit (the first add is
+# >= 1000 vectors, so calibration is always fitted, never identity).
+# Warm = a second add() on the same index: caches built, calibration
+# frozen by the first add — isolates the steady-state encode path.
+bulk_times, warm_times = [], []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    t0 = time.perf_counter()
+    tq.add(database)
+    bulk_times.append(time.perf_counter() - t0)
+    t0 = time.perf_counter()
+    tq.add(batch)
+    warm_times.append(time.perf_counter() - t0)
+tq_bulk = len(database) / sorted(bulk_times)[2]
+tq_warm = len(batch) / sorted(warm_times)[2]
+
+# Per-op latency of single-vector add() on the warm index. Includes the
+# Python-call overhead a caller actually pays per add(); the index grows
+# by N_SINGLE per run (<1% of 110K, negligible drift).
+single_times = []
+for _ in range(5):
+    t0 = time.perf_counter()
+    for i in range(N_SINGLE):
+        tq.add(singles[i:i + 1])
+    single_times.append((time.perf_counter() - t0) / N_SINGLE * 1e6)
+tq_single_us = sorted(single_times)[2]
+
+# FAISS PQ. train() is untimed (the one-time analogue of TQ's calibration
+# fit); reset() drops stored codes but keeps the trained codebooks, so
+# each run times add() into an empty trained index.
+m_pq = DIM
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+faiss_times = []
+for _ in range(5):
+    pq.reset()
+    t0 = time.perf_counter()
+    pq.add(database)
+    faiss_times.append(time.perf_counter() - t0)
+faiss_bulk = len(database) / sorted(faiss_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
+          "tq_bulk_insert_vecs_per_sec": round(tq_bulk),
+          "tq_warm_insert_vecs_per_sec": round(tq_warm),
+          "tq_single_add_us": round(tq_single_us, 2),
+          "faiss_bulk_insert_vecs_per_sec": round(faiss_bulk)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_insert_d3072_4bit_x86_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d1536_2bit_arm_mt.py
+++ b/benchmarks/suite/speed_remove_d1536_2bit_arm_mt.py
@@ -1,0 +1,61 @@
+import os, time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d1536_2bit_arm_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d1536_2bit_arm_st.py
+++ b/benchmarks/suite/speed_remove_d1536_2bit_arm_st.py
@@ -1,0 +1,63 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d1536_2bit_arm_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d1536_2bit_x86_mt.py
+++ b/benchmarks/suite/speed_remove_d1536_2bit_x86_mt.py
@@ -1,0 +1,61 @@
+import os, time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d1536_2bit_x86_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d1536_2bit_x86_st.py
+++ b/benchmarks/suite/speed_remove_d1536_2bit_x86_st.py
@@ -1,0 +1,63 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d1536_2bit_x86_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d1536_4bit_arm_mt.py
+++ b/benchmarks/suite/speed_remove_d1536_4bit_arm_mt.py
@@ -1,0 +1,61 @@
+import os, time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 4
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d1536_4bit_arm_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d1536_4bit_arm_st.py
+++ b/benchmarks/suite/speed_remove_d1536_4bit_arm_st.py
@@ -1,0 +1,63 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 4
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d1536_4bit_arm_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d1536_4bit_x86_mt.py
+++ b/benchmarks/suite/speed_remove_d1536_4bit_x86_mt.py
@@ -1,0 +1,61 @@
+import os, time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 4
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d1536_4bit_x86_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d1536_4bit_x86_st.py
+++ b/benchmarks/suite/speed_remove_d1536_4bit_x86_st.py
@@ -1,0 +1,63 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 4
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d1536_4bit_x86_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d3072_2bit_arm_mt.py
+++ b/benchmarks/suite/speed_remove_d3072_2bit_arm_mt.py
@@ -1,0 +1,61 @@
+import os, time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 2
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d3072_2bit_arm_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d3072_2bit_arm_st.py
+++ b/benchmarks/suite/speed_remove_d3072_2bit_arm_st.py
@@ -1,0 +1,63 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 2
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d3072_2bit_arm_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d3072_2bit_x86_mt.py
+++ b/benchmarks/suite/speed_remove_d3072_2bit_x86_mt.py
@@ -1,0 +1,61 @@
+import os, time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 2
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d3072_2bit_x86_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d3072_2bit_x86_st.py
+++ b/benchmarks/suite/speed_remove_d3072_2bit_x86_st.py
@@ -1,0 +1,63 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 2
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d3072_2bit_x86_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d3072_4bit_arm_mt.py
+++ b/benchmarks/suite/speed_remove_d3072_4bit_arm_mt.py
@@ -1,0 +1,61 @@
+import os, time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 4
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d3072_4bit_arm_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d3072_4bit_arm_st.py
+++ b/benchmarks/suite/speed_remove_d3072_4bit_arm_st.py
@@ -1,0 +1,63 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 4
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d3072_4bit_arm_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d3072_4bit_x86_mt.py
+++ b/benchmarks/suite/speed_remove_d3072_4bit_x86_mt.py
@@ -1,0 +1,61 @@
+import os, time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 4
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d3072_4bit_x86_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_remove_d3072_4bit_x86_st.py
+++ b/benchmarks/suite/speed_remove_d3072_4bit_x86_st.py
@@ -1,0 +1,63 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, numpy as np
+from turbovec import IdMapIndex, TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 4
+N_REMOVE = 50_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    return database
+
+database = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+# Deterministic removal order. remove() shrinks the index, so each run
+# rebuilds a fresh index (built untimed) — looping the op on one index
+# would not give comparable repeats. Timed loops include the Python-call
+# overhead a caller actually pays per op.
+rng = np.random.RandomState(7)
+remove_ids = [int(x) for x in rng.permutation(len(database))[:N_REMOVE]]
+# swap_remove targets slots, and every removal moves the last vector into
+# the freed slot — pick a valid slot of the shrinking index at each step.
+swap_slots = [int(rng.randint(0, len(database) - i)) for i in range(N_REMOVE)]
+
+# IdMapIndex.remove(id): O(1) swap-and-pop on the underlying index plus
+# the id-map bookkeeping (hash-map remove/insert + slot_to_id fix-up).
+idmap_times = []
+for _ in range(5):
+    im = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    im.add_with_ids(database, ids)
+    t0 = time.perf_counter()
+    for rid in remove_ids:
+        im.remove(rid)
+    idmap_times.append(time.perf_counter() - t0)
+idmap_t = sorted(idmap_times)[2]
+
+# TurboQuantIndex.swap_remove(idx): the raw swap-and-pop (the last vector
+# moves into the freed slot — order is not preserved). Baseline that
+# isolates the cost of the id-map layer above.
+swap_times = []
+for _ in range(5):
+    tq = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    tq.add(database)
+    t0 = time.perf_counter()
+    for slot in swap_slots:
+        tq.swap_remove(slot)
+    swap_times.append(time.perf_counter() - t0)
+swap_t = sorted(swap_times)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
+          "tq_idmap_remove_us_per_op": round(idmap_t / N_REMOVE * 1e6, 3),
+          "tq_idmap_removes_per_sec": round(N_REMOVE / idmap_t),
+          "tq_swap_remove_us_per_op": round(swap_t / N_REMOVE * 1e6, 3)}
+out = os.path.join(os.path.dirname(__file__), "..", "results", "speed_remove_d3072_4bit_x86_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))


### PR DESCRIPTION
Closes #65.

Adds permanent insertion and removal speed benchmarks to `benchmarks/suite/`, mirroring the existing `speed_*` cell matrix (d=1536/3072 × 2-bit/4-bit × ARM/x86 × ST/MT): 16 `speed_insert_*` scripts and 16 `speed_remove_*` scripts. Results follow the suite's flat JSON schema (`dim` / `bit_width` / `arch` / `threading` + metric keys) and land in `benchmarks/results/`.

## Methodology

Both operations mutate index state (`add()` is cumulative, `remove()` shrinks the index), so unlike the search scripts the timed op cannot be looped on one index — **every timed run gets a fresh index**, and the reported number is the median of 5 runs, matching the suite's median-of-5 convention. Same deterministic data as the search cells: 100K vectors from `openai-{dim}.npy`, seed 42, unit-normalized. ST cells pin `RAYON_NUM_THREADS=1` (+ `faiss.omp_set_num_threads(1)`); MT cells leave defaults — same as the existing speed scripts.

**`speed_insert_*`** reports four numbers per cell:

- `tq_bulk_insert_vecs_per_sec` — one `add()` of 100K vectors into an empty index. Includes the one-time rotation/codebook init and the TQ+ calibration fit (first add is ≥ 1000 vectors, so calibration is always fitted — never the sub-threshold identity path). This is the full cost a user pays to populate an empty index.
- `tq_warm_insert_vecs_per_sec` — a 10K-vector `add()` onto that 100K index: caches built, calibration frozen by the first add. Isolates the steady-state encode path — this is the regression target for encode-path work like #57.
- `tq_single_add_us` — per-op latency of single-vector `add()` on the warm index (includes the Python-call overhead a caller actually pays).
- `faiss_bulk_insert_vecs_per_sec` — FAISS `IndexPQFastScan` bulk add for the matching configuration (same `m_pq` mapping as the search scripts: `DIM//2` at 2-bit, `DIM` at 4-bit). `train()` is untimed (the one-time analogue of TQ's calibration fit); `reset()` keeps the trained codebooks, so each run times `add()` into an empty trained index.

**`speed_remove_*`** reports three numbers per cell (50K removals in a fixed seeded random order):

- `tq_idmap_remove_us_per_op` / `tq_idmap_removes_per_sec` — `IdMapIndex.remove(id)`: the O(1) swap-and-pop plus the id-map bookkeeping (hash-map remove/insert + `slot_to_id` fix-up).
- `tq_swap_remove_us_per_op` — raw `TurboQuantIndex.swap_remove(slot)` baseline, isolating the id-map layer's overhead. (Both are swap-and-pop: the last vector moves into the freed slot, order is not preserved.)

Timed remove loops include per-call Python overhead — the number is the per-op cost as seen from Python, consistent with how the search scripts measure through the binding.

## ARM results (measured on this machine — Apple M3 Max, same host as the published ARM search cells)

**Insertion**

| Cell | TQ bulk (vec/s) | TQ warm append (vec/s) | TQ single add (µs/op) | FAISS bulk (vec/s) |
|---|---:|---:|---:|---:|
| d=1536 2-bit ST | 21,001 | 80,819 | 65.4 | 45,799 |
| d=1536 2-bit MT | 51,445 | 85,439 | 65.5 | 125,338 |
| d=1536 4-bit ST | 23,679 | 78,900 | 79.9 | 35,065 |
| d=1536 4-bit MT | 33,759 | 81,363 | 99.8 | 83,536 |
| d=3072 2-bit ST | 8,054 | 34,913 | 879.2 | 25,500 |
| d=3072 2-bit MT | 14,289 | 31,355 | 810.6 | 62,122 |
| d=3072 4-bit ST | 5,359 | 19,866 | 1,395.3 | 10,761 |
| d=3072 4-bit MT | 11,808 | 28,962 | 839.8 | 35,914 |

**Removal**

| Cell | IdMap remove (µs/op) | IdMap remove (ops/s) | swap_remove (µs/op) |
|---|---:|---:|---:|
| d=1536 2-bit ST | 0.384 | 2,601,000 | 0.281 |
| d=1536 2-bit MT | 0.727 | 1,375,376 | 0.597 |
| d=1536 4-bit ST | 0.377 | 2,651,137 | 0.267 |
| d=1536 4-bit MT | 0.825 | 1,212,519 | 0.675 |
| d=3072 2-bit ST | 0.234 | 4,278,868 | 0.177 |
| d=3072 2-bit MT | 0.255 | 3,918,534 | 0.210 |
| d=3072 4-bit ST | 0.320 | 3,126,050 | 0.255 |
| d=3072 4-bit MT | 0.339 | 2,953,236 | 0.272 |

Cross-checks on the recorded numbers:

- Bulk ST at d=1536 (21.0K / 23.7K vec/s) is the same order as #57's ad-hoc encode bench (25.7K / 21.9K on an M2 Pro) — that bench measured `encode()` inside Rust; the suite numbers additionally carry the calibration fit + one-time init inside the timed first `add()`, which is why warm append (the pure steady-state encode path) is 3-4× higher.
- Warm append scales ~4× down from d=1536 to d=3072, matching the d² rotation cost per vector.
- Removal is O(1)-flat: sub-µs per op everywhere, with the id-map layer adding a consistent ~0.05-0.15µs of bookkeeping over raw `swap_remove`. The MT remove cells read slightly slower than ST — removal itself is serial; the plausible cause is Rayon workers spin-waiting right after the untimed MT index build. Recorded as measured.
- FAISS bulk add is faster than TQ bulk in most cells — expected: `IndexPQFastScan.add()` encodes against already-trained codebooks with no per-vector d×d rotation. Recorded as measured; no prose claims drawn from it here.

## x86 pending

The 16 `speed_insert_*_x86_*.py` / `speed_remove_*_x86_*.py` scripts are committed runnable but not run — ARM and x86 results have always landed from separate runs. One pass of the new x86 scripts on the GCP bench instance completes the result set.

## Notes

- No README prose changes, no diagram changes (`create_diagrams.py` references speed files explicitly, so nothing breaks; the issue marks an insert diagram out of scope), no CI changes.
- CHANGELOG: entry added under `[Unreleased] → Benchmarks`.
- Full `cargo test` and `pytest` suites run clean (scripts are additive; nothing under test changed).

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
